### PR TITLE
Fix: Attempted Umami fix

### DIFF
--- a/components/analytics/analytics.client.tsx
+++ b/components/analytics/analytics.client.tsx
@@ -230,6 +230,7 @@ function AnalyticsScripts() {
         strategy="lazyOnload"
         src={`https://umami.iocloudhost.net/script.js?t=${Date.now()}`}
         data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+        data-cache="false"
         onLoad={() => {
           try {
             setScriptsLoaded(prev => ({ ...prev, umami: true }))

--- a/middleware.ts
+++ b/middleware.ts
@@ -122,7 +122,8 @@ export function middleware(request: NextRequest): NextResponse {
         response.headers.set('Accept-CH', 'DPR, Width, Viewport-Width')
       }
     } else if (url === '/' || !url.includes('.')) {
-      response.headers.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+      // Ensure HTML pages are freshly served so analytics scripts always update
+      response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
     }
   } else {
     response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')


### PR DESCRIPTION
This pull request focuses on improving the behavior of analytics scripts and ensuring that HTML pages are always served fresh by updating caching strategies. The key changes include adding a new attribute to the analytics script tag and modifying the `Cache-Control` headers for HTML responses.

### Analytics script behavior:

* [`components/analytics/analytics.client.tsx`](diffhunk://#diff-abf18d5a995c6247cecbac8e81fe0511cc01c683b28248da2f7aaecfc61ba60dR233): Added a `data-cache="false"` attribute to the analytics script to explicitly disable caching and ensure the script is always freshly loaded.

### Caching strategy for HTML pages:

* [`middleware.ts`](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL125-R126): Updated the `Cache-Control` header for HTML pages to `no-store, no-cache, must-revalidate, proxy-revalidate`, ensuring that these pages are always served fresh to reflect the latest changes, including updates to analytics scripts.