### PR TITLE
feat: expose lifetime github contribution totals

### DIFF
--- a/components/features/github/github-activity.client.tsx
+++ b/components/features/github/github-activity.client.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import type { ContributionDay, UserActivityView } from "@/types/github";
+import type { CommitsOlderThanYearSummary, ContributionDay, UserActivityView } from "@/types/github";
 import { formatDistanceToNow } from "date-fns";
 import { Code, RefreshCw } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -58,11 +58,14 @@ const GitHubActivity = () => {
   const [allTimeLinesAdded, setAllTimeLinesAdded] = useState<number | null>(null); // All-time lines added
   const [allTimeLinesRemoved, setAllTimeLinesRemoved] = useState<number | null>(null); // All-time lines removed
   const [allTimeTotalContributions, setAllTimeTotalContributions] = useState<number | null>(null); // All-time total contributions
+  const [commitsOlderThanYear, setCommitsOlderThanYear] = useState<CommitsOlderThanYearSummary | null>(null); // Older-than-year commit stats
 
   const [dataComplete, setDataComplete] = useState<boolean>(true); // Flag indicating if the fetched data is complete
   const [lastRefreshed, setLastRefreshed] = useState<string | null>(null); // Timestamp of the last data refresh
   const [showCrossEnvRefresh, setShowCrossEnvRefresh] = useState(false); // Show option to refresh other environments
   const [isRefreshingProduction, setIsRefreshingProduction] = useState(false); // Loading state for production refresh
+  const lifetimeContributionTotal =
+    allTimeTotalContributions ?? (totalContributions ?? 0) + (commitsOlderThanYear?.totalCommits ?? 0);
 
   // Determine if refresh buttons should be shown based on environment
   // Show refresh button for non-production environments (development, test, staging)
@@ -125,6 +128,7 @@ const GitHubActivity = () => {
     setAllTimeLinesAdded(null); // Reset for cards
     setAllTimeLinesRemoved(null); // Reset for cards
     setAllTimeTotalContributions(null); // Reset for cards
+    setCommitsOlderThanYear(null);
     setDataComplete(false); // Assume data is incomplete after reset
     setLastRefreshed(null);
     setError(null); // Also reset error state
@@ -205,6 +209,7 @@ const GitHubActivity = () => {
           setAllTimeLinesAdded(result?.allTimeStats?.linesAdded ?? null);
           setAllTimeLinesRemoved(result?.allTimeStats?.linesRemoved ?? null);
           setAllTimeTotalContributions(result?.allTimeStats?.totalContributions ?? null);
+          setCommitsOlderThanYear(result?.commitsOlderThanYear ?? null);
 
           setLastRefreshed(result?.lastRefreshed ?? null);
           return; // Return after setting partial data/error
@@ -228,6 +233,7 @@ const GitHubActivity = () => {
         setAllTimeLinesAdded(result?.allTimeStats?.linesAdded ?? null);
         setAllTimeLinesRemoved(result?.allTimeStats?.linesRemoved ?? null);
         setAllTimeTotalContributions(result?.allTimeStats?.totalContributions ?? null);
+        setCommitsOlderThanYear(result?.commitsOlderThanYear ?? null);
 
         if (result?.allTimeStats) {
           console.log("[Client] All-time stats received:", result.allTimeStats);
@@ -460,6 +466,18 @@ const GitHubActivity = () => {
               </span>
             )}
           </div>
+          {lifetimeContributionTotal > 0 && (
+            <div className="mt-2 text-xs text-gray-600 dark:text-gray-300">
+              Lifetime contributions:{" "}
+              <span className="font-semibold">{lifetimeContributionTotal.toLocaleString()}</span>
+              {commitsOlderThanYear && totalContributions !== null && (
+                <span className="ml-1 text-gray-500 dark:text-gray-400">
+                  (Prior years: {commitsOlderThanYear.totalCommits.toLocaleString()} + Trailing year:{" "}
+                  {totalContributions.toLocaleString()})
+                </span>
+              )}
+            </div>
+          )}
           {allTimeLinesAdded !== null && allTimeLinesRemoved !== null && allTimeTotalContributions !== null && (
             <div className="mt-6">
               <CumulativeGitHubStatsCards

--- a/lib/data-access/github-public-api.ts
+++ b/lib/data-access/github-public-api.ts
@@ -74,6 +74,7 @@ function formatActivityView(
   };
 
   const allTimeData = s3ActivityData.cumulativeAllTimeData || trailingYearData;
+  const commitsOlderThanYear = allTimeData.allCommitsOlderThanYear;
 
   return {
     source,
@@ -90,6 +91,7 @@ function formatActivityView(
       linesAdded: allTimeData.linesAdded || 0,
       linesRemoved: allTimeData.linesRemoved || 0,
     },
+    commitsOlderThanYear,
     lastRefreshed,
   };
 }

--- a/types/github.ts
+++ b/types/github.ts
@@ -34,6 +34,7 @@ export interface StoredGithubActivityS3 {
   error?: string;
   details?: string;
   allTimeTotalContributions?: number;
+  allCommitsOlderThanYear?: CommitsOlderThanYearSummary;
 }
 
 /**
@@ -77,6 +78,28 @@ export interface GitHubActivitySummary {
     };
     other: { linesAdded: number; linesRemoved: number; netChange: number; repoCount: number };
   };
+}
+
+/**
+ * Per-repository stats for commits older than one trailing year window
+ */
+export interface CommitsOlderThanYearRepoStats {
+  commits: number;
+  linesAdded: number;
+  linesRemoved: number;
+  isPrivate: boolean;
+}
+
+/**
+ * Aggregated commit statistics for activity that occurred more than one year ago
+ */
+export interface CommitsOlderThanYearSummary {
+  totalCommits: number;
+  totalLinesAdded: number;
+  totalLinesRemoved: number;
+  publicCommits: number;
+  privateCommits: number;
+  perRepo: Record<string, CommitsOlderThanYearRepoStats>;
 }
 
 /**
@@ -227,6 +250,7 @@ export interface UserActivityView {
     linesAdded: number;
     linesRemoved: number;
   };
+  commitsOlderThanYear?: CommitsOlderThanYearSummary;
   lastRefreshed?: string;
 }
 


### PR DESCRIPTION
This pull request adds support for tracking and displaying commit statistics for contributions older than one year in the GitHub activity summary. The changes include new data structures for aggregating these stats, updates to the data-fetching logic to compute and store them, and UI improvements to show lifetime contributions broken down by trailing year and prior years.

**Backend: Commit statistics for contributions older than one year**
* Added new types `CommitsOlderThanYearSummary` and `CommitsOlderThanYearRepoStats` to represent aggregated and per-repository commit stats for activity older than one year. (`types/github.ts`)
* Updated `refreshGitHubActivityDataFromApi` to calculate and accumulate older-than-year commit stats per repository, including public/private breakdowns and per-repo details. (`lib/data-access/github.ts`) [[1]](diffhunk://#diff-8ea1b82e25c2dbe824251e08771a75147f694df83ad3fdb5d99df3ef879a7dbdR224-R232) [[2]](diffhunk://#diff-8ea1b82e25c2dbe824251e08771a75147f694df83ad3fdb5d99df3ef879a7dbdR255-R267) [[3]](diffhunk://#diff-8ea1b82e25c2dbe824251e08771a75147f694df83ad3fdb5d99df3ef879a7dbdR362-R365) [[4]](diffhunk://#diff-8ea1b82e25c2dbe824251e08771a75147f694df83ad3fdb5d99df3ef879a7dbdR418-R440)
* Modified the all-time stats object to include both trailing year and older-than-year commit counts for a more accurate lifetime contribution estimate. (`lib/data-access/github.ts`)
* Extended the stored S3 activity data and `UserActivityView` to include older-than-year commit statistics. (`types/github.ts`) [[1]](diffhunk://#diff-2ccf93359aa30bc09c4b2fe0e07a9a4c6c767012633fe205ba84018d79a1422cR37) [[2]](diffhunk://#diff-2ccf93359aa30bc09c4b2fe0e07a9a4c6c767012633fe205ba84018d79a1422cR253)

**Frontend: Display of lifetime contributions**
* Updated the GitHub activity component to fetch, store, and display the new older-than-year commit stats, including a breakdown of lifetime contributions into prior years and trailing year. (`components/features/github/github-activity.client.tsx`, `lib/data-access/github-public-api.ts`) [[1]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdL8-R8) [[2]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdR61-R68) [[3]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdR131) [[4]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdR212) [[5]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdR236) [[6]](diffhunk://#diff-2e88e96705964e60703ca58f4810e3af3b46e1dc3719f1127741ff8fbc2c44bdR469-R480) [[7]](diffhunk://#diff-532fdbf56006a1d6a0ec38a3a1fb10f1282ebf9bddb47e3628ef5fdca99bd491R77) [[8]](diffhunk://#diff-532fdbf56006a1d6a0ec38a3a1fb10f1282ebf9bddb47e3628ef5fdca99bd491R94)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute and surface pre-trailing-year commit stats, store them with all-time data, and display lifetime contributions with prior-years vs trailing-year breakdown.
> 
> - **Backend**:
>   - Add `CommitsOlderThanYearSummary` and `CommitsOlderThanYearRepoStats` types in `types/github.ts`.
>   - Aggregate commits/LOC older than one year per repo (incl. public/private breakdown) in `refreshGitHubActivityDataFromApi` and include in `allCommitsOlderThanYear`.
>   - Set all-time `totalContributions` to `(trailing year commits) + (older-than-year commits)`.
> - **Public API**:
>   - Expose `commitsOlderThanYear` via `getGithubActivity` response by reading `allCommitsOlderThanYear` from S3 (`lib/data-access/github-public-api.ts`).
> - **Frontend**:
>   - Fetch and store `commitsOlderThanYear` in `github-activity.client.tsx`; compute `lifetimeContributionTotal` and render lifetime line with prior-years + trailing-year breakdown.
>   - No changes to calendar rendering; add lifetime summary UI below stats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd94ab734d4a362e263963a684d4fba51e97939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->