### PR TITLE
merge

### DIFF
--- a/__tests__/integration/pre-computation-pipeline.test.ts
+++ b/__tests__/integration/pre-computation-pipeline.test.ts
@@ -222,21 +222,39 @@ describe("Pre-computation Pipeline Integration", () => {
 
         // Test production paths
         process.env.NODE_ENV = "production";
-        jest.resetModules();
-        const prodConstants = require("@/lib/constants");
-        expect(prodConstants.CONTENT_GRAPH_S3_PATHS.RELATED_CONTENT).toBe("json/content-graph/related-content.json");
+        jest.isolateModules(() => {
+          const prodConstants = require("@/lib/constants");
+          expect(prodConstants.CONTENT_GRAPH_S3_PATHS.RELATED_CONTENT).toBe("json/content-graph/related-content.json");
+        });
 
         // Test development paths
         process.env.NODE_ENV = "development";
-        jest.resetModules();
-        const devConstants = require("@/lib/constants");
-        expect(devConstants.CONTENT_GRAPH_S3_PATHS.RELATED_CONTENT).toBe("json/content-graph-dev/related-content.json");
+        jest.isolateModules(() => {
+          const devConstants = require("@/lib/constants");
+          expect(devConstants.CONTENT_GRAPH_S3_PATHS.RELATED_CONTENT).toBe("json/content-graph-dev/related-content.json");
+        });
       } finally {
         // Restore original environment variables even if test fails
-        process.env.NODE_ENV = originalEnv;
-        if (originalApiUrl) process.env.API_BASE_URL = originalApiUrl;
-        if (originalSiteUrl) process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
-        if (originalDeploymentEnv) process.env.DEPLOYMENT_ENV = originalDeploymentEnv;
+        if (originalEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalEnv;
+        }
+        if (originalApiUrl === undefined) {
+          delete process.env.API_BASE_URL;
+        } else {
+          process.env.API_BASE_URL = originalApiUrl;
+        }
+        if (originalSiteUrl === undefined) {
+          delete process.env.NEXT_PUBLIC_SITE_URL;
+        } else {
+          process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
+        }
+        if (originalDeploymentEnv === undefined) {
+          delete process.env.DEPLOYMENT_ENV;
+        } else {
+          process.env.DEPLOYMENT_ENV = originalDeploymentEnv;
+        }
       }
     });
 

--- a/app/api/github-activity/refresh/route.ts
+++ b/app/api/github-activity/refresh/route.ts
@@ -169,8 +169,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       invalidateGitHubCache(); // in-memory
       try {
         revalidateTag("github-activity"); // Next.js function cache tag
-      } catch {
+      } catch (err) {
         // No-op outside of Next request context
+        console.warn(
+          "[API Refresh] revalidateTag('github-activity') skipped or failed:",
+          err instanceof Error ? err.message : String(err),
+        );
       }
 
       const responseData = {

--- a/lib/bookmarks/bookmarks-data-access.server.ts
+++ b/lib/bookmarks/bookmarks-data-access.server.ts
@@ -297,14 +297,15 @@ async function persistTagFilteredBookmarksToS3(bookmarks: UnifiedBookmark[]): Pr
       tagCounts[tagSlugValue] = (tagCounts[tagSlugValue] || 0) + 1;
     }
   }
-  // Apply MAX_TAGS_TO_PERSIST limit if configured
+  // Apply MAX_TAGS_TO_PERSIST limit if configured with O(n) fast-path when limit >= totalTags
   const allTags = Object.keys(bookmarksByTag);
-  const tagsToProcess = MAX_TAGS_TO_PERSIST && MAX_TAGS_TO_PERSIST > 0
-    ? Object.entries(tagCounts)
-        .sort((a, b) => b[1] - a[1]) // Sort by count descending
-        .slice(0, MAX_TAGS_TO_PERSIST)
-        .map(([tag]) => tag)
-    : allTags;
+  const tagsToProcess =
+    MAX_TAGS_TO_PERSIST > 0 && MAX_TAGS_TO_PERSIST < allTags.length
+      ? Object.entries(tagCounts)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, MAX_TAGS_TO_PERSIST)
+          .map(([tag]) => tag)
+      : allTags;
   
   envLogger.log(
     `Persisting ${tagsToProcess.length} of ${allTags.length} tags to S3 storage`, 
@@ -344,6 +345,8 @@ async function persistTagFilteredBookmarksToS3(bookmarks: UnifiedBookmark[]): Pr
     { tagCount: tagsToProcess.length, totalTags: allTags.length },
     { category: LOG_PREFIX }
   );
+  // Reduce staleness window by clearing in-memory dataset cache after writes
+  fullDatasetMemoryCache = null;
 }
 
 /** Core refresh logic - only process new/changed bookmarks */

--- a/lib/bookmarks/normalize.ts
+++ b/lib/bookmarks/normalize.ts
@@ -83,10 +83,15 @@ export function normalizeBookmark(raw: RawApiBookmark, index: number): UnifiedBo
       ogImageEtag: undefined,
     };
   } catch (normError) {
-    console.error(
-      `[Bookmarks Normalize] Error normalizing bookmark at index ${index} (ID: ${raw.id || "N/A"}):`,
-      normError,
-      raw,
+    envLogger.log(
+      "Error normalizing bookmark",
+      {
+        index,
+        bookmarkId: raw?.id ?? "N/A",
+        // Avoid logging full raw object to reduce PII leakage
+        error: normError instanceof Error ? normError.message : String(normError),
+      },
+      { category: "BookmarksNormalize" },
     );
     return null;
   }

--- a/lib/config/environment.ts
+++ b/lib/config/environment.ts
@@ -15,6 +15,9 @@ import type { Environment } from "@/types/config";
  * CRITICAL: During build time, we MUST use explicit environment variables
  * because the deployment URL is not yet known. The DEPLOYMENT_ENV variable
  * should be set in CI/CD to match the target deployment.
+ * 
+ * GITHUB ACTIVITY FIX: Always prefer DEPLOYMENT_ENV for consistency between
+ * build-time and runtime to prevent environment-specific file mismatches.
  */
 export function getEnvironment(): Environment {
   const isJest = typeof process !== "undefined" && !!process.env.JEST_WORKER_ID;
@@ -28,6 +31,8 @@ export function getEnvironment(): Environment {
       logger.info(`[Environment] Using explicit DEPLOYMENT_ENV: ${normalized}`);
       return normalized as Environment;
     }
+    // Log warning for invalid DEPLOYMENT_ENV values
+    logger.warn(`[Environment] Invalid DEPLOYMENT_ENV value: '${deploymentEnv}', falling back to URL detection`);
   }
 
   // PRIORITY 2: Try to infer from URLs (runtime detection)

--- a/lib/data-access/github-storage.ts
+++ b/lib/data-access/github-storage.ts
@@ -84,8 +84,7 @@ export async function writeGitHubActivityToS3(
       const ty = d.trailingYearData as { data?: unknown[]; dataComplete?: boolean; totalContributions?: number } | undefined;
       const hasData = Array.isArray(ty?.data) && (ty?.data?.length ?? 0) > 0;
       const complete = ty?.dataComplete === true;
-      const contributions = typeof ty?.totalContributions === "number" ? ty?.totalContributions : 0;
-      return !hasData || !complete || contributions === 0;
+      return !hasData || !complete;
     };
 
     // If new data looks incomplete, check existing

--- a/lib/data-access/opengraph.ts
+++ b/lib/data-access/opengraph.ts
@@ -271,7 +271,16 @@ export async function getOpenGraphData(
       const ogError = new OgError(`Background refresh failed for ${normalizedUrl}`, "refresh", {
         originalError: error,
       });
-      envLogger.log(`Background refresh failed`, { url: normalizedUrl, error: String(ogError) }, { category: "OpenGraph" });
+      envLogger.log(
+        `Background refresh failed`,
+        {
+          url: normalizedUrl,
+          errorName: ogError.name,
+          errorMessage: ogError.message,
+          originalErrorMessage: error instanceof Error ? error.message : String(error),
+        },
+        { category: "OpenGraph" },
+      );
     });
 
     return {

--- a/lib/data-access/opengraph.ts
+++ b/lib/data-access/opengraph.ts
@@ -233,7 +233,7 @@ export async function getOpenGraphData(
 
   // Validate URL first
   if (!validateOgUrl(normalizedUrl)) {
-    console.warn(`[DataAccess/OpenGraph] Invalid or unsafe URL: ${normalizedUrl}`);
+    envLogger.log("Invalid or unsafe URL", { url: normalizedUrl }, { category: "OpenGraph" });
     return createFallbackResult(normalizedUrl, "Invalid or unsafe URL", validatedFallback);
   }
 
@@ -271,7 +271,7 @@ export async function getOpenGraphData(
       const ogError = new OgError(`Background refresh failed for ${normalizedUrl}`, "refresh", {
         originalError: error,
       });
-      console.error(`[DataAccess/OpenGraph] ${ogError.message}:`, ogError);
+      envLogger.log(`Background refresh failed`, { url: normalizedUrl, error: String(ogError) }, { category: "OpenGraph" });
     });
 
     return {
@@ -433,11 +433,11 @@ export async function serveOpenGraphImage(s3Key: string): Promise<{ buffer: Buff
 export function invalidateOpenGraphCache(): void {
   if (USE_NEXTJS_CACHE) {
     safeRevalidateTag("opengraph");
-    console.log("[OpenGraph] Cache invalidated for all OpenGraph data");
+    envLogger.log("Cache invalidated for all OpenGraph data", undefined, { category: "OpenGraph" });
   } else {
     // Legacy: clear memory cache
     ServerCacheInstance.deleteOpenGraphData("*");
-    console.log("[OpenGraph] Legacy cache cleared for all OpenGraph data");
+    envLogger.log("Legacy cache cleared for all OpenGraph data", undefined, { category: "OpenGraph" });
   }
 }
 
@@ -449,10 +449,10 @@ export function invalidateOpenGraphCacheForUrl(url: string): void {
 
   if (USE_NEXTJS_CACHE) {
     safeRevalidateTag(`opengraph-${normalizedUrl}`);
-    console.log(`[OpenGraph] Cache invalidated for URL: ${normalizedUrl}`);
+    envLogger.log("Cache invalidated for URL", { url: normalizedUrl }, { category: "OpenGraph" });
   } else {
     // Legacy: clear specific entry from memory cache
     ServerCacheInstance.deleteOpenGraphData(normalizedUrl);
-    console.log(`[OpenGraph] Legacy cache cleared for URL: ${normalizedUrl}`);
+    envLogger.log("Legacy cache cleared for URL", { url: normalizedUrl }, { category: "OpenGraph" });
   }
 }

--- a/lib/opengraph/fetch.ts
+++ b/lib/opengraph/fetch.ts
@@ -365,9 +365,17 @@ async function fetchExternalOpenGraph(
     }
   } else {
     if (!bestImageUrl) {
-      envLogger.log(`No image found to persist`, { url }, { category: "OpenGraph" });
+      envLogger.log(
+        `No image found to persist`,
+        { url, idempotencyKey: fallbackImageData?.idempotencyKey },
+        { category: "OpenGraph" },
+      );
     } else if (!fallbackImageData?.idempotencyKey) {
-      envLogger.log(`No idempotencyKey provided, cannot persist image`, { bestImageUrl }, { category: "OpenGraph" });
+      envLogger.log(
+        `No idempotencyKey provided, cannot persist image`,
+        { url, bestImageUrl },
+        { category: "OpenGraph" },
+      );
     }
   }
 

--- a/lib/server-cache.ts
+++ b/lib/server-cache.ts
@@ -44,6 +44,8 @@ export class ServerCache implements ICache {
   }
 
   private proactiveEviction(percentage: number): void {
+    // Clamp percentage to a safe range [0, 0.95]
+    percentage = Math.min(0.95, Math.max(0, percentage));
     // If disabled, don't perform eviction
     if (this.disabled) {
       return;
@@ -56,8 +58,8 @@ export class ServerCache implements ICache {
     if (currentSizeBytes < 1024 * 1024) {
       envLogger.log(
         `Skipping eviction - cache size only ${Math.round(currentSizeBytes / 1024)}KB`,
-        undefined,
-        { category: "ServerCache" },
+        { sizeKB: Math.round(currentSizeBytes / 1024) },
+        { category: "ServerCache", context: { event: "eviction-skip" } },
       );
       return;
     }
@@ -80,8 +82,8 @@ export class ServerCache implements ICache {
 
     envLogger.log(
       `Proactive eviction complete. Removed ${removedCount} entries (${Math.round(removedBytes / 1024)}KB)`,
-      undefined,
-      { category: "ServerCache" },
+      { removedCount, removedKB: Math.round(removedBytes / 1024) },
+      { category: "ServerCache", context: { event: "eviction-complete" } },
     );
   }
 
@@ -110,7 +112,7 @@ export class ServerCache implements ICache {
       this.hits++;
       return entry.value as T;
     } catch (error) {
-      console.error("[ServerCache] Error in get operation:", error);
+      envLogger.log("Error in get operation", { error }, { category: "ServerCache" });
       this.handleFailure();
       return undefined;
     }
@@ -135,7 +137,7 @@ export class ServerCache implements ICache {
         if (size > 10 * 1024 * 1024) {
           envLogger.log(
             `Rejected ${Math.round(size / 1024)}KB buffer – exceeds 10MB item limit`,
-            { key },
+            { key, sizeKB: Math.round(size / 1024), limitKB: 10 * 1024 },
             { category: "ServerCache" },
           );
           return false;
@@ -158,7 +160,11 @@ export class ServerCache implements ICache {
 
       // If still too big after eviction, reject
       if (this.totalSize + size > this.maxSize) {
-        envLogger.log("Cache full, cannot store key", { key }, { category: "ServerCache" });
+        envLogger.log(
+          "Cache full, cannot store key",
+          { key, utilizationPercent: Math.round((this.totalSize / this.maxSize) * 100) },
+          { category: "ServerCache", context: { event: "cache-full" } },
+        );
         return false;
       }
 
@@ -175,7 +181,7 @@ export class ServerCache implements ICache {
       this.totalSize += size;
       return true;
     } catch (error) {
-      console.error("[ServerCache] Error in set operation:", error);
+      envLogger.log("Error in set operation", { error }, { category: "ServerCache" });
       this.handleFailure();
       return false;
     }
@@ -242,8 +248,8 @@ export class ServerCache implements ICache {
       this.disabled = true;
       envLogger.log(
         `Circuit breaker activated after ${this.failureCount} failures. Cache operations disabled to prevent system instability.`,
-        undefined,
-        { category: "ServerCache" },
+        { failureCount: this.failureCount },
+        { category: "ServerCache", context: { event: "circuit-breaker-activated" } },
       );
     }
   }
@@ -256,7 +262,7 @@ export class ServerCache implements ICache {
   public clearAllCaches(): void {
     // If disabled, don't attempt cleanup
     if (this.disabled) {
-      envLogger.log("Cache is disabled, skipping clear operation", undefined, { category: "ServerCache" });
+      envLogger.log("Cache is disabled, skipping clear operation", undefined, { category: "ServerCache", context: { event: "clear-skip" } });
       return;
     }
 
@@ -274,7 +280,7 @@ export class ServerCache implements ICache {
               this.totalSize -= entry.size;
             }
           } catch (deleteError) {
-            console.error(`[ServerCache] Failed to delete key ${key}:`, deleteError);
+            envLogger.log("Failed to delete key during clear", { key, error: deleteError }, { category: "ServerCache" });
           }
         }
       }
@@ -284,7 +290,7 @@ export class ServerCache implements ICache {
       this.hits = 0;
       this.misses = 0;
     } catch (error) {
-      console.error("[ServerCache] Error during cache clear:", error);
+      envLogger.log("Error during cache clear", { error }, { category: "ServerCache" });
       this.handleFailure();
     }
   }
@@ -320,14 +326,14 @@ export class ServerCache implements ICache {
       this.failureCount = 0;
       envLogger.log(
         `Circuit breaker reset. Memory usage ${Math.round(memUsage.rss / 1024 / 1024)}MB is below safe threshold.`,
-        undefined,
-        { category: "ServerCache" },
+        { rssMB: Math.round(memUsage.rss / 1024 / 1024) },
+        { category: "ServerCache", context: { event: "circuit-breaker-reset" } },
       );
     } else {
       envLogger.log(
         `Cannot reset circuit breaker. Memory usage ${Math.round(memUsage.rss / 1024 / 1024)}MB still above safe threshold.`,
-        { rssMB: Math.round(memUsage.rss / 1024 / 1024) },
-        { category: "ServerCache" },
+        { rssMB: Math.round(memUsage.rss / 1024 / 1024), safeThresholdMB: Math.round(safeThreshold / 1024 / 1024) },
+        { category: "ServerCache", context: { event: "circuit-breaker-not-reset" } },
       );
     }
   }
@@ -376,8 +382,8 @@ function attachHelpers<T extends Record<string, unknown>>(prototype: object, hel
     if (key in prototype) {
       envLogger.log(
         `Overwriting existing method '${key}' on prototype while attaching '${helperName}' helpers.`,
-        undefined,
-        { category: "ServerCache" },
+        { method: key, helperName },
+        { category: "ServerCache", context: { event: "prototype-overwrite" } },
       );
     }
     // Define non-enumerable to keep prototype surface tidy

--- a/lib/server-cache/bookmarks.ts
+++ b/lib/server-cache/bookmarks.ts
@@ -36,7 +36,7 @@ export function setBookmarks(this: ICache): void {
     envLogger.log(
       "setBookmarks called - this is deprecated. Bookmarks are stored in S3 only.",
       undefined,
-      { category: "ServerCache" },
+      { category: "ServerCache", context: { method: "setBookmarks", deprecated: true } },
     );
   }
 }

--- a/scripts/debug-github-activity.ts
+++ b/scripts/debug-github-activity.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env bun
+
+/**
+ * Debug Script for GitHub Activity Data Issues
+ * 
+ * This script helps diagnose and fix GitHub Activity JSON issues by:
+ * 1. Checking environment configuration
+ * 2. Listing existing S3 files
+ * 3. Validating data structure
+ * 4. Attempting data refresh
+ */
+
+import { getEnvironment, getEnvironmentSuffix } from "@/lib/config/environment";
+import { 
+  readGitHubActivityFromS3,
+  GITHUB_ACTIVITY_S3_KEY_FILE,
+  GITHUB_ACTIVITY_S3_KEY_FILE_FALLBACK,
+  ALL_TIME_SUMMARY_S3_KEY_FILE,
+  GITHUB_STATS_SUMMARY_S3_KEY_FILE
+} from "@/lib/data-access/github-storage";
+import { listS3Objects } from "@/lib/s3-utils";
+import { refreshGitHubActivityDataFromApi } from "@/lib/data-access/github";
+
+async function main() {
+  console.log("🔍 GitHub Activity Debug Script\n");
+  console.log("=" .repeat(50));
+  
+  // 1. Check environment configuration
+  console.log("\n📋 Environment Configuration:");
+  console.log(`  DEPLOYMENT_ENV: ${process.env.DEPLOYMENT_ENV || "(not set)"}`);
+  console.log(`  NODE_ENV: ${process.env.NODE_ENV || "(not set)"}`);
+  console.log(`  Detected Environment: ${getEnvironment()}`);
+  console.log(`  Environment Suffix: "${getEnvironmentSuffix()}"`);
+  console.log(`  Primary File: ${GITHUB_ACTIVITY_S3_KEY_FILE}`);
+  console.log(`  Fallback File: ${GITHUB_ACTIVITY_S3_KEY_FILE_FALLBACK}`);
+  
+  // 2. List existing GitHub activity files in S3
+  console.log("\n📁 S3 GitHub Activity Files:");
+  try {
+    const files = await listS3Objects("json/github-activity");
+    if (files.length === 0) {
+      console.log("  ❌ No files found in json/github-activity/");
+    } else {
+      for (const file of files.slice(0, 20)) {
+        console.log(`  - ${file}`);
+      }
+      if (files.length > 20) {
+        console.log(`  ... and ${files.length - 20} more files`);
+      }
+    }
+  } catch (error) {
+    console.error("  ❌ Error listing S3 files:", error);
+  }
+  
+  // 3. Check primary file
+  console.log("\n🔍 Checking Primary File:");
+  console.log(`  File: ${GITHUB_ACTIVITY_S3_KEY_FILE}`);
+  try {
+    const primaryData = await readGitHubActivityFromS3(GITHUB_ACTIVITY_S3_KEY_FILE);
+    if (primaryData) {
+      const trailing = primaryData.trailingYearData;
+      const allTime = primaryData.cumulativeAllTimeData;
+      console.log(`  ✅ File exists`);
+      console.log(`  - Trailing Year Contributions: ${trailing?.totalContributions ?? 0}`);
+      console.log(`  - Trailing Year Data Points: ${trailing?.data?.length ?? 0}`);
+      console.log(`  - Trailing Year Complete: ${trailing?.dataComplete ?? false}`);
+      console.log(`  - All-Time Contributions: ${allTime?.totalContributions ?? 0}`);
+      
+      // Check for data inconsistencies
+      if (trailing && allTime) {
+        if (trailing.totalContributions > allTime.totalContributions) {
+          console.log("  ⚠️  WARNING: Trailing year > All-time contributions!");
+        }
+      }
+      if (trailing?.data?.length === 0 && trailing?.totalContributions > 0) {
+        console.log("  ⚠️  WARNING: Has contributions but no data points!");
+      }
+    } else {
+      console.log(`  ❌ File not found or empty`);
+    }
+  } catch (error) {
+    console.log(`  ❌ Error reading file:`, error);
+  }
+  
+  // 4. Check fallback file
+  console.log("\n🔍 Checking Fallback File:");
+  console.log(`  File: ${GITHUB_ACTIVITY_S3_KEY_FILE_FALLBACK}`);
+  try {
+    const fallbackData = await readGitHubActivityFromS3(GITHUB_ACTIVITY_S3_KEY_FILE_FALLBACK);
+    if (fallbackData) {
+      const trailing = fallbackData.trailingYearData;
+      console.log(`  ✅ File exists`);
+      console.log(`  - Trailing Year Contributions: ${trailing?.totalContributions ?? 0}`);
+      console.log(`  - Trailing Year Data Points: ${trailing?.data?.length ?? 0}`);
+    } else {
+      console.log(`  ❌ File not found or empty`);
+    }
+  } catch (error) {
+    console.log(`  ❌ Error reading file:`, error);
+  }
+  
+  // 5. Check other summary files
+  console.log("\n📊 Other Summary Files:");
+  const summaryFiles = [
+    { name: "Stats Summary", path: GITHUB_STATS_SUMMARY_S3_KEY_FILE },
+    { name: "All-Time Summary", path: ALL_TIME_SUMMARY_S3_KEY_FILE }
+  ];
+  
+  for (const file of summaryFiles) {
+    console.log(`  ${file.name}: ${file.path}`);
+    try {
+      const exists = await listS3Objects(file.path);
+      console.log(`    ${exists.length > 0 ? "✅ Exists" : "❌ Not found"}`);
+    } catch {
+      console.log(`    ❌ Error checking`);
+    }
+  }
+  
+  // 6. Ask if user wants to refresh
+  console.log("\n" + "=".repeat(50));
+  const args = process.argv.slice(2);
+  if (args.includes("--refresh") || args.includes("-r")) {
+    console.log("\n🔄 Refreshing GitHub Activity Data...");
+    console.log("  This may take a few minutes...\n");
+    
+    try {
+      const result = await refreshGitHubActivityDataFromApi();
+      if (result) {
+        console.log("✅ Refresh completed successfully!");
+        console.log(`  - Trailing Year: ${result.trailingYearData.totalContributions} contributions`);
+        console.log(`  - All-Time: ${result.allTimeData.totalContributions} contributions`);
+        console.log(`  - Lines Added: +${result.trailingYearData.linesAdded || 0}`);
+        console.log(`  - Lines Removed: -${result.trailingYearData.linesRemoved || 0}`);
+      } else {
+        console.log("❌ Refresh returned no data");
+      }
+    } catch (error) {
+      console.error("❌ Refresh failed:", error);
+      if (error instanceof Error && error.message.includes("rate")) {
+        console.log("\n💡 Tip: GitHub API rate limit exceeded. Try again later.");
+      }
+    }
+  } else {
+    console.log("\n💡 To refresh GitHub data, run: bun scripts/debug-github-activity.ts --refresh");
+  }
+  
+  // 7. Provide diagnostic summary
+  console.log("\n" + "=".repeat(50));
+  console.log("📋 Diagnostic Summary:\n");
+  
+  const suffix = getEnvironmentSuffix();
+  
+  if (!process.env.DEPLOYMENT_ENV) {
+    console.log("⚠️  DEPLOYMENT_ENV is not set - this can cause environment detection issues");
+    console.log("   Set DEPLOYMENT_ENV=development or DEPLOYMENT_ENV=production");
+  }
+  
+  if (suffix && !GITHUB_ACTIVITY_S3_KEY_FILE.includes(suffix)) {
+    console.log("⚠️  Environment suffix mismatch in file path");
+    console.log(`   Expected suffix '${suffix}' not found in ${GITHUB_ACTIVITY_S3_KEY_FILE}`);
+  }
+  
+  console.log("\n✅ Recommended Actions:");
+  console.log("1. Ensure DEPLOYMENT_ENV is set consistently in CI/CD and runtime");
+  console.log("2. Run data refresh: bun scripts/data-updater.ts --github --force");
+  console.log("3. Check cron job configuration for automatic daily updates");
+  console.log("4. Verify S3 bucket permissions for reading and writing");
+}
+
+main().catch(error => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the codebase, focusing on reliability, maintainability, and consistency of environment handling, image selection logic, GitHub activity data access, and test robustness. The changes streamline image selection in bookmark cards, enhance fallback logic for GitHub activity data, improve environment variable handling, and optimize cache and error logging.

### Bookmark Card Image Selection and Logging
* Replaced the complex `getDisplayImageUrl` logic in `BookmarkCardClient` with a centralized `selectBestImage` function, ensuring consistent image selection and fallback handling across server and client components. Also removed the unused `ogImageExternal` prop. [[1]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL32-R32) [[2]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL56-R56) [[3]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL84-L172)

### GitHub Activity Data Reliability
* Enhanced fallback logic in `getGithubActivity` to always attempt using the production file as a fallback for any environment if the environment-scoped file is missing or empty, with additional logging for critical failures and base filename fallback in production.
* Updated the write logic in `writeGitHubActivityToS3` to be less strict, allowing writes if new data has more contributions than existing data, even if incomplete, and only skipping writes if the existing dataset is healthier.

### Environment Variable Consistency
* Improved `getEnvironment` to always prefer `DEPLOYMENT_ENV` for consistency between build-time and runtime, and added warnings for invalid values to reduce environment-specific file mismatches. [[1]](diffhunk://#diff-818b0948efd99cd8d642650c13af752fd0a128434ba2599fff48b618b7ab43dcR18-R20) [[2]](diffhunk://#diff-818b0948efd99cd8d642650c13af752fd0a128434ba2599fff48b618b7ab43dcR34-R35)

### Bookmark Tag Persistence and Caching
* Optimized tag persistence logic to use a fast path when the tag limit exceeds the number of tags, and reduced cache staleness by clearing the in-memory dataset cache after writes. [[1]](diffhunk://#diff-f205873943bb77543521d909d9ae7eb49f6116bf02a668f84155ab9a19a4999dL300-R305) [[2]](diffhunk://#diff-f205873943bb77543521d909d9ae7eb49f6116bf02a668f84155ab9a19a4999dR348-R349)

### Test and Utility Robustness
* Improved test isolation in `pre-computation-pipeline.test.ts` by using `jest.isolateModules` instead of `jest.resetModules`, and enhanced environment variable restoration logic for safer test cleanup.
* Switched OpenGraph invalid URL logging to use `envLogger` for structured logging and reduced PII leakage in bookmark normalization error logging. [[1]](diffhunk://#diff-400846baaad249e78eb037a599fe0654e118feebe0dd47d308eb87a019a42190L236-R236) [[2]](diffhunk://#diff-fe3240f3de5d7d5c7e78e29b491ea31aa126daac3a059ab26066c893d479c748L86-R94)

---

**References:**  
[[1]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL32-R32) [[2]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL56-R56) [[3]](diffhunk://#diff-edcb489039b459f7601e3d768015c68395298bc77ea6ca927a2b7ecabf0762caL84-L172) [[4]](diffhunk://#diff-532fdbf56006a1d6a0ec38a3a1fb10f1282ebf9bddb47e3628ef5fdca99bd491L101-R165) [[5]](diffhunk://#diff-7ad41646839e692ce28aa18d7579f7ff663d3390019613bea867278abe786831R82-R122) [[6]](diffhunk://#diff-818b0948efd99cd8d642650c13af752fd0a128434ba2599fff48b618b7ab43dcR18-R20) [[7]](diffhunk://#diff-818b0948efd99cd8d642650c13af752fd0a128434ba2599fff48b618b7ab43dcR34-R35) [[8]](diffhunk://#diff-f205873943bb77543521d909d9ae7eb49f6116bf02a668f84155ab9a19a4999dL300-R305) [[9]](diffhunk://#diff-f205873943bb77543521d909d9ae7eb49f6116bf02a668f84155ab9a19a4999dR348-R349) [[10]](diffhunk://#diff-6c2b7c1840c32bd5c1a2bd37b904a2d95647c67c8ec438126adec8bf791edb53L225-R257) [[11]](diffhunk://#diff-400846baaad249e78eb037a599fe0654e118feebe0dd47d308eb87a019a42190L236-R236) [[12]](diffhunk://#diff-fe3240f3de5d7d5c7e78e29b491ea31aa126daac3a059ab26066c893d479c748L86-R94)