### PR TITLE
Improve Umami analytics init, update sitemap errors, expand tests

### DIFF
--- a/src/lib/sitemap/blog-collector.ts
+++ b/src/lib/sitemap/blog-collector.ts
@@ -76,10 +76,15 @@ export const collectBlogSitemapData = (
       }
     }
   } catch (error) {
-    return handleSitemapCollectorError("Error reading blog posts directory", error, {
-      blogPostEntries: [],
-      blogTagEntries: [],
-    });
+    return handleSitemapCollectorError(
+      "Error reading blog posts directory",
+      error,
+      {
+        blogPostEntries: [],
+        blogTagEntries: [],
+      },
+      "throw-in-production",
+    );
   }
 
   const blogPostEntries: MetadataRoute.Sitemap = postsData.map((post) => ({

--- a/src/lib/sitemap/content-collectors.ts
+++ b/src/lib/sitemap/content-collectors.ts
@@ -51,10 +51,15 @@ export const collectBookSitemapData = async (
       latestBookUpdateTime: getSafeDate(PAGE_METADATA.books?.dateModified),
     };
   } catch (error) {
-    return handleSitemapCollectorError("Failed to collect book sitemap entries", error, {
-      entries: [],
-      latestBookUpdateTime: undefined,
-    });
+    return handleSitemapCollectorError(
+      "Failed to collect book sitemap entries",
+      error,
+      {
+        entries: [],
+        latestBookUpdateTime: undefined,
+      },
+      "throw-in-production",
+    );
   }
 };
 
@@ -106,9 +111,14 @@ export const collectThoughtSitemapData = async (
       latestThoughtUpdateTime: latestDate,
     };
   } catch (error) {
-    return handleSitemapCollectorError("Failed to collect thought sitemap entries", error, {
-      entries: [],
-      latestThoughtUpdateTime: undefined,
-    });
+    return handleSitemapCollectorError(
+      "Failed to collect thought sitemap entries",
+      error,
+      {
+        entries: [],
+        latestThoughtUpdateTime: undefined,
+      },
+      "throw-in-production",
+    );
   }
 };

--- a/src/lib/sitemap/date-utils.ts
+++ b/src/lib/sitemap/date-utils.ts
@@ -69,8 +69,10 @@ export const isTestEnvironment = (): boolean =>
 
 /**
  * Shared error handler for sitemap collectors.
- * Logs the error and returns a default fallback value.
- * Strategy can either throw in tests (default) or throw in production.
+ * Logs the error, then either re-throws or returns a fallback:
+ *
+ *  - "throw-in-production" → THROWS in production, returns fallback in test
+ *  - "throw-in-test"       → THROWS in test, returns fallback in production
  */
 export const handleSitemapCollectorError = <T>(
   context: string,
@@ -82,7 +84,10 @@ export const handleSitemapCollectorError = <T>(
   console.error(`[Sitemap] ${context}:`, message);
 
   const isTestEnv = isTestEnvironment();
-  if (throwStrategy === "throw-in-production" ? !isTestEnv : isTestEnv) {
+  const shouldThrow =
+    (throwStrategy === "throw-in-production" && !isTestEnv) ||
+    (throwStrategy === "throw-in-test" && isTestEnv);
+  if (shouldThrow) {
     throw error;
   }
 


### PR DESCRIPTION
This pull request introduces robust error handling for sitemap collectors, ensures analytics providers degrade gracefully when environment variables are missing, and improves test coverage for edge cases. The most important changes are grouped below by theme.

**Sitemap Collector Error Handling Improvements:**

* The `handleSitemapCollectorError` function now accepts a `throwStrategy` parameter, allowing collectors to throw errors in production but return fallbacks in test environments, or vice versa. This ensures failures are visible in production while tests remain resilient.
* All sitemap collector functions (`collectBookmarkSitemapData`, `collectTagSitemapData`, `collectBlogSitemapData`, `collectBookSitemapData`, `collectThoughtSitemapData`) now use the new error handling strategy, throwing in production and returning empty fallbacks in tests. [[1]](diffhunk://#diff-ee1a66c58afbf48a4d45286c32796b147c92a0a353659feffec92159a35eedc2L142-R151) [[2]](diffhunk://#diff-ee1a66c58afbf48a4d45286c32796b147c92a0a353659feffec92159a35eedc2L212-R225) [[3]](diffhunk://#diff-055742a55d6151ce08c7d299c8de056981f7879972e08dba756f93a3796ee6a0L79-R87) [[4]](diffhunk://#diff-df94bbc31ac8a01140738d258fc03e7fc16fd10f3d5b74e7fb3dc9c653430906L54-R62) [[5]](diffhunk://#diff-df94bbc31ac8a01140738d258fc03e7fc16fd10f3d5b74e7fb3dc9c653430906L109-R122)
* Added comprehensive tests for error handling in sitemap collectors, verifying correct behavior in both production and test environments.

**Analytics Graceful Degradation & Testing:**

* The `Analytics` component now gracefully falls back to runtime values or hardcoded defaults if required environment variables are missing, ensuring Plausible and other providers still function even if Umami does not.
* Updated analytics event tracking to always log failures, and improved event name truncation logic for Umami. [[1]](diffhunk://#diff-1aa37325d0cac1aa591de47d9d483e7f38f3da99f56479f989cf489e4a5f9c05R17-R19) [[2]](diffhunk://#diff-1aa37325d0cac1aa591de47d9d483e7f38f3da99f56479f989cf489e4a5f9c05L119-R165)
* Enhanced analytics tests to verify that other providers render even when Umami environment variables are missing.

**Build & Environment Configuration:**

* Added new secret mounts for additional environment variables in the `Dockerfile`, improving build-time configuration for analytics and deployment.

**Testing Infrastructure:**

* Refactored and expanded mocks in sitemap tests for better isolation and reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production behavior for sitemap generation to throw on collector failures and adjusts client analytics env resolution, which could surface new runtime failures/missing pages if assumptions are wrong. Scope is contained and backed by new/updated tests.
> 
> **Overview**
> Improves sitemap collector robustness by extending `handleSitemapCollectorError` with a `throwStrategy` and switching multiple collectors to **throw in production** while returning empty fallbacks in tests.
> 
> Hardens client analytics by no longer gating all providers on Umami env vars: it resolves `NEXT_PUBLIC_SITE_URL` via env → `window.location.origin` → hardcoded fallback, only loads Umami when its website ID is present and `localStorage` is usable, and makes `safeTrack` consistently truncate event names and warn on failures.
> 
> Updates build/test coverage: the `Dockerfile` now mounts additional build-time secrets (`NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_UMAMI_WEBSITE_ID`, `DEPLOYMENT_ENV`), analytics tests assert Plausible still initializes without Umami config, and sitemap tests add explicit production-vs-test error-handling expectations with mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebee5f33d29d09c4b68624e3930d1b3071b4a9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements robust error handling for sitemap collectors and graceful degradation for analytics providers when environment variables are missing. The sitemap error strategy now throws in production (ensuring failures are visible) while returning fallbacks in tests (keeping tests resilient). Analytics providers now degrade gracefully when Umami env vars are missing, allowing Plausible and other providers to continue functioning.

**Key changes:**
- Added configurable `throwStrategy` parameter to `handleSitemapCollectorError` allowing "throw-in-production" or "throw-in-test" behavior
- All sitemap collectors now use "throw-in-production" strategy to ensure S3 or data collection outages surface in production
- Analytics component now falls back to runtime-detected values (window.location.origin) or hardcoded domain when `NEXT_PUBLIC_SITE_URL` or `NEXT_PUBLIC_UMAMI_WEBSITE_ID` are missing at build time
- Improved error logging in analytics to always log tracking failures (removed conditional debug-only logging)
- Added comprehensive tests for both error handling strategies and analytics graceful degradation
- Added Dockerfile secret mounts for `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_UMAMI_WEBSITE_ID`, and `DEPLOYMENT_ENV`

All changes follow the repository's [RC1] Root Cause Resolution policy by logging fallbacks explicitly rather than silently masking errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-designed with clear separation of concerns, comprehensive test coverage for both happy and error paths, and explicit logging at all degradation points. The error handling strategy is sound (fail-fast in production, resilient in tests) and aligns with the repository's [RC1] policy. All fallbacks are logged with warnings to surface configuration issues.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/sitemap/date-utils.ts | Added `throwStrategy` parameter to `handleSitemapCollectorError` for configurable error handling (throw in production vs tests) |
| src/lib/sitemap/bookmark-collectors.ts | Updated bookmark and tag collectors to use "throw-in-production" strategy for error handling |
| src/components/analytics/analytics.client.tsx | Added graceful degradation for missing env vars with runtime fallbacks and improved error logging; extracted Umami max length constant |
| __tests__/seo/sitemap.test.ts | Added comprehensive error handling tests verifying throw-in-production vs fallback-in-test behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant App
    participant Analytics
    participant SitemapGen
    participant BookmarkService
    
    Note over App,Analytics: Analytics Graceful Degradation Flow
    User->>App: Page Load
    App->>Analytics: Initialize Analytics Component
    Analytics->>Analytics: Check NEXT_PUBLIC_SITE_URL
    alt Env var missing
        Analytics->>Analytics: Fall back to window.location.origin
        Analytics->>Analytics: Log warning
    end
    Analytics->>Analytics: Check NEXT_PUBLIC_UMAMI_WEBSITE_ID
    alt Umami ID missing
        Analytics->>Analytics: Skip Umami, continue with other providers
        Analytics->>Analytics: Log warning
    end
    Analytics-->>User: Render Plausible/SA/Clicky scripts
    
    Note over SitemapGen,BookmarkService: Sitemap Error Handling Flow
    User->>SitemapGen: Request sitemap.xml
    SitemapGen->>BookmarkService: collectBookmarkSitemapData()
    BookmarkService->>BookmarkService: getBookmarksIndex()
    alt S3 Outage (Production)
        BookmarkService->>BookmarkService: handleSitemapCollectorError("throw-in-production")
        BookmarkService->>BookmarkService: Log error
        BookmarkService-->>SitemapGen: Throw Error
        SitemapGen-->>User: 500 Error (failure visible)
    else S3 Outage (Test)
        BookmarkService->>BookmarkService: handleSitemapCollectorError("throw-in-production")
        BookmarkService->>BookmarkService: Log error
        BookmarkService-->>SitemapGen: Return empty fallback
        SitemapGen-->>User: Empty sitemap (test resilient)
    end
```

<sub>Last reviewed commit: 2ebee5f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->