### PR TITLE
fix(robots): allow /api/assets/ for Googlebot to index bookmark images

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -27,7 +27,7 @@ export default function robots(): MetadataRoute.Robots {
   // NOTE: In robots.txt, the most specific matching rule takes precedence; order here is for readability only
   const disallowedProdPaths = [
     "/api/debug/", // Block debug endpoints
-    "/api/send", // Block analytics proxy (Plausible)
+    "/api/send", // Block analytics proxy (Umami)
     "/api/tunnel", // Block error tracking proxy (Sentry)
     "/api/cache/images", // Block internal cache endpoint
     "/opt/",


### PR DESCRIPTION
Previously robots.txt blocked all /api/ paths, which prevented Google from crawling bookmark preview images served via /api/assets/[assetId]. This caused ~25 "blocked by robots.txt" errors in Search Console.

Changes:
- Remove blanket /api/ block
- Explicitly allow /api/assets/ for image indexing
- Selectively block internal endpoints: /api/debug/, /api/send, /api/tunnel, /api/cache-images

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables crawling of `/api/assets/` while replacing the blanket `/api/` block with targeted disallows for specific internal endpoints in production.
> 
> - **Robots.txt (production)**:
>   - **Allow list**: add `"/"` and `"/api/assets/"`.
>   - **Targeted disallows**: replace blanket `"/api/"` block with specific paths: `"/api/debug/"`, `"/api/send"`, `"/api/tunnel"`, `"/api/cache/images"`.
>   - Retain existing disallowed legacy/system paths (e.g., `"/opt/"`, `"/Library/"`, `"/Applications/"`, `"/bin/"`, `"/etc/"`, `"/comments/feed/"`, `"/legacy-homepage/"`, `"/author/"`).
> - **Non-production**: unchanged (disallow all).
> - **Sitemap**: unchanged for production.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39add8bdb26964e670b0882fb58e3e50e5d746c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->