### PR TITLE
Fix: Dockerfile jest & pnpm setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Install dev dependencies for build and validation
 RUN \
   if [ -f pnpm-lock.yaml ]; then \
-    npm install -g pnpm && pnpm build; \
+    npm install -g pnpm && pnpm install --frozen-lockfile && pnpm build; \
   else \
-    npm run build; \
+    npm ci && npm run build; \
   fi
 
 # Production image, copy all the files and run next

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "version": "0.0.2",
   "scripts": {
     "dev": "next dev",
-    "build": "npm run validate && next build",
+    "build": "pnpm run validate && next build",
     "start": "node .next/standalone/server.js",
     "start:plain": "next start",
     "docker:build": "docker buildx build --platform=linux/amd64 --build-arg NODE_ENV=production --build-arg NEXT_TELEMETRY_DISABLED=1 --load -t williamcallahan-web:latest .",
     "docker:start": "docker run --platform=linux/amd64 -p 3010:3000 -e NODE_ENV=production williamcallahan-web:latest",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "validate": "npm run lint && npm run type-check",
+    "validate": "pnpm run lint && pnpm run type-check",
     "clean": "rm -rf .next out node_modules",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
@@ -37,6 +37,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@svgr/webpack": "^8.1.0",
     "@swc/core": "^1.10.1",
     "@swc/jest": "^0.2.37",


### PR DESCRIPTION
This pull request includes updates to the build and validation processes by switching from npm to pnpm, as well as adding a new dev dependency.

Changes to build and validation processes:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R30-R35): Updated the installation commands to use `pnpm` instead of `npm` for installing dependencies and building the project.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R14): Modified the `build` and `validate` scripts to use `pnpm` instead of `npm`.

Addition of new dev dependency:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40): Added `@jest/globals` to the `devDependencies`.