### PR TITLE
fix: remove non-standard period from projects page

### DIFF
--- a/data/projects.ts
+++ b/data/projects.ts
@@ -93,7 +93,7 @@ export const projects: Project[] = [
     name: "ComposerAI",
     description:
       "AI-native email client. Indexes every message in Qdrant for semantic search (embeddings and BM25/BM42 (RAG) search). Powerful full mailbox search, and automatically writes and generates replies that cite prior conversations, and suggests follow-up tasks from context. Built with Svelte + Vite and Spring Boot.",
-    shortSummary: "AI email client / mailbox for agentic search and tasks.",
+    shortSummary: "AI email client / mailbox for agentic search and tasks",
     url: "https://composerai.app",
     imageKey: "images/other/projects/composerai-app.png",
     tags: ["AI", "Email Client", "LLM", "Productivity", "Task Automation", "Vector Search", "Web App", "Svelte"],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove trailing period from `ComposerAI` `shortSummary` in `data/projects.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fa9661bc9f1a536204a380cff37fe9068db2909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->