### PR TITLE
feat: add Bookshelf & Thoughts features with ChromaDB vector search and navigation enhancements

### DIFF
--- a/app/api/og/books/route.tsx
+++ b/app/api/og/books/route.tsx
@@ -9,7 +9,7 @@
  * Uses @vercel/og for image generation via Satori.
  *
  * Query Parameters:
- * - title: Book title (required)
+ * - title: Book title (optional, defaults to "Untitled Book")
  * - author: Author name(s) (optional)
  * - coverUrl: URL to book cover image (optional)
  * - formats: Comma-separated formats: audio,ebook,print (optional)
@@ -27,10 +27,14 @@ import { isPrivateIP } from "@/types/schemas/url";
 /**
  * DO NOT ADD `export const runtime = "nodejs"` HERE - DO NOT REMOVE THIS COMMENT
  *
- * Despite sharp being a native Node.js binding, this route works correctly without
- * an explicit runtime export in this project's configuration. Adding the runtime
- * export causes issues with the build pipeline. The default runtime handles sharp
- * appropriately for OG image generation.
+ * Next.js 16 guarantees Node.js runtime for all app/api/* routes by default.
+ * Sharp's native bindings work correctly without an explicit runtime export.
+ * Adding the runtime export breaks this project's build pipeline (tested empirically).
+ *
+ * This is documented behavior: Next.js 16 defaults API routes to Node.js runtime,
+ * making explicit runtime declarations unnecessary and potentially problematic.
+ *
+ * @see docs/projects/structure/next-js-16-usage.md for framework runtime guarantees
  */
 
 // OG Image dimensions (standard)


### PR DESCRIPTION
## Summary

- **Bookshelf feature**: Full reading list functionality with AudioBookShelf API integration, book detail pages, LQIP blur placeholders, related content discovery, and site-wide search
- **Thoughts feature**: Short-form TIL-style content system with ChromaDB Cloud vector store for semantic search, category/tag suggestions, and duplicate detection
- **Navigation overhaul**: Nested dropdown menus with hover (desktop) and tap (mobile) interactions; CV now contains Experience/Education children
- **Search improvements**: MiniSearch indexing for blog (replaces linear filtering), books/thoughts integrated into unified search API
- **SEO standardization**: Title format changed from possessive ("William Callahan's Blog") to dash-separated ("William Callahan - Blog")

## New Features

- `/books` collection page with responsive grid and macOS-style window container
- `/books/[book-slug]` detail pages with AI summary, personal thoughts, format badges (ebook/audiobook/print)
- `/thoughts` collection page with category filtering
- `/thoughts/[slug]` detail pages with markdown rendering and related thoughts
- Book cover blur placeholders (LQIP) for improved perceived performance
- Enhanced book slug format with authors and full ID for SEO and uniqueness
- ChromaDB Cloud client infrastructure for vector-based semantic queries
- Expandable navigation items with chevron animation and active state detection

## Refactoring

- Blog search migrated to cached MiniSearch index with fuzzy matching and field boosting
- Schema consolidation: moved Zod schemas from `lib/schemas/` to `types/schemas/` as single source of truth
- Book description formatter handles inline bullets, section headers, and numbered lists from AudioBookShelf

## Documentation

- Architecture docs for Books, Thoughts, and Chroma integration
- Updated AGENTS.md with schema organization patterns

## Other Changes

- Terminal commands added: `books`, `thoughts`
- Sitemap generation includes all book detail pages
- Related content system extended to support books
- Dependencies: chromadb@3.1.7, @chroma-core/default-embed@0.1.9
- Environment variables: AudioBookShelf and ChromaDB Cloud credentials
- Next.js 16 `connection()` mock added for test compatibility
- Draft status support for blog articles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Bookshelf and Thoughts features with Chroma vector search, refactors search and navigation, and integrates AudioBookShelf with OG images and blur placeholders.
> 
> - **Bookshelf**:
>   - New `/books` and `/books/[book-slug]` with AudioBookShelf API, slug helpers, LQIP blur covers, OG image route, and S3-backed related-content generation/reader.
>   - ABS transforms, image utils, resilient fetch with ISR; sitemap includes books.
> - **Thoughts**:
>   - New `/thoughts` and `/thoughts/[slug]` with schemas, server data, list/detail UI.
>   - Chroma-backed semantic ops: related thoughts, search, category/tag suggestions, dup detection.
> - **Chroma**:
>   - Cloud client + config validation; thoughts sync (add/upsert/delete/full sync) and queries; comprehensive tests.
> - **Search**:
>   - Blog search via MiniSearch index; adds books/thoughts search and tag search; bookmark tag indexing improved.
> - **Navigation**:
>   - Expandable dropdown/accordion items; CV groups Experience/Education.
> - **SEO/Infra**:
>   - Standardized titles; OG for books; CSP/remotePatterns allow self-hosted domains.
> - **Next.js 16 & Caching**:
>   - Replaced `no-store`/`connection()` with timed ISR; docs on static→dynamic prevention; cache TTLs adjusted.
> - **Schemas/Utils/Tests**:
>   - Consolidated Zod schemas under `types/schemas`; HTML formatter for book descriptions; new unit tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39dd307d2ec17216a8e025b93c2f48fcdbde344f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->