### PR TITLE
fix(blog): address code review violations for error handling and para…

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -160,8 +160,9 @@ async function lookupMdxPost(slug: string, skipHeavyProcessing: boolean): Promis
       const directPost = await getMDXPostCached(slug, directFilePath, undefined, skipHeavyProcessing);
       if (directPost) return { found: true, post: directPost };
     } catch (error) {
+      // Only suppress ENOENT (file not found) - propagate all other errors
       const code = (error as NodeJS.ErrnoException | null)?.code;
-      if (code && code !== "ENOENT") {
+      if (code !== "ENOENT") {
         throw error;
       }
     }


### PR DESCRIPTION
…meter count

Code review identified three issues:
1. getMdxSlugIndex swallowed filesystem errors, returning empty results instead of surfacing failures to callers. Since lookupMdxPost already has proper error handling via discriminated unions, we let errors propagate naturally.
2. memoizedPostLookup had 4 positional parameters at the clean code threshold. Converted to MemoizedLookupParams interface for better readability.
3. FIFO eviction comment was missing - added clarification that insertion order equals expiration order since all entries share the same TTL.

- Remove try-catch blocks in getMdxSlugIndex that masked read/parse errors
- Convert warnings to thrown errors for missing slugs and duplicates
- Add MemoizedLookupParams interface to @/types/blog.ts
- Refactor memoizedPostLookup to use parameter object pattern
- Add clarifying comment for negative cache eviction logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Blog lookup and caching improvements**
> 
> - `getMdxSlugIndex` now propagates directory-level FS errors (with per-file warn/continue), clears cached promise on rejection, and warns/skips missing or duplicate slugs
> - `lookupMdxPost` avoids noisy warnings by `fs.stat`-checking conventional paths before calling `getMDXPostCached`; falls back to the slug index when needed
> - Refactors `memoizedPostLookup` to a params object (`MemoizedLookupParams`) and updates callers; preserves explicit found/not_found/error semantics and negative-cache behavior
> - Adds clarifying comment on FIFO eviction for the short-lived not-found cache
> 
> **Investment card build optimization**
> 
> - During `phase-production-build`, defers logo fetching by using `getRuntimeLogoUrl` (falls back to placeholder), reducing blocking I/O at build time
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e4a6ad79e7dd9404a8b28809059b8aaebb51a56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Addresses three code review violations by improving error handling and parameter organization in blog MDX lookup code.

**Key changes:**
- **Error propagation in `getMdxSlugIndex`**: Removed try-catch that swallowed filesystem errors (returning empty results), now lets errors propagate naturally to callers with existing error handling via discriminated unions. Added cache clearing on rejection to allow recovery after transient failures.
- **Parameter object pattern**: Converted `memoizedPostLookup` from 4 positional parameters to `MemoizedLookupParams` interface for better readability and maintainability.
- **FIFO eviction comment**: Added clarifying comment explaining that insertion order equals expiration order in negative cache since all entries share the same TTL.
- **Reduced noisy warnings**: Added `fs.stat` pre-check in `lookupMdxPost` to avoid calling `getMDXPostCached` when file doesn't exist (expected for slugs where filename differs from frontmatter slug).
- **Consistent warn-and-skip**: Uses warn-and-skip pattern for missing/duplicate slugs in `getMdxSlugIndex`, matching the behavior of `getAllMDXPosts` in `mdx.ts:428-431` and `mdx.ts:454-457`.
- **Build-time logo optimization**: Investment card defers logo resolution to runtime during static generation phase to avoid blocking async I/O.

All call sites of `memoizedPostLookup` correctly updated to use the new parameter object syntax.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes address legitimate code review feedback with proper error handling improvements, consistent patterns across the codebase, and complete refactoring of all call sites. The changes improve error propagation instead of swallowing errors, use established warn-and-skip patterns from existing code, and reduce unnecessary I/O during build phase. No breaking changes, no new dependencies, and all modifications follow the repository's strict coding standards (CLAUDE.md rules).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/types/blog.ts | Added `MemoizedLookupParams` interface to replace 4-parameter function signature with parameter object pattern |
| src/lib/blog.ts | Improved error handling in `getMdxSlugIndex` (removed try-catch that swallowed errors, added warn-and-skip for missing/duplicate slugs, clear cache on rejection), added `fs.stat` pre-check in `lookupMdxPost` to avoid noisy warnings, refactored `memoizedPostLookup` to use parameter object, added FIFO eviction comment |
| src/components/features/investments/investment-card.server.tsx | Added build-phase logo resolution strategy to defer async I/O during static generation by using runtime logo endpoint instead of `getLogoCdnData` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant memoizedPostLookup
    participant lookupMdxPost
    participant getMdxSlugIndex
    participant fs as FileSystem
    participant getMDXPostCached

    Caller->>memoizedPostLookup: getPostBySlug(slug)
    
    alt Already memoized
        memoizedPostLookup-->>Caller: Return cached result
    else Negatively cached (404)
        memoizedPostLookup-->>Caller: { status: "not_found" }
    else Need to lookup
        memoizedPostLookup->>lookupMdxPost: Perform lookup
        
        Note over lookupMdxPost: Try direct path first
        lookupMdxPost->>fs: stat(slug.mdx)
        
        alt File exists (direct path)
            fs-->>lookupMdxPost: File found
            lookupMdxPost->>getMDXPostCached: Parse & process
            getMDXPostCached-->>lookupMdxPost: BlogPost
            lookupMdxPost-->>memoizedPostLookup: { found: true, post }
        else ENOENT (file not found)
            fs-->>lookupMdxPost: ENOENT
            Note over lookupMdxPost: Suppress ENOENT, try index
            lookupMdxPost->>getMdxSlugIndex: Get slug index
            
            alt Index not cached
                getMdxSlugIndex->>fs: readdir(POSTS_DIRECTORY)
                fs-->>getMdxSlugIndex: File list
                
                loop For each MDX file
                    getMdxSlugIndex->>fs: readFile(fileName)
                    fs-->>getMdxSlugIndex: File contents
                    Note over getMdxSlugIndex: Parse frontmatter<br/>Warn-and-skip missing/duplicate slugs
                end
                
                alt Success
                    getMdxSlugIndex-->>getMdxSlugIndex: Cache promise
                    getMdxSlugIndex-->>lookupMdxPost: Map<slug, filePath>
                else Filesystem error
                    getMdxSlugIndex-->>getMdxSlugIndex: Clear cached promise
                    getMdxSlugIndex-->>lookupMdxPost: throw error
                    lookupMdxPost-->>memoizedPostLookup: { found: false, reason: "error" }
                end
            else Index cached
                getMdxSlugIndex-->>lookupMdxPost: Map<slug, filePath>
            end
            
            alt Slug found in index
                lookupMdxPost->>getMDXPostCached: Parse & process
                getMDXPostCached-->>lookupMdxPost: BlogPost
                lookupMdxPost-->>memoizedPostLookup: { found: true, post }
            else Slug not in index
                lookupMdxPost-->>memoizedPostLookup: { found: false, reason: "not_found" }
            end
        else Other filesystem error
            fs-->>lookupMdxPost: Error
            lookupMdxPost-->>memoizedPostLookup: throw error
            memoizedPostLookup-->>memoizedPostLookup: { status: "error" }
        end
        
        alt Result is found
            memoizedPostLookup-->>memoizedPostLookup: Memoize success
            memoizedPostLookup-->>Caller: { status: "found", post }
        else Result is error
            memoizedPostLookup-->>memoizedPostLookup: Clear memo, allow retry
            memoizedPostLookup-->>Caller: { status: "error", error }
        else Result is not_found
            memoizedPostLookup-->>memoizedPostLookup: Set negative cache (TTL), clear memo
            memoizedPostLookup-->>Caller: { status: "not_found" }
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=23822fbb-4a3d-480a-90b4-1b28f83b089c))

<!-- /greptile_comment -->