### PR TITLE
feat(search): S3 index prebuilding, scope filtering, and reliability fixes

### DIFF
--- a/__tests__/lib/seo/utils.test.ts
+++ b/__tests__/lib/seo/utils.test.ts
@@ -60,9 +60,20 @@ describe("SEO Utilities", () => {
   });
 
   describe("formatSeoDate", () => {
+    let originalTz: string | undefined;
+
     beforeAll(() => {
+      originalTz = process.env.TZ;
       // Mock timezone to America/Los_Angeles
       process.env.TZ = "America/Los_Angeles";
+    });
+
+    afterAll(() => {
+      if (originalTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTz;
+      }
     });
 
     it("should format date string with Pacific Time offset during standard time", () => {


### PR DESCRIPTION
## Summary

Major improvements to search infrastructure for faster cold starts, better reliability, and more efficient queries.

## New Features

- **Search API scope filtering**: New `scope` query parameter limits which sources are searched (blog, books, tags, etc.) instead of querying all 9 sources unconditionally
- **Pre-built S3 books index**: Books search index now built at deploy time and uploaded to S3, eliminating cold start API calls to AudioBookShelf
- **Unified data caching**: Shared `getCachedBooksData()` cache eliminates duplicate API calls between search index and genre extraction

## Bug Fixes

- **MiniSearch S3 serialization**: Fixed "[object Object]" JSON parsing error when loading indexes from S3 - `loadIndexFromJSON` now handles both string and object formats
- **Next.js 16 params Promise**: Await params Promise before accessing in search route handlers
- **MiniSearch ID handling**: Fixed extractField to return actual document ID instead of empty string, preventing "duplicate ID" errors
- **Per-source timeout protection**: Added 10s timeout per search source to prevent slow services from blocking entire response

## Refactoring

- Remove unused `FormatBadge` component from book-detail (~40 lines dead code)
- Replace `searchPosts` with `searchBlogPostsServerSide` across codebase
- Update test assertions to validate behavior rather than MiniSearch internals

## Documentation

- README rewritten as concise reference (392 → 133 lines)
- Normalized markdown formatting across docs (Unicode arrows → ASCII)
- Updated search architecture docs for new blog search function

## Other Changes

- CSP hashes regenerated for current build
- Removed IDE-specific config files (.clinerules, .cursor/environment.json)
- Added comprehensive tests for S3 index serialization and books search

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prebuild and load MiniSearch indexes (incl. books) from S3, add scoped/timeouted site-wide search with blog server search, and fix S3 serialization/ID issues while refining related-content and books UI.
> 
> - **Search/Backend**:
>   - Prebuild MiniSearch indexes (incl. `books`) and upload to S3; load at runtime with robust JSON handling in `loadIndexFromJSON`.
>   - Add site-wide search scope filtering (`scope=`) and per-source 10s timeouts; await Next 16 params; switch to `searchBlogPostsServerSide`.
>   - Consolidate books data via `getCachedBooksData`, fix MiniSearch ID extraction, add `BOOKS_INDEX` paths and S3 writes; extend `VALID_SCOPES` (incl. `tags`, `books`, `thoughts`).
>   - Update index builder/manager to build/upload books index; improve tag aggregation; add comprehensive tests (books search, index serialization, cache invalidation, slug mapping, content-graph paths).
> - **Related Content**:
>   - Centralize enabled types/config (`config/related-content.config.ts`), use in APIs; dynamic grouping/order; per-type exclude handling; pass `sourceType` to section.
> - **UI**:
>   - Books detail: remove `FormatBadge`, add safe external links and collapsible metadata; minor navigation tweaks.
> - **Tooling/Infra**:
>   - Upgrade `next` to `16.0.10`; adjust Jest image mocks/mappers; add BOOKS index/constants; expand data-fetch manager uploads; docs/README condensed and normalized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a0510c9b012b94a31d8db7fcc3a884342b905a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->