### PR TITLE
chore(sitemap): add new file for IndexNow submission identifier and correct endpoint URLs

### DIFF
--- a/public/1fcee00b0b6348c3a5fc70dfcf83f28d.txt
+++ b/public/1fcee00b0b6348c3a5fc70dfcf83f28d.txt
@@ -1,0 +1,1 @@
+1fcee00b0b6348c3a5fc70dfcf83f28d

--- a/scripts/submit-sitemap.ts
+++ b/scripts/submit-sitemap.ts
@@ -280,8 +280,8 @@ async function submitToIndexNow(siteUrlCanonical: string): Promise<void> {
       console.info(`${LOG_PREFIX.indexNow} Submitting with payload:`, JSON.stringify(payload, null, 2));
     }
 
-    const aggregatorEndpoint = "https://api.indexnow.org/IndexNow";
-    const bingEndpoint = "https://www.bing.com/IndexNow";
+    const aggregatorEndpoint = "https://api.indexnow.org/indexnow";
+    const bingEndpoint = "https://www.bing.com/indexnow";
 
     const attemptSubmit = async (endpoint: string): Promise<Response> => {
       return fetch(endpoint, {


### PR DESCRIPTION
This pull request includes two changes: the addition of a new file and a minor adjustment to endpoint URLs in the `submitToIndexNow` function. The most important changes are summarized below.

### File addition:

* [`public/1fcee00b0b6348c3a5fc70dfcf83f28d.txt`](diffhunk://#diff-f004e89889be37ed19dd979a88aa33e5eb1d81a0d8da05b86a88019df86fe88cR1): Added a new file with the identifier `1fcee00b0b6348c3a5fc70dfcf83f28d`.

### Endpoint adjustments:

* [`scripts/submit-sitemap.ts`](diffhunk://#diff-9c48d09af8db59f62b49045db35c3cbc5271204f2e4c0918b3308b3ac784b2cdL283-R284): Updated the `aggregatorEndpoint` and `bingEndpoint` URLs in the `submitToIndexNow` function to use lowercase paths (`indexnow` instead of `IndexNow`).