### PR TITLE
Improve AI prompts, relax dependencies and improve Dockerfile, update metadata

### DIFF
--- a/docs/projects/structure/linting-formatting.md
+++ b/docs/projects/structure/linting-formatting.md
@@ -87,7 +87,7 @@ if (e.target instanceof HTMLInputElement) {
 
 ### 5. Duplicate Types
 
-**Rule:** All shared types MUST be in `types/` directory. Check existing types before creating new ones.
+**Rule (lint warning):** All shared types MUST be in `types/` directory. Check existing types before creating new ones.
 
 ### 6. Unchecked Array Access
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -252,7 +252,7 @@ const config = tseslint.config(
     ignores: ["src/types/**/*", "**/*.d.ts", "**/*.mdx"],
     rules: {
       "no-restricted-syntax": [
-        "error",
+        "warn",
         {
           selector: "TSTypeAliasDeclaration",
           message: "Type aliases must reside in @/types or declaration files (*.d.ts)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Runs app as non-root with proper file ownership, adds OpenAI-compatible chat message builder with server-injected system prompts, loosens Next/React pins and adds Clerk, downgrades certain ESLint rules to warnings, and tweaks metadata/content.
> 
> - **AI/API**:
>   - **Server prompts + message builder**: Add `buildChatMessages` and use it in `src/app/api/ai/chat/[feature]/route.ts` with feature-specific system prompts (e.g., `terminal_chat`).
> - **Infrastructure (Docker/Runtime)**:
>   - Run container as non-root `nextjs` (UID 1001); set ownership (`--chown`) for `.next`, `scripts`, `generated`, and create writable caches under `/app/cache` with correct permissions.
>   - Adjust entrypoint `scripts/entrypoint.sh` for non-root runtime and clarify behavior.
>   - Omit `--frozen-lockfile` during `bun install` to allow semver updates; ensure caches/paths exist.
> - **Dependencies**:
>   - Loosen pins to caret for `next`, `react`, `react-dom`; add `@clerk/nextjs`.
> - **Linting/Docs**:
>   - Change centralized types enforcement (`no-restricted-syntax`) from `error` to `warn`; docs updated to reflect warning level.
> - **Sitemap/Build**:
>   - Document dual-purpose `src/app/sitemap.ts` and explicitly copy it in Docker image.
> - **Content/Types**:
>   - Minor copy updates in `data/metadata.ts` and `home` component; fix `next-env.d.ts` routes path; export `useTheme`.
> - **Tests**:
>   - Add unit tests for `chat-messages` and keep existing AI utilities tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845ad9c1fefb700d9742b55d646e4c0e63957fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->