### PR TITLE
fix(bookmarks): implement title-based slug generation for content-sha…

### DIFF
--- a/docs/projects/structure/bookmarks.md
+++ b/docs/projects/structure/bookmarks.md
@@ -115,7 +115,7 @@ param generation, but readers now prefer the embedded `slug` when present.
 
 **Previous Behavior**:
 
-```
+```text
 youtube.com/watch?v=abc123 → "youtube-com-watch"
 youtube.com/watch?v=xyz789 → "youtube-com-watch-2" ❌ Collision with numeric suffix
 ```
@@ -124,7 +124,7 @@ youtube.com/watch?v=xyz789 → "youtube-com-watch-2" ❌ Collision with numeric 
 
 **New Behavior**:
 
-```
+```text
 youtube.com/watch?v=abc123 + "How to Use OpenAI" → "youtube-how-to-use-openai"
 youtube.com/watch?v=xyz789 + "React Best Practices" → "youtube-react-best-practices"
 ```
@@ -184,9 +184,11 @@ youtube.com/watch?v=xyz789 + "React Best Practices" → "youtube-react-best-prac
 
 **Strategy**:
 
-1. **Primary**: Title-based slugs for content-sharing domains (YouTube, Reddit, etc.)
-2. **Secondary**: Domain + path-based slugs for regular domains
-3. **Fallback**: Numeric suffixes when identical slugs detected (-2, -3, etc.)
+```text
+1. Primary: Title-based slugs for content-sharing domains (YouTube, Reddit, etc.)
+2. Secondary: Domain + path-based slugs for regular domains
+3. Fallback: Numeric suffixes when identical slugs detected (-2, -3, etc.)
+```
 
 **Deterministic Ordering**:
 

--- a/lib/bookmarks/slug-manager.ts
+++ b/lib/bookmarks/slug-manager.ts
@@ -41,15 +41,16 @@ export function generateSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugM
   // Sort bookmarks by ID for consistent ordering (string comparison)
   const sortedBookmarks = bookmarks.toSorted((a, b) => a.id.localeCompare(b.id));
 
-  for (const bookmark of sortedBookmarks) {
-    // generateUniqueSlug should handle uniqueness, but add a belt-and-suspenders guard
-    // Include title in candidates for content-sharing domain detection
-    const candidates = sortedBookmarks.map(b => ({ id: b.id, url: b.url, title: b.title })).filter(c => !!c.url);
+  // Build candidates array once (performance optimization: avoids O(n²) array rebuilding)
+  const candidates = sortedBookmarks
+    .map(b => ({ id: b.id, url: b.url, title: b.title }))
+    .filter(c => typeof c.url === "string" && c.url.length > 0);
 
+  for (const bookmark of sortedBookmarks) {
     // Pass bookmark title for content-sharing domains (YouTube, Reddit, etc.)
     let slug = generateUniqueSlug(
       bookmark.url || "",
-      candidates as Array<{ id: string; url: string; title?: string }>,
+      candidates,
       bookmark.id,
       bookmark.title, // ✅ Pass title for content-sharing domain slug generation
     );

--- a/lib/utils/domain-utils.ts
+++ b/lib/utils/domain-utils.ts
@@ -199,8 +199,7 @@ function getBaseSlugFromUrl(url: string, title?: string): string {
       if (titleSlug) {
         return `${domainPrefix}-${titleSlug}`;
       }
-      // Fall back to domain-only if title conversion failed
-      return domainPrefix;
+      // No valid title slug → fall through to domain+path handling below
     }
 
     // For regular domains, use domain + path approach
@@ -260,7 +259,7 @@ export function generateUniqueSlug(
     const slugCounts = new Map<string, number>();
 
     // Process bookmarks in a deterministic order (by ID)
-    const sortedBookmarks = [...allBookmarks].sort((a, b) => a.id.localeCompare(b.id));
+    const sortedBookmarks = allBookmarks.toSorted((a, b) => a.id.localeCompare(b.id));
 
     for (const bookmark of sortedBookmarks) {
       if (bookmark.id === currentBookmarkId) continue; // Skip current bookmark


### PR DESCRIPTION
…ring domains

Resolves slug collisions on platforms like YouTube, Reddit, Google Docs, etc. where multiple pieces of content share the same base URL structure.

Problem:
- youtube.com/watch?v=abc → 'youtube-com-watch'
- youtube.com/watch?v=xyz → 'youtube-com-watch-2' (collision!)
- Same issue for Reddit, Medium, GitHub, Google Workspace, etc.

Solution:
- Whitelist of 47 content-sharing platforms
- Title-based natural language slugs for whitelisted domains
- Domain+path slugs for regular domains (backward compatible)
- Deterministic ordering ensures consistent slug assignment

Changes:
- NEW: lib/config/content-sharing-domains.ts (whitelist configuration)
- ENHANCED: lib/utils/domain-utils.ts (titleToSlug + enhanced slug generation)
- UPDATED: lib/bookmarks/slug-manager.ts (pass titles to slug generator)
- TESTS: +5 new tests for Google Workspace, Figma, Notion (52/52 passing)
- DOCS: Updated bookmarks.md with new slug strategy

Examples after fix:
- youtube.com/watch?v=abc + 'How to Use OpenAI' → 'youtube-how-to-use-openai'
- docs.google.com/document/d/123 + 'Q4 Planning' → 'docs-google-com-q4-planning-document'
- reddit.com/r/foo/123 + 'TypeScript Tips' → 'reddit-com-typescript-tips'

Platforms covered: YouTube, Reddit, Twitter/X, Medium, GitHub, Google Workspace (Docs/Sheets/Slides/Forms/Drive), Figma, Notion, Miro, and 30+ more.

No breaking changes: Regular domains continue using existing slug logic.
All validation passing: 0 lint errors, 0 type errors, 52/52 tests passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements title-based slugging for whitelisted content-sharing domains, updates slug generation/manager, adds comprehensive tests, and documents the new strategy.
> 
> - **Slug generation**:
>   - **Title-based slugs**: `generateUniqueSlug` and helper now use titles on content-sharing domains; fall back to domain+path when title slug is empty; deterministic ordering and numeric suffixing preserved.
>   - **New utility**: `titleToSlug(title, maxLength)` for natural-language slugs.
>   - Performance: pre-sorts and uses `toSorted`; improves base-slug computation.
> - **Config**:
>   - **New**: `lib/config/content-sharing-domains.ts` with whitelist, `isContentSharingDomain`, and `extractDomain`.
> - **Slug Manager**:
>   - Passes `title` into `generateUniqueSlug`; precomputes candidates once; maintains collision safety.
> - **Tests**:
>   - Expanded suite covering `isContentSharingDomain`, subdomains, edge cases, `titleToSlug`, and title-based `generateUniqueSlug` behaviors.
> - **Docs**:
>   - `docs/projects/structure/bookmarks.md` updated with the title-based slug strategy and slug uniqueness guarantees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b34d6d0a41201f666ffb80fa30808bb715df7b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->