### PR TITLE
Add package registry links for projects/bookmarks; harden image service request handling

### DIFF
--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import type { ExtendedError } from "./error";
 import { registryLinkSchema } from "./schemas/registry-link";
 
@@ -380,6 +380,6 @@ export const bookmarkSlugMappingSchema = z.object({
   generated: z.string().datetime(), // ISO8601
   count: z.number().int().min(0),
   checksum: z.string().regex(/^[a-f0-9]{32}$/), // MD5 hex
-  slugs: z.record(bookmarkSlugEntrySchema),
-  reverseMap: z.record(z.string()),
+  slugs: z.record(z.string(), bookmarkSlugEntrySchema),
+  reverseMap: z.record(z.string(), z.string()),
 });


### PR DESCRIPTION
## Summary

Adds package registry links to projects and bookmarks, enabling direct access to npm, Maven, PyPI, VS Code marketplace, and other package distributions. Also includes image service improvements that fix a race condition and remove dead code.

---

## New Features

- **Registry Links Component** (`registry-links.client.tsx`): New UI component displaying package registry links with registry-specific icons (npm, Maven, PyPI, VS Code, Homebrew, etc.) and branded color schemes
- **Registry Link Schema** (`types/schemas/registry-link.ts`): Zod schema with `superRefine` validation enforcing label requirement for "other" registry types
- **Project/Bookmark Integration**: Registry links now display on project detail and bookmark detail pages
- **Initial Data**: Added registry links for Flag Deprecated Files (VS Code + Open VSX), tui4j (Maven), and apple-maps-java (Maven)

## Bug Fixes

- **Session Manager Race Condition** (`session-manager.ts`): Fixed race condition where concurrent requests for the same domain could have their promises prematurely removed. Now uses promise identity check before deletion in cleanup timeout
- **Duplicate Error Logging** (`s3-operations.ts`): Removed redundant error log in `uploadToS3` catch block (error already logged with full context in `trackFailedUpload`)
- **Zod v4 Compatibility** (`bookmark.ts`, `registry-link.ts`): Migrated to `zod/v4` imports and updated `z.record()` syntax to use explicit key types per v4 API

## Refactoring

- **Simplified fetchAndProcess** (`unified-image-service.ts`): Removed dead code paths including redundant streaming check, unsupported image transformation code, and unnecessary try/catch wrapper
- **Dead Code Removal** (`url-utils.ts`): Removed unused `detectRegistryType` function and `REGISTRY_PATTERNS` constant that were exported but never imported

## Type Changes

- Extended `Project` interface with optional `registryLinks` array
- Extended `UnifiedBookmark` schema with optional `registryLinks` array  
- Added `RegistryConfig` type for UI styling configuration
- Re-exported registry types from `types/index.ts`

---

**Files Changed:** 13 | **Additions:** 343 | **Deletions:** 25