### PR TITLE
Add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN \
 FROM base AS runner
 WORKDIR /app
 
-# Install sharp dependencies
-RUN apk add --no-cache vips-dev build-base
+# Install sharp dependencies and curl for healthchecks
+RUN apk add --no-cache vips-dev build-base curl
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change adds the installation of `curl` for health checks alongside the existing dependencies.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L41-R42): Added `curl` to the list of installed packages in the `RUN` command for health checks.