### PR TITLE
fix: broken GitHub auto-refresh, terminal search scopes, and cache staleness

### DIFF
--- a/__tests__/lib/search/api-guards.test.ts
+++ b/__tests__/lib/search/api-guards.test.ts
@@ -191,16 +191,14 @@ describe("Search API Guards", () => {
   });
 
   describe("createSearchErrorResponse", () => {
-    it("includes details in non-production environment", () => {
+    it("includes details in non-production environment", async () => {
       process.env.NODE_ENV = "development";
       const response = createSearchErrorResponse("User message", "Internal details");
 
       expect(response.status).toBe(500);
-      // Parse the response body
-      response.json().then(body => {
-        expect(body.error).toBe("User message");
-        expect(body.details).toBe("Internal details");
-      });
+      const body = await response.json();
+      expect(body.error).toBe("User message");
+      expect(body.details).toBe("Internal details");
     });
 
     it("excludes details in production environment", async () => {

--- a/__tests__/lib/utils/search-helpers.test.ts
+++ b/__tests__/lib/utils/search-helpers.test.ts
@@ -175,7 +175,9 @@ describe("Search Helpers", () => {
     });
 
     it("should return same promise for concurrent requests with same key", async () => {
-      let resolveSearch: (value: string[]) => void;
+      let resolveSearch: (value: string[]) => void = () => {
+        throw new Error("resolveSearch not set");
+      };
       const searchPromise = new Promise<string[]>(resolve => {
         resolveSearch = resolve;
       });
@@ -186,7 +188,7 @@ describe("Search Helpers", () => {
       const promise2 = coalesceSearchRequest("same-key", searchFn);
 
       // Resolve the search
-      resolveSearch!(["result"]);
+      resolveSearch(["result"]);
 
       const [result1, result2] = await Promise.all([promise1, promise2]);
 
@@ -240,8 +242,12 @@ describe("Search Helpers", () => {
     });
 
     it("should handle different keys independently", async () => {
-      let resolveA: (value: string) => void;
-      let resolveB: (value: string) => void;
+      let resolveA: (value: string) => void = () => {
+        throw new Error("resolveA not set");
+      };
+      let resolveB: (value: string) => void = () => {
+        throw new Error("resolveB not set");
+      };
 
       const promiseA = new Promise<string>(resolve => {
         resolveA = resolve;
@@ -257,8 +263,8 @@ describe("Search Helpers", () => {
       const resultB = coalesceSearchRequest("key-b", fnB);
 
       // Resolve in different order
-      resolveB!("B result");
-      resolveA!("A result");
+      resolveB("B result");
+      resolveA("A result");
 
       expect(await resultA).toBe("A result");
       expect(await resultB).toBe("B result");
@@ -350,7 +356,7 @@ describe("Search Helpers", () => {
 
       // Mock crypto.randomUUID
       const mockUUID = "mock-uuid-12345";
-      const originalRandomUUID = crypto.randomUUID;
+      const originalRandomUUID = crypto.randomUUID.bind(crypto);
       crypto.randomUUID = jest.fn().mockReturnValue(mockUUID);
 
       const result = transformSearchResultToTerminalResult(searchResult);


### PR DESCRIPTION
## Summary

This PR fixes several critical bugs that caused silent failures in production and improves search infrastructure reliability.

### Bug Fixes
- **Fix GitHub auto-refresh silent failure**: Scheduler was using `--github-activity` flag but data-updater expected `--github`, causing refresh jobs to run but do nothing. Created centralized `DATA_UPDATER_FLAGS` constants to prevent future mismatches.
- **Fix stale data after scheduled refreshes**: GitHub activity cache wasn't invalidated after S3 updates. Users saw stale data until full server restart.
- **Fix terminal "projects" search**: Terminal command handler was missing the "projects" case, causing searches like `projects react` to fall through to site-wide search instead of scoped search.
- **Remove broken "skills" navigation**: The `/skills` route doesn't exist, causing 404 errors when users navigated via terminal.
- **Standardize blog search prefix handling**: `[Blog]` prefix was added inconsistently across different code paths; now applied only in the aggregator.

### Security & Reliability
- **Add rate limiting to scoped search endpoints**: Scoped endpoints (`/api/search/[scope]`) were missing the rate limiting and memory pressure guards that existed on `/api/search/all`.
- **Standardize API response format**: All search endpoints now return `{ results, meta }` wrapper for consistent client handling.
- **Add request coalescing to scoped search**: Prevents duplicate concurrent API calls for identical queries.

### Refactoring
- Centralize all GitHub cache keys, tags, and invalidation logic into `lib/cache/invalidation.ts`
- Create `lib/constants/cli-flags.ts` for type-safe CLI argument handling
- Add smoke tests to verify scheduler/data-updater flag consistency in CI

### New Endpoints
- `POST /api/revalidate/github-activity` - Called by scheduler after successful refresh to invalidate caches

### Dependencies
- Bump file-type, tailwind-merge, autoprefixer, eslint-plugin-jest, and others to latest minor versions

### Tests
- Fix LogoImage tests to expect proxied URLs (matches actual component behavior)
- Fix SEO date format test to handle timezone interpretation correctly
- Add scheduler/data-updater flag consistency smoke tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shared search API guards and response shape, centralizes GitHub cache invalidation and CLI flags to fix scheduler refresh, and improves terminal/project search behavior.
> 
> - **Search API**:
>   - Add shared guards (`/lib/search/api-guards`): rate limiting, memory pressure (`MEMORY_CRITICAL_*`), no-store headers, prod-safe errors.
>   - Standardize responses to `{ results, meta }`; apply to `GET /api/search/all` and scoped `GET /api/search/[scope]`.
>   - Add request coalescing via `coalesceSearchRequest`; tighten query/scope validation.
>   - Refine blog relevance scoring in `lib/blog/server-search.ts`.
> - **Terminal**:
>   - Support `projects` navigation/scope; remove non-existent `skills`.
>   - Unify result mapping via `transformSearchResultToTerminalResult`; update help text.
> - **GitHub activity & caching**:
>   - Centralize invalidation (`lib/cache/invalidation.ts`) and replace `invalidateGitHubCache` with `invalidateAllGitHubCaches` across app and tests.
>   - New endpoint `POST /api/revalidate/github-activity` (Bearer auth) and use it from scheduler after refresh.
>   - Use centralized `DATA_UPDATER_FLAGS`; fix scheduler to spawn with `--github` (not `--github-activity`).
>   - Update cache clear route to use new GitHub tags/invalidators.
> - **Infra/CLI**:
>   - Add `lib/constants/cli-flags.ts` with helpers (`hasFlag`, `parseTestLimit`); adopt in data-updater and data-fetch-manager.
> - **Docs**: README adds "Memory Pressure Guards"; batch-fetch doc updates examples (`--github`).
> - **Tests**:
>   - Add guards unit tests; flag consistency smoke tests.
>   - Update API/search integration to new response; LogoImage tests expect proxied URLs; SEO date test adjustment; GitHub tests use S3 path constant.
> - **Deps**: Bump `file-type`, `tailwind-merge`, `autoprefixer`, `eslint-plugin-jest`, and related lockfile entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ae4fda3f2eb1ee726688430216c22367677cc1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->