### PR TITLE
Increase blog card image loading and remove redundant dash in blog articles

### DIFF
--- a/components/features/blog/blog-list/blog-card.tsx
+++ b/components/features/blog/blog-list/blog-card.tsx
@@ -6,6 +6,7 @@
  * @component
  * @param {Object} props
  * @param {BlogPost} props.post - The blog post to display
+ * @param {boolean} props.isPriority - Optional priority flag
  */
 
 import Link from 'next/link';
@@ -17,9 +18,10 @@ import type { BlogPost } from '@/types/blog';
 
 interface BlogCardProps {
   post: BlogPost;
+  isPriority?: boolean;
 }
 
-export function BlogCard({ post }: BlogCardProps) {
+export function BlogCard({ post, isPriority = false }: BlogCardProps) {
   return (
     <Link
       href={`/blog/${post.slug}`}
@@ -32,7 +34,7 @@ export function BlogCard({ post }: BlogCardProps) {
               src={post.coverImage}
               alt={post.title}
               fill
-              priority
+              priority={isPriority}
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="object-cover transition-transform duration-300 group-hover:scale-105"
             />

--- a/components/features/blog/blog-list/blog-list.server.tsx
+++ b/components/features/blog/blog-list/blog-list.server.tsx
@@ -35,8 +35,8 @@ export async function BlogListServer({ posts }: BlogListServerProps): Promise<JS
   return (
     <div className="space-y-8">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {posts.map((post) => (
-          <BlogCard key={post.slug} post={post} />
+        {posts.map((post, index) => (
+          <BlogCard key={post.slug} post={post} isPriority={index < 2} />
         ))}
       </div>
     </div>

--- a/components/ui/collapse-dropdown.client.tsx
+++ b/components/ui/collapse-dropdown.client.tsx
@@ -51,6 +51,7 @@ export function CollapseDropdown({
       open={defaultOpen}
     >
       <summary
+        style={{ listStyle: 'none' }} // Explicitly hide the default marker
         className={cn(
           "text-lg font-semibold cursor-pointer list-none", // list-none removes default marker, removed mb-4
           "flex items-center gap-2", // Use flex for icon alignment


### PR DESCRIPTION
This pull request introduces a new optional priority flag to the `BlogCard` component and updates the `BlogListServer` component to prioritize the first two blog posts. Additionally, it includes a small style update to the `CollapseDropdown` component.

### BlogCard component updates:
* Added an optional `isPriority` flag to the `BlogCard` component to control the priority of the image loading. [[1]](diffhunk://#diff-bb2751a4767718804c05f9de73bc50dc60df740a9bb7a469c8c1c859dffc9d34R9) [[2]](diffhunk://#diff-bb2751a4767718804c05f9de73bc50dc60df740a9bb7a469c8c1c859dffc9d34R21-R24) [[3]](diffhunk://#diff-bb2751a4767718804c05f9de73bc50dc60df740a9bb7a469c8c1c859dffc9d34L35-R37)

### BlogListServer component updates:
* Updated the `BlogListServer` component to pass the `isPriority` flag to the first two `BlogCard` components to prioritize their image loading.

### CollapseDropdown component updates:
* Added inline style to the `CollapseDropdown` component to explicitly hide the default marker in the summary element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Blog posts now dynamically prioritize image loading, enhancing the display for featured posts.
- **Style**
	- Refined dropdown visuals by removing default list markers for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->