### PR TITLE
Increase bookmarks lock TTL to 30m, gate cleanup, update logs/docs

### DIFF
--- a/docs/projects/structure/bookmarks.md
+++ b/docs/projects/structure/bookmarks.md
@@ -119,7 +119,12 @@ param generation, but readers now prefer the embedded `slug` when present.
 
 **Problem**: Race conditions with concurrent refresh operations
 
-**Solution**: Conditional writes using `IfNoneMatch: "*"` for atomic lock acquisition
+**Solution**: Conditional writes using `IfNoneMatch: "*"` for atomic lock acquisition.
+
+- Default TTL is **30 minutes** to cover the worst-case OpenGraph enrichment window. The previous 5-minute TTL
+  allowed long-running refreshes to appear stale, which meant other processes could start overlapping refreshes.
+- Periodic stale-lock cleanup now skips while the current process owns the distributed lock, avoiding self-deletion
+  during active refresh cycles.
 
 ### 3. Tag Caching Memory Protection
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase distributed lock TTL to 30 minutes and skip stale-lock cleanup when the current process holds the lock; update docs accordingly.
> 
> - **Backend (bookmarks data access)**:
>   - Default distributed lock TTL set to `30 minutes` (`DEFAULT_LOCK_TTL_MS`); fallback increased from `5 minutes` and log message updated.
>   - Stale-lock cleanup: skip initial and periodic cleanup when `isRefreshLocked` is true; add debug log when skipped.
> - **Docs**:
>   - Clarify atomic S3 locking: emphasize conditional writes, set default TTL to 30 minutes, and note cleanup is skipped while lock is owned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f556c9fb000c15312a38e9f72e627de44df0db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->