### PR TITLE
Fix bookmarks page route search, add aVenture.vc link to author bio

### DIFF
--- a/app/api/search/[scope]/route.ts
+++ b/app/api/search/[scope]/route.ts
@@ -12,10 +12,7 @@ import { coalesceSearchRequest } from "@/lib/utils/search-helpers";
 import { validateSearchQuery } from "@/lib/validators/search";
 import { type SearchResult, VALID_SCOPES } from "@/types/search";
 import { unstable_noStore as noStore } from "next/cache";
-import { NextResponse, type NextRequest } from "next/server";
-
-// Force dynamic rendering - prevents Next.js from pre-rendering this route during build
-export const dynamic = "force-dynamic";
+import { NextResponse, connection, type NextRequest } from "next/server";
 
 // CRITICAL: Check build phase AT RUNTIME using dynamic property access.
 // Direct property access (process.env.NEXT_PHASE) gets inlined by Turbopack/webpack
@@ -40,6 +37,8 @@ function resolveRequestUrl(request: NextRequest): URL {
  * @returns A JSON response containing the search results or an error message.
  */
 export async function GET(request: NextRequest, { params }: { params: { scope: string } }) {
+  // connection(): ensure this handler always runs at request time under cacheComponents
+  await connection();
   // CRITICAL: Call noStore() FIRST to prevent Next.js from caching ANY response
   // If called after the build phase check, the buildPhase:true response gets cached
   if (typeof noStore === "function") {

--- a/app/api/search/all/route.ts
+++ b/app/api/search/all/route.ts
@@ -12,10 +12,7 @@ import { coalesceSearchRequest } from "@/lib/utils/search-helpers";
 import { validateSearchQuery } from "@/lib/validators/search";
 import type { SearchResult } from "@/types/search";
 import { unstable_noStore } from "next/cache";
-import { NextResponse, type NextRequest } from "next/server";
-
-// Force dynamic rendering - prevents Next.js from pre-rendering this route during build
-export const dynamic = "force-dynamic";
+import { NextResponse, connection, type NextRequest } from "next/server";
 
 // CRITICAL: Check build phase AT RUNTIME using dynamic property access.
 // Direct property access (process.env.NEXT_PHASE) gets inlined by Turbopack/webpack
@@ -40,6 +37,8 @@ function getFulfilled<T>(result: PromiseSettledResult<T>): T | [] {
  * @returns A JSON response containing the search results or an error message.
  */
 export async function GET(request: NextRequest) {
+  // connection(): ensure this handler stays request-time under cacheComponents
+  await connection();
   // CRITICAL: Call noStore() FIRST to prevent Next.js from caching ANY response
   // If called after the build phase check, the buildPhase:true response gets cached
   const disableCache = unstable_noStore as (() => void) | undefined;

--- a/app/api/search/blog/route.ts
+++ b/app/api/search/blog/route.ts
@@ -14,10 +14,7 @@ import { searchBlogPostsServerSide } from "@/lib/blog/server-search";
 import { createSearchErrorResponse, withNoStoreHeaders } from "@/lib/search/api-guards";
 import { validateSearchQuery } from "@/lib/validators/search";
 import { unstable_noStore as noStore } from "next/cache";
-import { NextResponse, type NextRequest } from "next/server";
-
-// Force dynamic rendering - prevents Next.js from pre-rendering this route during build
-export const dynamic = "force-dynamic";
+import { NextResponse, connection, type NextRequest } from "next/server";
 
 // CRITICAL: Check build phase AT RUNTIME using dynamic property access.
 // Direct property access (process.env.NEXT_PHASE) gets inlined by Turbopack/webpack
@@ -43,6 +40,8 @@ function resolveRequestUrl(request: NextRequest): URL {
  * @returns A JSON response containing the search results or an error message.
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  // connection(): ensure this route stays request-time under cacheComponents
+  await connection();
   // CRITICAL: Call noStore() FIRST to prevent Next.js from caching ANY response
   // If called after the build phase check, the buildPhase:true response gets cached
   if (typeof noStore === "function") {

--- a/app/api/search/bookmarks/route.ts
+++ b/app/api/search/bookmarks/route.ts
@@ -16,12 +16,7 @@ import { createSearchErrorResponse, withNoStoreHeaders } from "@/lib/search/api-
 import { validateSearchQuery } from "@/lib/validators/search";
 import type { UnifiedBookmark } from "@/types";
 import { unstable_noStore as noStore } from "next/cache";
-import { NextResponse, type NextRequest } from "next/server";
-
-// Force dynamic rendering - prevents Next.js from pre-rendering this route during build
-// and caching the buildPhase:true response. The x-nextjs-cache: HIT issue occurs when
-// a route is statically generated during build; this export opts out entirely.
-export const dynamic = "force-dynamic";
+import { NextResponse, connection, type NextRequest } from "next/server";
 
 // CRITICAL: Check build phase AT RUNTIME using dynamic property access.
 // Direct property access (process.env.NEXT_PHASE) gets inlined by Turbopack/webpack
@@ -39,6 +34,8 @@ function resolveRequestUrl(request: NextRequest | { nextUrl?: URL; url: string }
 }
 
 export async function GET(request: NextRequest) {
+  // connection(): ensure request-time execution under cacheComponents to avoid prerendered buildPhase responses
+  await connection();
   // CRITICAL: Call noStore() FIRST to prevent Next.js from caching ANY response
   // If called after the build phase check, the buildPhase:true response gets cached
   if (typeof noStore === "function") {


### PR DESCRIPTION
## Summary

This PR fixes bookmarks search reliability and adds a hyperlink to the author bio on blog pages.

### Bookmarks Search Fix
- **Memory guard bug fix**: Corrected critical bug where memory pressure errors were silently swallowed during search index building, causing search to fail without indication
- **Empty index diagnostics**: Added warning logs when bookmark indexes are empty despite having source data - helps diagnose slug mapping issues
- **Circuit breaker auto-recovery**: ServerCache now self-heals after 5-minute cooldown when memory pressure subsides, eliminating need for manual instance restarts

### Blog Author Bio Enhancement
- **Added aVenture.vc hyperlink**: Author bio now links to aVenture.vc with proper styling
- **Serializable bio format**: Refactored from `React.ReactNode` to typed `AuthorBioSegment[]` array to support inline links without creating invalid nested anchor elements (avatar/name already link to homepage)

### Sentry Monitoring Expansion
- **Client integrations**: thirdPartyErrorFilter, zodErrors, extraErrorData, httpClient, browserTracing (Web Vitals), reportingObserver
- **Server integrations**: zodErrors, extraErrorData, dedupe
- **Bundler**: applicationKey for third-party frame filtering

### Dependencies
- `next`: 16.0.1 → 16.0.7
- `@sentry/*`: aligned to 10.27.0 (security fix for PII leak)

### Other
- Blog metadata: DRY refactor with `baseArticleParams`; uses `rawContent` for articleBody
- MDX: Added jsxDEV runtime helpers for React 19 compatibility
- AGENTS.md: Enhanced file creation and OOP best practices guidance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves search reliability and runtime behavior, adds author bio link with safe rendering and image preload/blur support, expands Sentry monitoring, and updates Next/dependencies with supporting docs/tests tweaks.
> 
> - **Search APIs (runtime safety & caching)**:
>   - Use `connection()` + call `noStore()` first; add `dynamic = "force-dynamic"`-safe patterns and runtime `NEXT_PHASE` checks via bracket notation to avoid build-time inlining.
>   - Prevent caching of build-phase/empty results; add diagnostics for empty bookmark indexes and memory-pressure guard.
> - **Caching & Stability**:
>   - `ServerCache`: circuit-breaker auto-recovery with cooldown and memory-aware reset; improved stats/logging.
>   - S3 utils/cache: clearer storage vs cache messaging; suppress expected AbortError logs in dev.
> - **Blog/UI**:
>   - Author bio now segment-based (`AuthorBioSegment[]`) with external link; avoid nested anchors.
>   - Blog/article metadata DRY via `baseArticleParams`; `articleBody` uses `rawContent`.
>   - MDX runtime helpers (`jsxDEV`) for React 19.
> - **Images**:
>   - `OptimizedCardImage`/`LogoImage`: unified proxy helper, `preload` prop (replacing `priority`), optional `blurDataURL`.
>   - Blog cover images get LQIP via `plaiceholder`; added Jest mock and config mapping.
> - **Projects/Blog cards**:
>   - Props renamed to `preload`; components updated accordingly.
> - **Sentry/Observability**:
>   - Client: add `thirdPartyErrorFilter`, `zodErrors`, `extraErrorData`, `httpClient`, `browserTracing`, `reportingObserver`.
>   - Server: `zodErrors`, `extraErrorData`, `dedupe`; Webpack plugin `applicationKey`.
> - **Types/Data**:
>   - Add `coverImageBlurDataURL` to `BlogPost`; introduce `AuthorBioSegment`; update `authors` data to `.tsx` with link.
> - **Testing**:
>   - Map `plaiceholder` to mock in Jest.
> - **Dependencies**:
>   - Bump `next` 16.0.1 → 16.0.7; align `@sentry/*` to 10.27.0; add `plaiceholder`; minor lib updates.
> - **Docs**:
>   - Hardening notes for search, caching, memory mgmt, Next 16 patterns; clarify build/runtime behaviors.
> - **CI**:
>   - Remove CLAUDE GitHub Action workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d3047123341da5ceb5110d36534844aa840220. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->