### PR TITLE
refactor: migrate to src/ directory structure with generated/ build artifacts

### DIFF
--- a/src/lib/books/image-utils.server.ts
+++ b/src/lib/books/image-utils.server.ts
@@ -77,7 +77,8 @@ export async function generateBookCoverBlur(coverUrl: string): Promise<string | 
     return base64;
   } catch (error) {
     if (isDevLoggingEnabled) {
-      console.warn(`[generateBookCoverBlur] Error generating blur for ${sanitizeUrlForLogs(coverUrl)}:`, error);
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[generateBookCoverBlur] Error generating blur for ${sanitizeUrlForLogs(coverUrl)}: ${message}`);
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary

Major codebase restructuring that moves application source to `src/`, introduces a `generated/` directory for build artifacts, and fixes Docker/runtime path issues.

## Structural Changes

- **Source migration to `src/`**: Move app/, lib/, components/, types/, hooks/, styles/, and instrumentation files into src/ directory following common Next.js patterns
- **Path alias update**: `@/*` now maps to `./src/*` in tsconfig.json
- **Generated files directory**: Introduce `generated/` (gitignored) for build-time artifacts:
  - `generated/csp-hashes.json` (was config/csp-hashes.json)
  - `generated/bookmarks/*.json` (was src/lib/data/*.json)
- **Remove skip-worktree requirement**: Developers no longer need git skip-worktree for generated files

## Bug Fixes

- **Docker runtime paths**: Fix Dockerfile to copy from `/app/src/lib`, `/app/src/types`, `/app/src/app/` instead of non-existent root paths
- **Package.json scripts**: Fix `scheduler` and `monitor:status` script paths to use `src/lib/`
- **Sentry instrumentation**: Cache Sentry module during `register()` for synchronous access in `onRequestError`, preventing request context loss
- **Test isolation**: Restore `global.fetch` mock after override in terminal tests

## Refactoring

- **Related-content API**: Replace inline `groupByType` + loop with single `limitByTypeAndTotal` call, reducing route.ts logic from 12 lines to 2
- **Import consistency**: Standardize all imports to use `@/` path aliases
- **Type safety**: Add proper type narrowing for `bookmark.id` in fetch scripts

## Removed

- Unused `getContentByIds` and `streamContent` from cached-aggregator
- Orphaned related-content client components
- Documentation with embedded task tracking and placeholder API keys
- Legacy sample files (bookmarks.sample.json, slug-mapping.sample.json)

## Configuration Updates

- tsconfig.json, jest config, ESLint, Biome, Oxlint, Next.js config updated for src/ paths
- Husky pre-push hook simplified (no longer checks config/csp-hashes.json)
- .gitignore updated with generated/ patterns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves code to src/, introduces generated/ for CSP/bookmark artifacts, overhauls search into modular loaders/factories, and updates configs, scripts, Docker, and APIs accordingly.
> 
> - **Repo Structure & Paths**:
>   - Move application code to `src/` (app, lib, components, types, hooks, styles, instrumentation) and update all imports/aliases (`@/* -> ./src/*`).
>   - Introduce `generated/` (gitignored) for build artifacts (`generated/csp-hashes.json`, `generated/bookmarks/*.json`) and migrate scripts to read/write there.
>   - Update config/tooling for new paths: `tsconfig`, Jest, ESLint, Biome, Tailwind, Next.js, `.gitignore`, `next-env.d.ts`.
> - **Search System**:
>   - Replace monolithic `lib/search.ts` with modular `src/lib/search/*` (config, factories, loaders, serialization, searchers) and add S3 fallback for bookmarks index mapping.
>   - Add shared tag aggregator and cached search factory; update tests and add S3-fallback test.
> - **Docker & Scripts**:
>   - Fix Dockerfile to copy from `src/*`, create/copy `generated/`, and adjust runtime copies (sitemap, lib/types).
>   - Update package scripts (`scheduler`, `monitor:status`), Husky hooks (pre-commit/pre-push), and various maintenance scripts to new paths.
> - **APIs & Features**:
>   - Related-content API: sanitize pagination, apply per-type limits via `limitByTypeAndTotal`, and handle `excludeIds` before limiting.
>   - Books/Images: skip blur gen during build, add timeouts/concurrency; image service gains `skipUpload`, `timeoutMs`, `retainBuffer`, and safer logging; HTTP client strips query/hash in errors.
> - **Sentry**:
>   - Cache Sentry module during `register()` and use it synchronously in `onRequestError` for proper request-context error capture.
> - **Removals/Migrations**:
>   - Remove orphaned related-content client components and legacy sample/data files; replace `lib/data-access/investments` with `src` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 228bccf855a67701c16f2bd9e92029fa9e3b4a48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->