### PR TITLE
fix(terminal): resolve hydration mismatches and improve mobile UX

### DIFF
--- a/data/blog/posts/attempting-cleaner-architecture-boundaries-backend-refactor.mdx
+++ b/data/blog/posts/attempting-cleaner-architecture-boundaries-backend-refactor.mdx
@@ -25,7 +25,7 @@ Principles of _modularity_ (e.g., in the 'lego blocks' or 'IKEA furniture' sense
 
 ---
 
-## Scope Creep
+## Scope creep
 
 Recently, after a flurry of new code/features being pushed, I did my customary practice of reflecting on what went well and what could be improved. So I decided to revisit the [book Clean Architecture](https://amzn.to/3LryYC9) for a fresh look/reflection... and _oh my god I just realized that the author, Robert Martin, is "Uncle Bob"!_ (the humorous Twitter sensation I've been watching for years, but never put two-and-two together). He has a [great blog](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html), too.
 


### PR DESCRIPTION
## Bug Fixes

- **Prevent hydration mismatch in CommandInput**: Add mounted state guard to defer responsive placeholder text until after hydration. SSR and initial client render now consistently show the desktop placeholder, then switch to mobile variant post-mount.

- **Hide keyboard shortcut hint on mobile**: The `TerminalSearchHint` component (⌘K/Ctrl+K badge) was displaying on mobile devices where physical keyboards aren't available. Now hidden below `md` breakpoint using Tailwind responsive classes.

- **Fix escaped newline rendering in blog post**: The sitemap submission article had `\n` escape sequences incorrectly rendering as literal newlines instead of displaying as code.

## Documentation

- Standardize blog heading capitalization by removing "The" prefix from section headings
- Improve aria-label to "Press Command/Control K to search..." for better screen reader context

## Other Changes

- Capitalize "ctrl" to "Ctrl" for consistent casing on Windows/Linux
- Update Next.js routes types import path from `.next/dev/types/` to `.next/types/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents hydration mismatch in terminal input and hides the shortcut hint on mobile; updates blog text (headings and private key newline guidance) and fixes Next.js routes types import.
> 
> - **Terminal UI**:
>   - **CommandInput**: Add `mounted` guard to defer mobile placeholder (`isMobile`) until after hydration, avoiding SSR/client mismatch.
>   - **TerminalSearchHint**: Hide below `md` breakpoint; improve `aria-label` to "Press Command/Control K..."; capitalize `Ctrl`; ensure SSR placeholder mirrors visibility.
> - **Content/Docs**:
>   - Standardize headings in blog posts (`attempting-cleaner-architecture-...`, `proximity-bias-in-venture-capital`).
>   - Clarify `.env` guidance to preserve literal `\n` in `GOOGLE_SEARCH_INDEXING_SA_PRIVATE_KEY` in sitemap article.
> - **Config**:
>   - Update Next.js routes types import to `"./.next/types/routes.d.ts"` in `next-env.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e1f7553582f3c6c446e42a71dab1dae422197e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->