### PR TITLE
chore(data): add updatedAt constants for data files

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,174 +10,166 @@
  */
 
 import { MetadataRoute } from 'next';
-import { PAGE_METADATA, metadata as siteMetadata } from '../data/metadata';
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { kebabCase } from '@/lib/utils/formatters';
 
-// Refined helper function to safely get date from frontmatter
+// Import data file update timestamps
+import { updatedAt as experienceUpdatedAt } from '../data/experience';
+import { updatedAt as educationUpdatedAt } from '../data/education';
+import { updatedAt as investmentsUpdatedAt } from '../data/investments';
+import { updatedAt as projectsUpdatedAt } from '../data/projects';
+// Assuming metadata.ts might have its own overall update timestamp, or we use specific PAGE_METADATA dates
+import { PAGE_METADATA, metadata as siteMetadata } from '../data/metadata';
+
+// Helper function to safely parse a date string (including simple YYYY-MM-DD)
 const getSafeDate = (dateInput: any): Date | undefined => {
   if (!dateInput) return undefined;
   try {
     let dateStr = String(dateInput);
-    // If it's just a date (YYYY-MM-DD), append a time to make it specific
-    // and parse consistently, e.g., end of day UTC.
     if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
-      dateStr = `${dateStr}T23:59:59.999Z`; // Assume end of day UTC
+      // Append time for consistency, assume end of day UTC
+      dateStr = `${dateStr}T23:59:59.999Z`;
     }
     const date = new Date(dateStr);
-    // Check if the date is valid
     if (!isNaN(date.getTime())) {
       return date;
     }
   } catch (error) {
-    console.error(`Error parsing date: ${dateInput}`, error);
+    console.error(`Sitemap: Error parsing date: ${dateInput}`, error);
   }
   return undefined;
 };
 
-/**
- * Generate sitemap entries for all static and dynamic pages
- * @returns {MetadataRoute.Sitemap} Sitemap entries following Next.js format
- */
+// Helper to get the latest date from a list of potential date objects
+const getLatestDate = (...dates: (Date | undefined)[]): Date | undefined => {
+  return dates.reduce((latest, current) => {
+    if (current && (!latest || current > latest)) {
+      return current;
+    }
+    return latest;
+  }, undefined as Date | undefined);
+};
+
+// --- Main Sitemap Generation ---
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = siteMetadata.site.url;
-
-  // Helper function to get mtime of a specific data file
-  const getDataFileMtime = (filename: string): Date | undefined => {
-    const filePath = path.join(process.cwd(), 'data', filename);
-    try {
-      return fs.statSync(filePath).mtime;
-    } catch (statError) {
-      console.error(`Failed to get mtime for data file ${filePath}:`, statError);
-      return undefined;
-    }
-  };
-
-  // Helper function to get mtime of a specific app page file
-  const getPageFileMtime = (pagePath: string): Date | undefined => {
-    const filePath = path.join(process.cwd(), 'app', pagePath);
-    try {
-      return fs.statSync(filePath).mtime;
-    } catch (statError) {
-      console.error(`Failed to get mtime for page file ${filePath}:`, statError);
-      return undefined;
-    }
-  };
-
-  // --- Dynamic Blog Posts (Process First to get latest date for /blog) ---
   const postsDirectory = path.join(process.cwd(), 'data/blog/posts');
-  let blogEntries: MetadataRoute.Sitemap = [];
-  let latestBlogPostDate: Date | undefined = undefined;
+
+  // --- 1. Process Blog Posts and Tags ---
+  const postsData: { slug: string; lastModified: Date | undefined; tags: string[] }[] = [];
+  const tagLastModifiedMap: { [tagSlug: string]: Date } = {};
+  let latestPostUpdateTime: Date | undefined = undefined;
 
   try {
     const filenames = fs.readdirSync(postsDirectory);
-
-    blogEntries = filenames
+    filenames
       .filter((filename) => filename.endsWith('.mdx'))
-      .map((filename) => {
+      .forEach((filename) => {
         const filePath = path.join(postsDirectory, filename);
+        let fileMtime: Date | undefined;
+        try {
+          fileMtime = fs.statSync(filePath).mtime;
+        } catch (statError) {
+          console.error(`Sitemap: Failed to get mtime for ${filePath}:`, statError);
+        }
+
         const fileContents = fs.readFileSync(filePath, 'utf8');
         const { data } = matter(fileContents);
         const slug = filename.replace(/\.mdx$/, '');
 
-        // Use the refined getSafeDate
-        let postLastModifiedDate = getSafeDate(data.updatedAt || data.publishedAt);
+        // Prioritize frontmatter date, fallback to file mtime
+        const postLastModified = getLatestDate(
+          getSafeDate(data.updatedAt),
+          getSafeDate(data.publishedAt),
+          fileMtime
+        );
 
-        // Fallback to file system mtime if frontmatter dates are missing/invalid
-        if (!postLastModifiedDate) {
-          try {
-            postLastModifiedDate = fs.statSync(filePath).mtime;
-            console.warn(`Sitemap: Falling back to mtime for blog post: ${slug}`); // Add warning
-          } catch (statError) {
-            console.error(`Failed to get mtime for blog post ${filePath}:`, statError);
-          }
+        if (!postLastModified) {
+          console.warn(`Sitemap: Could not determine lastModified date for post: ${slug}`);
         }
 
-        // Track the latest modification date among all posts
-        if (postLastModifiedDate) {
-          if (!latestBlogPostDate || postLastModifiedDate > latestBlogPostDate) {
-            latestBlogPostDate = postLastModifiedDate;
-          }
+        postsData.push({
+          slug,
+          lastModified: postLastModified,
+          tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
+        });
+
+        // Update latest overall post time
+        latestPostUpdateTime = getLatestDate(latestPostUpdateTime, postLastModified);
+
+        // Update lastModified time for each tag
+        if (postLastModified && Array.isArray(data.tags)) {
+          data.tags.forEach((tag: string) => {
+            const tagSlug = kebabCase(tag);
+            tagLastModifiedMap[tagSlug] = getLatestDate(tagLastModifiedMap[tagSlug], postLastModified) || postLastModified;
+          });
         }
-
-        const entry: MetadataRoute.Sitemap[number] = {
-          url: `${siteUrl}/blog/${slug}`,
-          changeFrequency: 'weekly',
-          priority: 0.7,
-        };
-
-        if (postLastModifiedDate) {
-          entry.lastModified = postLastModifiedDate;
-        }
-        return entry;
-      })
-      .filter(Boolean) as MetadataRoute.Sitemap;
-
+      });
   } catch (error) {
-    console.error("Error reading blog posts directory for sitemap:", error);
+    console.error("Sitemap: Error reading blog posts directory:", error);
   }
 
-  // --- Static Pages ---
-  const staticRoutesMap = {
-    '/': 1.0,
-    '/blog': 0.9,
-    '/experience': 0.8,
-    '/investments': 0.8,
-    '/education': 0.5,
-    '/bookmarks': 0.7,
+  // Create blog post sitemap entries
+  const blogPostEntries: MetadataRoute.Sitemap = postsData.map(post => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: post.lastModified,
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }));
+
+  // Create blog tag sitemap entries
+  const blogTagEntries: MetadataRoute.Sitemap = Object.entries(tagLastModifiedMap).map(([tagSlug, lastModified]) => ({
+    url: `${siteUrl}/blog/tags/${tagSlug}`,
+    lastModified: lastModified,
+    changeFrequency: 'weekly',
+    priority: 0.6, // Slightly lower than individual posts
+  }));
+
+  // --- 2. Process Static Pages ---
+  const staticPages = {
+    '/': { priority: 1.0, lastModified: getLatestDate(getPageFileMtime('page.tsx'), getSafeDate(PAGE_METADATA.home.dateModified)) },
+    '/experience': { priority: 0.8, lastModified: getSafeDate(experienceUpdatedAt) },
+    '/investments': { priority: 0.9, lastModified: getSafeDate(investmentsUpdatedAt) },
+    '/education': { priority: 0.7, lastModified: getSafeDate(educationUpdatedAt) }, // Adjusted priority
+    '/projects': { priority: 0.9, lastModified: getSafeDate(projectsUpdatedAt) },   // Added projects
+    '/bookmarks': { priority: 0.6, lastModified: getLatestDate(getPageFileMtime('bookmarks/page.tsx'), getSafeDate(PAGE_METADATA.bookmarks.dateModified)) }, // Adjusted priority
+    '/blog': {
+      priority: 0.9,
+      lastModified: getLatestDate( // Use latest of blog page mtime, metadata date, or latest post update
+        getPageFileMtime('blog/page.tsx'),
+        getSafeDate(PAGE_METADATA.blog.dateModified),
+        latestPostUpdateTime
+      )
+    },
   } as const;
 
-  const staticEntries = Object.entries(staticRoutesMap).map(([route, priority]) => {
-    const key = route === '/' ? 'home' : (route.slice(1) as keyof typeof PAGE_METADATA);
-    const pageMetadata = PAGE_METADATA[key];
-    let lastModifiedDate: Date | undefined;
-
-    switch (key) {
-      case 'home':
-        // Prioritize page file mtime, fallback to metadata dates
-        lastModifiedDate = getPageFileMtime('page.tsx'); // Assuming app/page.tsx
-        if (!lastModifiedDate) {
-          lastModifiedDate = getSafeDate(pageMetadata.dateModified);
-          if (!lastModifiedDate) {
-            lastModifiedDate = getSafeDate(pageMetadata.dateCreated);
-          }
-        }
-        break;
-      case 'experience':
-      case 'investments':
-      case 'education':
-        lastModifiedDate = getDataFileMtime(`${key}.ts`);
-        break;
-      case 'blog':
-        // Use the latest blog post date if available and newer
-        const blogMetadataDate = getSafeDate(pageMetadata.dateModified) || getSafeDate(pageMetadata.dateCreated);
-        if (latestBlogPostDate && (!blogMetadataDate || latestBlogPostDate > blogMetadataDate)) {
-          lastModifiedDate = latestBlogPostDate;
-        } else {
-          lastModifiedDate = blogMetadataDate;
-        }
-        break;
-      default: // bookmarks
-        lastModifiedDate = getSafeDate(pageMetadata.dateModified);
-        if (!lastModifiedDate) {
-          lastModifiedDate = getSafeDate(pageMetadata.dateCreated);
-        }
-        break;
-    }
-
-    const entry: MetadataRoute.Sitemap[number] = {
+  const staticEntries: MetadataRoute.Sitemap = Object.entries(staticPages).map(
+    ([route, { priority, lastModified }]) => ({
       url: `${siteUrl}${route}`,
-      changeFrequency: 'monthly',
+      lastModified: lastModified,
+      changeFrequency: 'monthly', // Can adjust per page if needed
       priority,
-    };
+    })
+  );
 
-    if (lastModifiedDate) {
-      entry.lastModified = lastModifiedDate;
-    }
-    return entry;
-  });
-
-  // --- Combine ---
-  return [...staticEntries, ...blogEntries];
+  // --- 3. Combine and Return ---
+  return [...staticEntries, ...blogPostEntries, ...blogTagEntries];
 }
+
+// Helper function to get mtime of a specific app page file
+const getPageFileMtime = (pagePath: string): Date | undefined => {
+  // Ensure path starts within 'app' directory
+  const safePagePath = pagePath.startsWith('app/') ? pagePath : `app/${pagePath}`;
+  const filePath = path.join(process.cwd(), safePagePath);
+  try {
+    return fs.statSync(filePath).mtime;
+  } catch (statError) {
+    // Don't log error if file simply doesn't exist (e.g., for metadata-based dates)
+    if ((statError as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error(`Sitemap: Failed to get mtime for page file ${filePath}:`, statError);
+    }
+    return undefined;
+  }
+};

--- a/data/education.ts
+++ b/data/education.ts
@@ -2,6 +2,9 @@
  * Education Data
  */
 
+// Remember to update this date whenever the education data or the Education page design changes
+export const updatedAt = '2025-05-01';
+
 import type { Education, Certification, Class } from 'types/education';
 
 export const recentCourses: Class[] = [

--- a/data/experience.ts
+++ b/data/experience.ts
@@ -7,6 +7,9 @@
 
 import type { Experience } from '../types/experience';
 
+// Remember to update this date whenever the experience data or the Experience page design changes
+export const updatedAt = '2025-04-30';
+
 export const experiences: Experience[] = [
   {
     id: 'aventure',

--- a/data/investments.ts
+++ b/data/investments.ts
@@ -2,6 +2,9 @@
  * Investments Data
  */
 
+// Remember to update this date whenever the investment data or the Investments page design changes
+export const updatedAt = '2025-04-30';
+
 import type { Investment } from "../types/investment";
 
 export const investments: Investment[] = [

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,5 +1,8 @@
 import type { Project } from '@/types/project';
 
+// Remember to update this date whenever the projects data or the Projects page design changes
+export const updatedAt = '2025-04-30';
+
 export const projects: Project[] = [
   {
     name: 'aVenture.vc',


### PR DESCRIPTION
This pull request refactors the sitemap generation process to improve maintainability and accuracy, while also introducing update timestamps for key data files. The changes include a more modular approach to sitemap generation, better handling of dates, and the addition of `updatedAt` fields in data files for tracking content updates.

### Sitemap Refactor and Enhancements:
* Refactored `sitemap.ts` to modularize the sitemap generation process, including separate handling for static pages, blog posts, and tags. Improved date handling with utility functions like `getLatestDate` and enhanced error logging for better debugging.
* Introduced a new helper function `getPageFileMtime` to safely retrieve file modification times for app pages, ensuring fallback mechanisms for metadata-based dates.

### Data File Updates:
* Added `updatedAt` fields to `education.ts`, `experience.ts`, `investments.ts`, and `projects.ts` for tracking the last modification date of their respective data or page designs. These timestamps are now used in the sitemap generation to ensure accurate `lastModified` values. [[1]](diffhunk://#diff-57b155d1be07e875c32b15ea16dcb8e70cbccfc4a647290f456bc32afb37722cR5-R7) [[2]](diffhunk://#diff-8244c37d498a651d2d015ec201d843a9f1fc268b6afdd835648ca2cbac1a23a7R10-R12) [[3]](diffhunk://#diff-e0c436d07e81929d3f46a5d17b313f8f336085519c048ba181b402fe7c109ca5R5-R7) [[4]](diffhunk://#diff-84f9b099f6948c8d63feb5fc9dce1cca170fc1e603116e06ae1989a426c55cecR3-R5)