### PR TITLE
feat(bookmarks): add error handling and fallback caching

### DIFF
--- a/__tests__/app/api/bookmarks/route.test.ts
+++ b/__tests__/app/api/bookmarks/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the Bookmarks API Route
+ * @module __tests__/api/bookmarks/route.test
+ */
+
+import { GET } from '../../../../app/api/bookmarks/route';
+import { fetchExternalBookmarks } from '../../../../lib/bookmarks';
+import { ServerCacheInstance } from '../../../../lib/server-cache';
+import { NextResponse } from 'next/server';
+import type { UnifiedBookmark } from '../../../../types';
+
+// Mock dependencies
+jest.mock('../../../../lib/utils/ensure-server-only', () => ({
+  assertServerOnly: jest.fn(),
+}));
+jest.mock('../../../../lib/bookmarks');
+jest.mock('../../../../lib/server-cache');
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn(),
+  },
+}));
+
+// Mock console
+global.console = { ...console, log: jest.fn(), error: jest.fn() };
+
+const mockFetchBookmarks = fetchExternalBookmarks as jest.Mock;
+const mockGetCache = ServerCacheInstance.getBookmarks as jest.Mock;
+const mockResponseJson = NextResponse.json as jest.Mock;
+
+describe('GET /api/bookmarks', () => {
+  const mockBookmarksData: UnifiedBookmark[] = [
+    { id: '1', title: 'Bookmark 1', url: 'https://example.com/1' } as UnifiedBookmark,
+    { id: '2', title: 'Bookmark 2', url: 'https://example.com/2' } as UnifiedBookmark,
+  ];
+  const mockCachedData: UnifiedBookmark[] = [
+    { id: 'cached1', title: 'Cached Bookmark 1', url: 'https://cached.com/1' } as UnifiedBookmark,
+  ];
+  const cacheHeaders = { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=3600' };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should return fetched bookmarks on success', async () => {
+    mockFetchBookmarks.mockResolvedValue(mockBookmarksData);
+
+    await GET();
+
+    expect(mockFetchBookmarks).toHaveBeenCalledTimes(1);
+    expect(mockGetCache).not.toHaveBeenCalled();
+    expect(mockResponseJson).toHaveBeenCalledWith(mockBookmarksData, { status: 200, headers: cacheHeaders });
+    expect(console.log).toHaveBeenCalledWith('API route: Starting to fetch bookmarks');
+    expect(console.log).toHaveBeenCalledWith(`API route: Fetched ${mockBookmarksData.length} bookmarks`);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('should return cached bookmarks when fetch fails but cache exists', async () => {
+    const fetchError = new Error('Fetch failed');
+    mockFetchBookmarks.mockRejectedValue(fetchError);
+    mockGetCache.mockReturnValue({ bookmarks: mockCachedData });
+
+    await GET();
+
+    expect(mockFetchBookmarks).toHaveBeenCalledTimes(1);
+    expect(mockGetCache).toHaveBeenCalledTimes(1);
+    expect(mockResponseJson).toHaveBeenCalledWith(mockCachedData, { status: 200, headers: cacheHeaders });
+    expect(console.error).toHaveBeenCalledWith('Error fetching bookmarks:', fetchError);
+    expect(console.log).toHaveBeenCalledWith(`API route: Returning stale cached bookmarks, count: ${mockCachedData.length}`);
+  });
+
+  it('should return 500 error when fetch fails and cache is empty', async () => {
+    const fetchError = new Error('Fetch failed');
+    mockFetchBookmarks.mockRejectedValue(fetchError);
+    mockGetCache.mockReturnValue(undefined); // No cache
+
+    await GET();
+
+    expect(mockFetchBookmarks).toHaveBeenCalledTimes(1);
+    expect(mockGetCache).toHaveBeenCalledTimes(1);
+    expect(mockResponseJson).toHaveBeenCalledWith({ error: 'Fetch failed' }, { status: 500 });
+    expect(console.error).toHaveBeenCalledWith('Error fetching bookmarks:', fetchError);
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('Returning stale cached'));
+  });
+
+  it('should return 500 error when fetch fails and cache has empty array', async () => {
+    const fetchError = new Error('Fetch failed');
+    mockFetchBookmarks.mockRejectedValue(fetchError);
+    mockGetCache.mockReturnValue({ bookmarks: [] }); // Cache exists but is empty
+
+    await GET();
+
+    expect(mockFetchBookmarks).toHaveBeenCalledTimes(1);
+    expect(mockGetCache).toHaveBeenCalledTimes(1);
+    expect(mockResponseJson).toHaveBeenCalledWith({ error: 'Fetch failed' }, { status: 500 });
+    expect(console.error).toHaveBeenCalledWith('Error fetching bookmarks:', fetchError);
+  });
+
+  it('should return 500 with generic message for non-Error objects', async () => {
+    const fetchError = 'Something went wrong'; // Not an Error instance
+    mockFetchBookmarks.mockRejectedValue(fetchError);
+    mockGetCache.mockReturnValue(undefined);
+
+    await GET();
+
+    expect(mockResponseJson).toHaveBeenCalledWith({ error: 'Unknown error' }, { status: 500 });
+    expect(console.error).toHaveBeenCalledWith('Error fetching bookmarks:', fetchError);
+  });
+});

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,11 +1,12 @@
 /**
  * Bookmarks API Endpoint
- * 
+ *
  * Provides client-side access to all bookmarks
  */
 
 import { NextResponse } from 'next/server';
 import { fetchExternalBookmarks } from '@/lib/bookmarks';
+import { ServerCacheInstance } from '@/lib/server-cache';
 
 // This route always bypasses the cache for up-to-date bookmark data
 export const dynamic = 'force-dynamic';
@@ -14,22 +15,28 @@ export const dynamic = 'force-dynamic';
  * API route for fetching all bookmarks
  */
 export async function GET() {
+  let bookmarks;
   try {
     console.log('API route: Starting to fetch bookmarks');
-    // Add additional debug info
     console.log('API route: Using dynamic rendering with force-dynamic');
-    const bookmarks = await fetchExternalBookmarks();
+    bookmarks = await fetchExternalBookmarks();
     console.log(`API route: Fetched ${bookmarks.length} bookmarks`);
-    
-    // Log the first bookmark to verify data structure
     if (bookmarks.length > 0) {
       console.log('API route: First bookmark title:', bookmarks[0].title);
     }
-    
-    return NextResponse.json(bookmarks);
   } catch (error) {
     console.error('Error fetching bookmarks:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    const cached = ServerCacheInstance.getBookmarks();
+    if (cached && Array.isArray(cached.bookmarks) && cached.bookmarks.length > 0) {
+      console.log(`API route: Returning stale cached bookmarks, count: ${cached.bookmarks.length}`);
+      bookmarks = cached.bookmarks;
+    } else {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return NextResponse.json({ error: errorMessage }, { status: 500 });
+    }
   }
+  return NextResponse.json(bookmarks, {
+    status: 200,
+    headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=3600' }
+  });
 }

--- a/app/bookmarks/error.tsx
+++ b/app/bookmarks/error.tsx
@@ -1,0 +1,36 @@
+// This is the error boundary for the 'bookmarks' route
+'use client';
+
+import { useEffect } from 'react';
+
+interface ErrorPageProps {
+  error: Error;
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  // Log the error for debugging
+  useEffect(() => console.error('Error in /bookmarks page:', error), [error]);
+
+  return (
+    <main className="max-w-5xl mx-auto py-16 px-4 sm:px-6 lg:px-8 text-center">
+      <div className="bg-red-50 dark:bg-gray-800 border border-red-200 dark:border-red-700 p-8 rounded-lg shadow-md">
+        <h1 className="text-3xl font-bold text-red-600 dark:text-red-400 mb-4">
+          😵‍💫 Bookmarks Unavailable
+        </h1>
+        <p className="text-lg text-gray-700 dark:text-gray-300 mb-6">
+          Hmm, my bookmarks service is taking a break.
+        </p>
+        <p className="text-lg text-gray-700 dark:text-gray-300 mb-6">
+          Feel free to browse the rest of the site while this gets fixed!
+        </p>
+        <button
+          onClick={() => reset()}
+          className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-md shadow hover:bg-blue-700 transition"
+        >
+          Try Again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/components/features/bookmarks/bookmarks.server.tsx
+++ b/components/features/bookmarks/bookmarks.server.tsx
@@ -18,16 +18,16 @@ interface BookmarksServerProps {
   titleSlug?: string;
 }
 
-export async function BookmarksServer({ 
-  title, 
-  description, 
+export async function BookmarksServer({
+  title,
+  description,
   bookmarks: propsBookmarks,
   showFilterBar,
   titleSlug
 }: BookmarksServerProps): Promise<JSX.Element> {
   // If bookmarks are provided via props, use those; otherwise fetch from API
   let bookmarks: UnifiedBookmark[] = [];
-  
+
   // Helper function to sort bookmarks by date (newest first)
   const sortByDateDesc = (list: UnifiedBookmark[]) =>
     [...list].sort((a, b) => {
@@ -37,7 +37,7 @@ export async function BookmarksServer({
       };
       return safeTs(b.dateBookmarked) - safeTs(a.dateBookmarked);
     });
-  
+
   if (propsBookmarks) {
     // Apply the same consistent sorting even when bookmarks are provided externally
     bookmarks = sortByDateDesc(propsBookmarks);
@@ -59,12 +59,17 @@ export async function BookmarksServer({
 
     // Sort bookmarks by date (newest first) if we have any
     bookmarks = bookmarks.length ? sortByDateDesc(bookmarks) : [];
+
+    // If no bookmarks were fetched in production, trigger error to show boundary
+    if (!propsBookmarks && bookmarks.length === 0 && process.env.NODE_ENV === 'production') {
+      throw new Error('BookmarksUnavailable');
+    }
   }
 
   // Pass the processed data to the client component
   return (
-    <BookmarksClientWithWindow 
-      bookmarks={bookmarks} 
+    <BookmarksClientWithWindow
+      bookmarks={bookmarks}
       title={title}
       description={description}
       forceClientFetch={!propsBookmarks} // Only force client fetch if we didn't get bookmarks from props


### PR DESCRIPTION
This pull request introduces improvements to the bookmarks API route, adds an error boundary for the bookmarks page, and enhances error handling in the bookmarks server component. The key changes include implementing fallback logic for stale cache data, providing a user-friendly error page, and triggering errors in production when no bookmarks are fetched.

### Enhancements to the bookmarks API route:
* Introduced fallback logic to return stale cached bookmarks when fetching external bookmarks fails. This ensures the API can still serve data even during outages. (`app/api/bookmarks/route.ts`, [app/api/bookmarks/route.tsR18-R42](diffhunk://#diff-f88238e6479bd3497269a58673a9b1ff8796f31ce711ac15530b7ba8740773d2R18-R42))
* Added a `Cache-Control` header to the API response to improve caching behavior. (`app/api/bookmarks/route.ts`, [app/api/bookmarks/route.tsR18-R42](diffhunk://#diff-f88238e6479bd3497269a58673a9b1ff8796f31ce711ac15530b7ba8740773d2R18-R42))
* Imported `ServerCacheInstance` to facilitate access to cached bookmarks. (`app/api/bookmarks/route.ts`, [app/api/bookmarks/route.tsR9](diffhunk://#diff-f88238e6479bd3497269a58673a9b1ff8796f31ce711ac15530b7ba8740773d2R9))

### Error handling improvements:
* Added a new error boundary component (`ErrorPage`) for the bookmarks route, displaying a user-friendly error message and a "Try Again" button. (`app/bookmarks/error.tsx`, [app/bookmarks/error.tsxR1-R36](diffhunk://#diff-c66d5f39c10fb07b67430176bf791d54c6a619e174e0af9c174f202cfedf2067R1-R36))
* Updated the server component to throw an error in production if no bookmarks are fetched, triggering the error boundary. (`components/features/bookmarks/bookmarks.server.tsx`, [components/features/bookmarks/bookmarks.server.tsxR62-R66](diffhunk://#diff-e2a65a55339ec21285a0dae154974050af8abbf3dad01e537d633f0cfb56eeb0R62-R66))