### PR TITLE
feat(books,og-image): S3 books data pipeline, unified OG images, and modular sitemap

### DIFF
--- a/docs/features/opengraph.md
+++ b/docs/features/opengraph.md
@@ -354,21 +354,21 @@ Page generateMetadata() -> buildOgImageUrl(entity, params)
 
 - **`lib/og-image/security.ts`**: SSRF protection (host blocking, protocol restriction)
 - **`lib/og-image/fetch-image.ts`**: Image fetch with size/pixel/timeout limits, sharp PNG conversion
-- **`lib/og-image/design-tokens.ts`**: Shared colors, typography, layout dimensions, badge configs
+- **`lib/og-image/design-tokens.ts`**: Shared colors, typography, and layout dimensions
 - **`lib/og-image/build-og-url.ts`**: Type-safe URL builder for page metadata
 - **`lib/og-image/layouts/`**: Per-entity JSX renderers (book, bookmark, blog, project, text)
 - **`types/schemas/og-image.ts`**: Zod schemas for entity types and per-entity params
 
 ### Supported Entities
 
-| Entity       | Layout                      | Image Source  | Use Case              |
-| ------------ | --------------------------- | ------------- | --------------------- |
-| `books`      | Cover + title/author/badges | coverUrl      | Book detail pages     |
-| `bookmarks`  | Screenshot + title/domain   | screenshotUrl | Bookmark detail pages |
-| `blog`       | Cover + title/author/tags   | coverUrl      | Blog post pages       |
-| `projects`   | Screenshot + title/tags     | screenshotUrl | Project detail pages  |
-| `thoughts`   | Centered title/subtitle     | None          | Thought detail pages  |
-| `collection` | Centered title/section      | None          | Tag/collection pages  |
+| Entity       | Layout                    | Image Source  | Use Case              |
+| ------------ | ------------------------- | ------------- | --------------------- |
+| `books`      | Cover + title/author      | coverUrl      | Book detail pages     |
+| `bookmarks`  | Screenshot + title/domain | screenshotUrl | Bookmark detail pages |
+| `blog`       | Cover + title/author/tags | coverUrl      | Blog post pages       |
+| `projects`   | Screenshot + title/tags   | screenshotUrl | Project detail pages  |
+| `thoughts`   | Centered title/subtitle   | None          | Thought detail pages  |
+| `collection` | Centered title/section    | None          | Tag/collection pages  |
 
 ## Debugging
 

--- a/docs/file-map.md
+++ b/docs/file-map.md
@@ -300,10 +300,10 @@ File/Path Functionality Description
 - [x] **og-image/**
   - [x] `security.ts` `opengraph` - SSRF protection for OG image fetching (host blocking, protocol restriction)
   - [x] `fetch-image.ts` `opengraph` - Image fetch with size/pixel/timeout limits, sharp PNG conversion for Satori
-  - [x] `design-tokens.ts` `opengraph` - Shared colors, typography, layout dimensions, badge configs
+  - [x] `design-tokens.ts` `opengraph` - Shared colors, typography, and layout dimensions
   - [x] `build-og-url.ts` `opengraph` - Type-safe URL builder for /api/og/[entity] endpoint
   - [x] **layouts/**
-    - [x] `book-layout.tsx` `opengraph` - Book OG image layout (cover + title/author/badges)
+    - [x] `book-layout.tsx` `opengraph` - Book OG image layout (cover + title/author)
     - [x] `bookmark-layout.tsx` `opengraph` - Bookmark OG image layout (screenshot + title/domain)
     - [x] `blog-layout.tsx` `opengraph` - Blog post OG image layout (cover + title/author/tags)
     - [x] `project-layout.tsx` `opengraph` - Project OG image layout (screenshot + title/tags)

--- a/src/app/api/og/[entity]/route.tsx
+++ b/src/app/api/og/[entity]/route.tsx
@@ -7,7 +7,7 @@
  *
  * Supported entities: books, bookmarks, blog, projects, thoughts, collection
  *
- * @example GET /api/og/books?title=...&coverUrl=...&formats=audio,ebook
+ * @example GET /api/og/books?title=...&coverUrl=...
  * @example GET /api/og/blog?title=...&author=...&coverUrl=...&tags=AI,Next.js
  * @example GET /api/og/thoughts?title=...&subtitle=...
  *

--- a/src/app/books/[book-slug]/page.tsx
+++ b/src/app/books/[book-slug]/page.tsx
@@ -67,7 +67,6 @@ function buildBookOgImageUrl(book: Book): string {
     title: book.title,
     author: book.authors?.length ? book.authors.join(", ") : undefined,
     coverUrl: book.coverUrl ?? undefined,
-    formats: book.formats?.length ? book.formats.join(",") : undefined,
   });
 }
 

--- a/src/types/schemas/og-image.ts
+++ b/src/types/schemas/og-image.ts
@@ -25,7 +25,6 @@ export const ogBookParamsSchema = z.object({
   title: z.string().default("Untitled Book"),
   author: z.string().optional(),
   coverUrl: z.string().optional(),
-  formats: z.string().optional(),
 });
 
 export type OgBookParams = z.infer<typeof ogBookParamsSchema>;


### PR DESCRIPTION
## Summary
Books content is migrated from live AudioBookShelf API calls to a versioned S3 snapshot pipeline with automated daily refresh. All 7 content types now generate branded 1200×630 OG images through a single unified endpoint with SSRF protection. Sitemap generation is decomposed into domain-specific collectors with runtime caching and O(1) bookmark enumeration.

## Changes by Category

### Features
- **S3 Books Data Pipeline**: Books are now fetched from AudioBookShelf, enriched with local metadata and AI summaries, and persisted as checksum-versioned S3 snapshots with automated daily scheduling (6 AM PT) and cache revalidation (`books-data-access.server.ts`, `generate.ts`)
- **Unified OG Images**: All 7 content types (books, bookmarks, blog, projects, thoughts, bookmark-tags, blog-tags) now generate branded OG cards through `/api/og/[entity]` with per-entity layout renderers, SSRF-protected image fetching, and favicon branding — replacing the 438-line single-purpose `/api/og/books` monolith (`src/lib/og-image/`, `src/app/api/og/[entity]/route.tsx`)
- **OG Media & Branding**: OG cards display larger cover/screenshot regions and site favicon branding in the footer for stronger visual identity (`design-tokens.ts`, `shared-branding.tsx`)

### Bug Fixes
- **Build-Time Phase Inlining**: `process.env.NEXT_PHASE` is now accessed via bracket notation to prevent webpack DefinePlugin from statically freezing the build-phase value into the runtime bundle (`cache.ts`)
- **Incomplete Build Sitemaps**: Removed `NEXT_PHASE` gating that produced incomplete sitemaps during builds; bookmarks now use precomputed slug mapping for O(1) enumeration (`sitemap.ts`, `bookmark-collectors.ts`)
- **Production Cache Stability**: Disabled unstable `USE_NEXTJS_CACHE` in Docker runtime to resolve thousands of 'Connection closed' errors from the Next.js cache layer (`Dockerfile`)
- **Books Cache Correctness**: Fixed inflight race conditions (compare-and-swap in `.finally()`), false-negative `isFallback` when cache is null, cache retry TTL (5 min), and `'use cache'` directive gating behind `USE_NEXTJS_CACHE` flag (`books-data-access.server.ts`)
- **OG Proxy Origin**: OG image route now derives public origin from `Host` + `x-forwarded-proto` headers instead of `request.nextUrl.origin`, fixing placeholder images on reverse-proxy deployments (`route.tsx`)
- **Contact Sitemap Date**: `/contact` `lastModified` no longer always shows "now"; uses actual content modification date (`date-utils.ts`)
- **Docker S3 Secrets**: Reverted `S3_SECRET_ACCESS_KEY` secret mount to `required=false` for CI/CD compatibility (`Dockerfile`)
- **Image Manifests**: Avoided production request-path S3 fallback during prerender (`image-manifest-loader.ts`)

### Refactoring & Architecture
- **Modular Sitemap**: Decomposed 620-line `sitemap.ts` into 5 focused modules under `src/lib/sitemap/` (constants, date-utils, bookmark-collectors, content-collectors, blog-collector), reducing the orchestrator to 176 lines
- **Scheduler DRY**: Extracted `scheduleCronJob()` to eliminate 4-way duplication of jitter/lock/spawn/revalidation logic (~400 → 240 lines) (`scheduler.ts`)
- **OG Design Tokens**: Eliminated magic literals across all OG layouts with shared design tokens for dimensions, typography, and spacing (`design-tokens.ts`)
- **Node Build Guardrail**: Next.js builds now run on Node 22 (not Bun) for correct `cacheComponents` timer semantics (`Dockerfile`, `package.json`)

### Testing
- **Books Data Access**: Comprehensive S3-backed tests covering fallback signaling, cache TTL, refresh coalescing, and `USE_NEXTJS_CACHE` gating (298 lines)
- **OG Route Dispatch**: Entity routing and parameter validation tests (119 lines)
- **SSRF Security**: Private IP blocking, cloud metadata endpoint detection, and protocol validation (90 lines)
- **Sitemap**: Updated with slug-mapping fast path coverage and test factories

### Documentation
- **OpenGraph Architecture**: New `docs/features/opengraph.md` documenting the unified OG system
- **Architecture & File Map**: Updated for books pipeline, sitemap modules, and OG image infrastructure
- **Framework Standards**: Updated `nextjs-framework.md` with NEXT_PHASE anti-pattern and sitemap guidance

## Breaking Changes
- `/api/og/books` endpoint removed — replaced by `/api/og/[entity]?entity=books`
- Book OG images no longer accept `formats` query parameter (format badges removed from layout)