### PR TITLE
feat: add related content discovery to tag pages with excludeTags filtering

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -564,7 +564,7 @@ const config = tseslint.config(
                       node,
                       message: isInS3
                         ? `Hardcoded image path "${imagePath}" detected. Use getStaticImageUrl("${imagePath}") to ensure S3/CDN delivery.`
-                        : `New image "${imagePath}" is not in S3. Run 'bun run migrate-static-images:upload' to migrate it, then use getStaticImageUrl("${imagePath}").`,
+                        : `New image "${imagePath}" is not in the static image mapping. Add it to src/lib/data-access/static-image-mapping.json (and ensure the asset is uploaded to S3), then use getStaticImageUrl("${imagePath}").`,
                       fix:
                         isInS3 && hasImport
                           ? function (fixer: any) {

--- a/src/components/features/investments/investment-card.client.tsx
+++ b/src/components/features/investments/investment-card.client.tsx
@@ -20,6 +20,7 @@ import { LogoImage } from "@/components/ui";
 import { ExternalLink } from "@/components/ui/external-link.client";
 import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import type { InvestmentCardExtendedProps } from "@/types/features/investments";
+import { getStaticImageUrl } from "@/lib/data-access/static-images";
 import Image from "next/image";
 
 import type { JSX } from "react";
@@ -175,12 +176,13 @@ export function InvestmentCardClient({
                 className="flex items-center bg-slate-100 dark:bg-transparent hover:bg-slate-200 dark:hover:bg-gray-700/50 px-3 py-2 rounded-full transition-colors"
               >
                 <Image
-                  src="/images/aVenture%20Favicon.png"
+                  src={getStaticImageUrl("/images/ui-components/aVenture-research-button.png")}
                   alt="aVenture"
                   width={24}
                   height={24}
                   className="inline-block h-6 w-6"
                   data-testid="aventure-icon"
+                  unoptimized={true}
                 />
               </ExternalLink>
             )}

--- a/src/components/features/related-content/related-content-card.tsx
+++ b/src/components/features/related-content/related-content-card.tsx
@@ -14,6 +14,7 @@ import type { RelatedContentCardProps } from "@/types/related-content";
 import { ExternalLink } from "@/components/ui/external-link.client";
 import { tagToSlug } from "@/lib/utils/tag-utils";
 import { kebabCase } from "@/lib/utils/formatters";
+import { getStaticImageUrl } from "@/lib/data-access/static-images";
 // Local helper to avoid any unsafe function call/type issues in certain editor setups
 function sanitizeExternalHref(raw?: string): string | null {
   if (!raw) return null;
@@ -78,8 +79,7 @@ export function RelatedContentCard({ item, className = "", showScore = false }: 
   const [imageError, setImageError] = useState(false);
   const [imageLoading, setImageLoading] = useState(true);
 
-  // Use a stable S3-hosted asset and mark it unoptimized to avoid the Next image optimizer allowlist edge cases.
-  const aventureIconSrc = "https://s3-storage.callahan.cloud/images/ui-components/aVenture-research-button.png";
+  const aventureIconSrc = getStaticImageUrl("/images/ui-components/aVenture-research-button.png");
 
   // Build tag display (max 6 tags to fill two rows)
   const displayTags = metadata.tags?.slice(0, 6) || [];

--- a/src/lib/data-access/static-image-mapping.json
+++ b/src/lib/data-access/static-image-mapping.json
@@ -41,6 +41,7 @@
   "/images/williamcallahan-com-project.png": "https://s3-storage.callahan.cloud/images/other/projects/williamcallahan-com-project.png",
   "/images/opengraph-placeholder.png": "https://s3-storage.callahan.cloud/images/other/placeholders/opengraph-placeholder.png",
   "/images/share-icon.svg": "https://s3-storage.callahan.cloud/images/other/share-icon_9722b70e.svg",
+  "/images/ui-components/aVenture-research-button.png": "https://s3-storage.callahan.cloud/images/ui-components/aVenture-research-button.png",
   "/images/placeholder_2.jpeg": "https://s3-storage.callahan.cloud/images/other/placeholders/placeholder_2_c64081a3.jpeg",
   "/images/Company-Research-Screenshot.png": "https://s3-storage.callahan.cloud/images/other/projects/Company-Research-Screenshot.png",
   "/images/placeholder_5.jpeg": "https://s3-storage.callahan.cloud/images/other/placeholders/placeholder_5_004c9263.jpeg",


### PR DESCRIPTION
## Summary

- **Add "Discover More" related content sections to tag pages** - Both blog (`/blog/tags/[tagSlug]`) and bookmark (`/bookmarks/tags/[...slug]`) tag pages now display related content recommendations sourced from the first item on the page
- **Add `excludeTags` option to RelatedContentOptions** - New filtering capability that removes items containing specified tags from recommendations (case-insensitive matching), preventing redundant suggestions on tag listing pages
- **Fix build phase detection for related content** - Replace direct `process.env.NEXT_PHASE` property access with dynamic bracket notation to prevent Turbopack/webpack from inlining the build-time value, ensuring correct runtime evaluation
- **Fix invalid Date handling in content similarity calculations** - Add `parseYearToUtcDate()` helper with input validation and UTC normalization for year-only dates (books, investments); guard `calculateRecencyScore()` against NaN timestamps

## Other changes

- Refactor blog tag page to use centralized `getAllPosts()` helper instead of inline implementation
- Enable interactive tag navigation in blog articles via `interactive` prop on `BlogTags`
- Simplify blog list grid from 3-column to 2-column layout; add article count indicator
- Reduce bookmark detail page `maxPerType` from 4 to 3 for consistency
- Add LCP preload hints for first 2 blog cards
- Update architecture docs to reflect new tag page behavior
- Clean up README.md: reorder sections, rename Docker image references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds related-content sections to blog/bookmark tag pages with excludeTags filtering, fixes build-phase detection, and refines date handling and UI.
> 
> - **Related Content**:
>   - **Tag Pages**: Add “Discover More” sections to `app/blog/tags/[tagSlug]/page.tsx` and `app/bookmarks/tags/[...slug]/page.tsx`, sourcing from the first item and excluding the active tag via `excludeTags`.
>   - **Options/Types**: Extend `RelatedContentOptions` with `excludeTags`; implement filtering across `related-content.server.tsx` and API, adjust caching to avoid polluting results when filters are used.
>   - **Build Phase Guard**: Replace direct `process.env.NEXT_PHASE` reads with runtime bracket access in `related-content` API and debug routes and server component.
>   - **Stability**: Safeguard dates (`safeDateIso`), add `parseYearToUtcDate()` for year-only values, and guard recency scoring.
> - **Blog/Bookmarks UI**:
>   - Blog tags page refactored to use `getAllPosts()`; add related-content section; filter/tag derivation fixes.
>   - Blog lists: switch to 2-column grid, show article count, preload first 2 cards; make `BlogTags` interactive.
>   - Bookmarks detail: related-content `maxPerType` reduced 4→3; tag page adds related-content with active-tag exclusion.
> - **Assets/ESLint**:
>   - Route `aVenture` icons through `getStaticImageUrl()` and add to `static-image-mapping.json`; tweak ESLint rule message for unmapped images.
> - **Misc**:
>   - Convert terminal search hint to a clickable button that triggers ⌘/Ctrl+K.
>   - README: rename Docker image references; docs updated for tag-page behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac2e6bfed427e50a84efecab3f254dd60318b726. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->