### PR TITLE
Use toSorted() over Array.sort() and refine bookmarks metadata refresh

### DIFF
--- a/components/features/bookmarks/bookmarks-with-options.client.tsx
+++ b/components/features/bookmarks/bookmarks-with-options.client.tsx
@@ -204,7 +204,7 @@ export const BookmarksWithOptions: React.FC<BookmarksWithOptionsClientProps> = (
       return getTagsAsStringArray(bookmark.tags);
     })
     .filter((tag, index, self) => tag && self.indexOf(tag) === index)
-    .sort();
+    .toSorted();
 
   // Determine which set of bookmarks to filter
   const bookmarksToFilter = searchAllBookmarks && searchQuery ? allBookmarks : bookmarks;

--- a/components/features/bookmarks/bookmarks-with-pagination.client.tsx
+++ b/components/features/bookmarks/bookmarks-with-pagination.client.tsx
@@ -215,7 +215,7 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
     return bookmarks
       .flatMap((bookmark: UnifiedBookmark) => getTagsAsStringArray(bookmark.tags))
       .filter((tag, index, self) => tag && self.indexOf(tag) === index)
-      .sort();
+      .toSorted();
   }, [bookmarks]);
 
   // Filter bookmarks based on search and tags

--- a/lib/bookmarks/slug-manager.ts
+++ b/lib/bookmarks/slug-manager.ts
@@ -39,7 +39,7 @@ export function generateSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugM
   const reverseMap: Record<string, string> = {};
 
   // Sort bookmarks by ID for consistent ordering (string comparison)
-  const sortedBookmarks = [...bookmarks].sort((a, b) => a.id.localeCompare(b.id));
+  const sortedBookmarks = bookmarks.toSorted((a, b) => a.id.localeCompare(b.id));
 
   for (const bookmark of sortedBookmarks) {
     // generateUniqueSlug should handle uniqueness, but add a belt-and-suspenders guard
@@ -79,7 +79,7 @@ export function generateSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugM
 
   // Generate checksum for change detection based on [id, slug] pairs in a stable order
   const checksumPayload = Object.keys(slugs)
-    .sort((a, b) => a.localeCompare(b))
+    .toSorted((a, b) => a.localeCompare(b))
     .map(id => [id, slugs[id]?.slug]);
   const checksum = createHash("md5").update(JSON.stringify(checksumPayload)).digest("hex");
 
@@ -343,6 +343,6 @@ export async function getBookmarkBySlug(slug: string): Promise<UnifiedBookmark |
 export function generateBookmarkRoutes(mapping: BookmarkSlugMapping): string[] {
   return Object.values(mapping.slugs)
     .map(entry => entry.slug)
-    .sort((a, b) => a.localeCompare(b))
+    .toSorted((a, b) => a.localeCompare(b))
     .map(slug => `/bookmarks/${slug}`);
 }

--- a/scripts/force-refresh-repo-stats.ts
+++ b/scripts/force-refresh-repo-stats.ts
@@ -67,7 +67,7 @@ async function fetchStatsForRepo(owner: string, name: string): Promise<RepoRawWe
         );
         return userStatsEntry.weeks
           .map((w: RepoRawWeeklyStat) => ({ w: w.w, a: w.a, d: w.d, c: w.c }))
-          .sort((a, b) => a.w - b.w);
+          .toSorted((a, b) => a.w - b.w);
       }
       console.log(`[Script] No specific stats found for user ${GITHUB_REPO_OWNER} in ${owner}/${name}.`);
       return [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adopts toSorted across app and changes bookmarks refresh to update FILE/INDEX without rewriting pages/tags on metadata-only updates to curb S3 writes.
> 
> - **Backend (bookmarks data access)**:
>   - Metadata-only refresh behavior: update `BOOKMARKS_S3_PATHS.FILE` and `INDEX` using `baseIndex`; skip rewriting pages/tags when dataset unchanged; return `bookmarksWithSlugs`; refine logs.
>   - Non-selective path: on metadata changes, only update `FILE` and log that pages/tags refresh on next dataset change.
>   - Tag persistence selection uses `Object.entries(tagCounts).toSorted(...)` for deterministic limiting.
> - **Slug Manager**:
>   - Use `toSorted` for sorting bookmarks, checksum keys, and route generation in `generateBookmarkRoutes`.
> - **Frontend (bookmarks UI)**:
>   - Unique tag lists now use `toSorted()` in `bookmarks-with-options.client.tsx` and `bookmarks-with-pagination.client.tsx`.
> - **Scripts**:
>   - `force-refresh-repo-stats.ts`: weekly stats sorted with `toSorted()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0872f6701eb4017e0dfe09a41578822306caa39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->