### PR TITLE
improvement: implement cache busting for OpenGraph images by appending version query string

### DIFF
--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -241,6 +241,10 @@ export function getStaticPageMetadata(path: string, pageKey: keyof typeof PAGE_M
     ogImagePath = SEO_IMAGES.ogBlogIndex;
   }
 
+  // FORCE CACHE BUSTING: Append a version query string to bust social media cache.
+  // This version number can be manually incremented whenever you want to force a refresh.
+  const cacheBustingUrl = `${ogImagePath}?v=2`;
+
   // Type assertion is safe here because LOCAL_OG_ASSETS keys are the compile-time
   // image paths defined in data/metadata.ts. If the path exists, we can rely on
   // Next.js-provided width/height for perfect accuracy.
@@ -251,7 +255,7 @@ export function getStaticPageMetadata(path: string, pageKey: keyof typeof PAGE_M
   }
 
   const defaultOgImage = {
-    url: ensureAbsoluteUrl(ogImagePath),
+    url: ensureAbsoluteUrl(cacheBustingUrl),
     width: ogWidth,
     height: ogHeight,
     alt: siteMetadata.defaultImage.alt,
@@ -373,7 +377,7 @@ export function getStaticPageMetadata(path: string, pageKey: keyof typeof PAGE_M
       creator: siteMetadata.social.twitter,
       title: pageMetadata.title,
       description: pageMetadata.description,
-      images: [ensureAbsoluteUrl(ogImagePath)],
+      images: [ensureAbsoluteUrl(cacheBustingUrl)],
     },
     other: {
       // Standard HTML meta dates


### PR DESCRIPTION
This pull request adds cache-busting functionality to the Open Graph image URLs in the `getStaticPageMetadata` function to ensure social media platforms refresh their cached images when needed. The changes primarily involve appending a version query string to the image URLs.

Cache-busting implementation:

* [`lib/seo/metadata.ts`](diffhunk://#diff-86f4743fbd2751e978bab7b492a794cd76cdda0d08346338213be38107d86c84R244-R247): Introduced a `cacheBustingUrl` by appending a version query string (`?v=2`) to the `ogImagePath` to force cache refresh for social media platforms.
* [`lib/seo/metadata.ts`](diffhunk://#diff-86f4743fbd2751e978bab7b492a794cd76cdda0d08346338213be38107d86c84L254-R258): Updated the `defaultOgImage` object to use `cacheBustingUrl` instead of `ogImagePath`.
* [`lib/seo/metadata.ts`](diffhunk://#diff-86f4743fbd2751e978bab7b492a794cd76cdda0d08346338213be38107d86c84L376-R380): Modified the `images` property in the Open Graph metadata to use `cacheBustingUrl`, ensuring the cache-busting URL is applied consistently.