### PR TITLE
feat: add project warning for external apis

### DIFF
--- a/components/features/projects/project-card.client.tsx
+++ b/components/features/projects/project-card.client.tsx
@@ -7,6 +7,7 @@ import { buildCdnUrl, getCdnConfigFromEnv } from "@/lib/utils/cdn-utils";
 import { type JSX, useState, useEffect } from "react";
 import { getStaticImageUrl } from "@/lib/data-access/static-images";
 import { kebabCase } from "@/lib/utils/formatters";
+import { AlertTriangle } from "lucide-react";
 
 const MAX_DISPLAY_TECH_ITEMS = 10;
 
@@ -167,12 +168,17 @@ export function ProjectCard({ project, isPriority = false }: ProjectCardProps): 
               <code>{`// ${project.shortSummary}`}</code>
             </pre>
             {/* Description */}
-            {description && (
-              <p className="text-gray-400 leading-relaxed text-sm mt-1">
-                {" "}
-                {/* Adjusted text size/color */}
-                {description}
-              </p>
+            {description && <p className="text-gray-400 leading-relaxed text-sm mt-1">{description}</p>}
+            {project.note && (
+              <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-amber-900 text-sm font-medium shadow-sm dark:border-amber-400/60 dark:bg-amber-500/10 dark:text-amber-100">
+                <AlertTriangle
+                  className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500 dark:text-amber-200"
+                  aria-hidden
+                />
+                <span>
+                  <span className="font-semibold">Heads up:</span> {project.note}
+                </span>
+              </div>
             )}
             {/* Tech Stack */}
             {displayTech.length > 0 && (

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -122,6 +122,7 @@ export const projects: Project[] = [
     shortSummary: "Java-based book search and recommendation engine with OpenAI integration",
     url: "https://findmybook.net/",
     imageKey: "images/other/projects/book-finder-findmybook-net.png",
+    note: "Note: Because it relies on the Google Books API and other public endpoints, heavy traffic can hit their rate limits—during those windows some books or covers may fail to render until quotas reset.",
     tags: [
       "Java",
       "Spring Boot",

--- a/types/project.ts
+++ b/types/project.ts
@@ -17,4 +17,6 @@ export interface Project {
    * "Next.js", "TypeScript", "PostgreSQL", etc.
    */
   techStack?: string[];
+  /** Optional note/disclaimer surfaced alongside the project description */
+  note?: string;
 }


### PR DESCRIPTION
This pull request adds support for displaying project-specific notes or disclaimers on the project cards. The main change introduces a new optional `note` field to the `Project` type, ensures the note is surfaced in the UI with a styled alert box, and adds a note for the "FindMyBook" project to warn users about potential rate limits.

**Project note support:**

* Added a new optional `note` field to the `Project` interface in `types/project.ts` to allow projects to specify notes or disclaimers.
* Updated the "FindMyBook" project in `data/projects.ts` to include a note about possible API rate limits affecting book and cover rendering.

**UI enhancements:**

* Imported the `AlertTriangle` icon from `lucide-react` in `project-card.client.tsx` for use in the note alert box.
* Modified the `ProjectCard` component in `project-card.client.tsx` to display the note field, if present, in a styled alert box with an icon, making disclaimers more visible to users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `note` to `Project` and renders it as a styled alert in project cards; sets a note for the Book Finder project.
> 
> - **Frontend (UI)**:
>   - Display `project.note` in `components/features/projects/project-card.client.tsx` as an alert with `AlertTriangle` icon.
> - **Types**:
>   - Add optional `note` field to `Project` in `types/project.ts`.
> - **Data**:
>   - Add `note` to `Book Finder (findmybook.net)` in `data/projects.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b0a7aa7943b44b2468052ac12054ca29d0cb71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->