### PR TITLE
fix(middleware): add https://queue.simpleanalyticscdn.com to connect-src in Content Security Policy

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -66,7 +66,7 @@ export function middleware(request: NextRequest): NextResponse {
     'Content-Security-Policy': `
       default-src 'self';
       script-src 'self' 'unsafe-inline' 'unsafe-eval' https://umami.iocloudhost.net https://plausible.iocloudhost.net https://static.cloudflareinsights.com https://*.sentry.io https://scripts.simpleanalyticscdn.com https://static.getclicky.com https://in.getclicky.com;
-      connect-src 'self' https://umami.iocloudhost.net https://plausible.iocloudhost.net https://static.cloudflareinsights.com https://*.sentry.io;
+      connect-src 'self' https://umami.iocloudhost.net https://plausible.iocloudhost.net https://static.cloudflareinsights.com https://*.sentry.io https://queue.simpleanalyticscdn.com;
       worker-src 'self' blob:;
       img-src 'self' data: https:;
       style-src 'self' 'unsafe-inline';


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `middleware.ts` file to include an additional source for `connect-src`.

### Content Security Policy Updates:
* [`middleware.ts`](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL69-R69): Added `https://queue.simpleanalyticscdn.com` to the `connect-src` directive in the CSP header, allowing connections to this domain.