### PR TITLE
fix(layout): add relative positioning to header and z-index to terminal classes for improved layout stability

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -215,7 +215,7 @@ export default function RootLayout({
             {/* Revert to direct rendering */}
             <div className="min-h-screen bg-white dark:bg-[#1a1b26] text-gray-900 dark:text-gray-100 transition-colors duration-200">
               <ErrorBoundary silent>
-                <header className="w-full bg-white/80 dark:bg-[#1a1b26]/80 backdrop-blur-sm z-[1000]">
+                <header className="relative w-full bg-white/80 dark:bg-[#1a1b26]/80 backdrop-blur-sm z-[1000]">
                   {/* Add overflow-hidden for safety, ensure items can shrink */}
                   <div className="w-full max-w-[95%] xl:max-w-[1400px] 2xl:max-w-[1800px] mx-auto px-4 py-4 flex items-center justify-between overflow-hidden gap-4">
                     {/* Navigation should shrink if needed, but prioritize it */}

--- a/components/ui/terminal/terminal-implementation.client.tsx
+++ b/components/ui/terminal/terminal-implementation.client.tsx
@@ -179,7 +179,8 @@ export function Terminal() {
   // Define class sets for clarity
   const commonTerminalClasses = "bg-[#1a1b26] border border-gray-700 font-mono text-sm cursor-text overflow-hidden flex flex-col shadow-xl";
   // We now handle margin responsively via the terminal-reduced-margin class in globals.css
-  const normalTerminalClasses = "relative mx-auto terminal-reduced-margin w-full max-w-[calc(100vw-2rem)] sm:max-w-3xl p-4 sm:p-6 rounded-lg";
+  // Add z-10 to ensure it stays below the mobile menu dropdown
+  const normalTerminalClasses = "relative z-10 mx-auto terminal-reduced-margin w-full max-w-[calc(100vw-2rem)] sm:max-w-3xl p-4 sm:p-6 rounded-lg";
   const maximizedTerminalClasses = "fixed left-0 right-0 top-14 bottom-0 z-[60] w-full h-[calc(100vh-56px)] p-6 border-0 rounded-none"; // Full window below nav
 
   // Define classes for the inner scrollable area


### PR DESCRIPTION
This pull request includes updates to improve layout rendering and ensure proper stacking context for UI components. The most important changes involve modifying the `RootLayout` header and adjusting the z-index for the terminal component.

### Layout Rendering Improvements:
* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL218-R218): Changed the `header` element in `RootLayout` to use a `relative` position instead of the default static position. This ensures better control over stacking context and layout behavior.

### UI Component Stacking Fixes:
* [`components/ui/terminal/terminal-implementation.client.tsx`](diffhunk://#diff-709a78cbff72087f815bb94fc76eadc270d35781966adb0900fcd65276b7752bL182-R183): Added `z-10` to the `normalTerminalClasses` for the terminal component to ensure it stays below the mobile menu dropdown, improving layering and usability.