### PR TITLE
Fix: Attempted Umami fix

### DIFF
--- a/components/analytics/analytics.client.tsx
+++ b/components/analytics/analytics.client.tsx
@@ -228,7 +228,7 @@ function AnalyticsScripts() {
       <Script
         id="umami"
         strategy="lazyOnload"
-        src="https://umami.iocloudhost.net/script.js"
+        src={`https://umami.iocloudhost.net/script.js?t=${Date.now()}`}
         data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
         data-auto-track="false"
         data-do-not-track="false"
@@ -248,7 +248,7 @@ function AnalyticsScripts() {
       <Script
         id="plausible"
         strategy="lazyOnload"
-        src="https://plausible.iocloudhost.net/js/script.js"
+        src={`https://plausible.iocloudhost.net/js/script.js?t=${Date.now()}`}
         data-domain={domain}
         data-api="https://plausible.iocloudhost.net/api/event"
         onLoad={() => {


### PR DESCRIPTION
This pull request introduces changes to enhance cache control for analytics scripts and improve their handling in both the `AnalyticsScripts` component and `middleware`. The updates ensure that analytics scripts are not cached and include a mechanism to prevent stale versions by appending a timestamp to their URLs.

### Cache Control Enhancements:
* Added logic in `middleware.ts` to explicitly prevent caching of analytics scripts (`umami` and `plausible`) by setting appropriate `Cache-Control`, `Pragma`, `Expires`, and Cloudflare-specific headers. This ensures that analytics scripts are always fetched fresh. [[1]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR86-R103) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL102-R117)

### URL Versioning for Analytics Scripts:
* Updated the `src` attributes of the `umami` and `plausible` scripts in `AnalyticsScripts` to append a timestamp (`Date.now()`), ensuring that browsers always fetch the latest version of these scripts. [[1]](diffhunk://#diff-abf18d5a995c6247cecbac8e81fe0511cc01c683b28248da2f7aaecfc61ba60dL231-R231) [[2]](diffhunk://#diff-abf18d5a995c6247cecbac8e81fe0511cc01c683b28248da2f7aaecfc61ba60dL251-R251)