### PR TITLE
feat(ai-chat): 10-scope search tools, analytics misconfiguration alerts, and clickable external links in terminal

### DIFF
--- a/src/app/api/ai/chat/[feature]/upstream-runner.ts
+++ b/src/app/api/ai/chat/[feature]/upstream-runner.ts
@@ -18,6 +18,7 @@ import {
   formatBookmarkResultsAsLinks,
   normalizeInternalPath,
   sanitizeBookmarkLinksAgainstAllowlist,
+  TOOL_MAX_RESULTS_DEFAULT,
 } from "./bookmark-tool";
 import { getToolByName } from "./tool-registry";
 import { searchToolResultSchema } from "@/types/schemas/ai-chat";
@@ -288,10 +289,12 @@ async function resolveForcedToolFallback(
     });
     return { done: true, text: ctx.done(TOOL_FALLBACK_SEARCH_ERROR_MESSAGE) };
   }
-  const limitedResults = rawResults.slice(0, 5).flatMap((r) => {
-    const normalized = normalizeInternalPath(r.url);
-    return normalized ? [{ title: r.title, url: normalized }] : [];
-  });
+  const limitedResults = rawResults
+    .flatMap((r) => {
+      const normalized = normalizeInternalPath(r.url);
+      return normalized ? [{ title: r.title, url: normalized }] : [];
+    })
+    .slice(0, TOOL_MAX_RESULTS_DEFAULT);
   const validated = searchToolResultSchema.safeParse({
     query: searchQuery,
     results: limitedResults,


### PR DESCRIPTION
## Summary

AI chat can now search all 10 content types (bookmarks, blog, tags, investments, projects, experience, education, books, analysis, thoughts) instead of only bookmarks. Each scope has its own force-pattern so the model calls the right searcher automatically. Four production bugs discovered during live testing are also fixed: leaked Harmony control tokens, overly strict search recall, force-pattern scope shadowing, and broken external URL rendering in the terminal.

## Changes

### Features
- **AI chat searches 10 content scopes instead of 1**: User queries mentioning "blog", "investments", "projects", etc. now trigger dedicated searchers that return scope-specific results with internal navigation paths — previously only bookmark queries were handled (`tool-registry.ts`, `tool-dispatch.ts`)
- **Project links in AI responses navigate within the site**: Search results, RAG inventory, and static context now emit `/projects/<slug>` paths instead of external URLs like `https://aventure.vc`, so links are always clickable and deterministic; external URLs are preserved as a separate field for conversational mention (`static-searchers.ts`, `inventory-static.ts`, `static-context.ts`)
- **Search recall improved for partial and fuzzy queries**: MiniSearch switched from AND to OR combiner and fuzzy tolerance raised from 10% to 20%, so AI tool queries with partial term matches no longer return empty results (`search-content.ts`)

### Bug Fixes
- **Harmony `<|channel|>` control tokens no longer leak into AI responses**: gpt-oss models via llama.cpp sometimes emit raw control tokens in assistant text; `sanitizeModelOutput()` now strips these alongside `<think>` tags on both Chat Completions and Responses API paths (`think-tag-parser.ts`, `upstream-turn.ts`)
- **Analytics misconfiguration is now immediately visible**: Removed hardcoded `"williamcallahan.com"` domain fallback; Umami and Plausible scripts are conditionally skipped when `NEXT_PUBLIC_SITE_URL` is missing, and `console.error` alerts Sentry instead of silently degrading (`analytics.client.tsx`)
- **External HTTPS URLs in terminal chat are now clickable links**: Previously only internal `/...` paths rendered as links; external `https://` URLs and markdown links with trailing text now render correctly with `target="_blank" rel="noopener noreferrer"` (`history.tsx`)
- **"Favorite books" queries no longer route to bookmarks instead of books**: The `search_bookmarks` force-pattern included `favorites?`, which shadowed `search_books` due to first-match-wins ordering; removed from the bookmark pattern so "What are your favorite books?" correctly triggers `search_books` (`tool-registry.ts`)
- **Forced-tool fallback no longer discards valid results when early URLs are external**: The deterministic fallback path sliced results before filtering non-internal URLs, so valid results could be discarded if earlier entries had external URLs; now filters first then slices to the result cap (`upstream-runner.ts:resolveForcedToolFallback`)
- **Single-tool determinism restored for forced tool calls**: When `forcedToolName` is set on turn 0, the tools array is now filtered to only that tool — restoring mechanical determinism lost when the registry grew from 1 to 10 tools (`upstream-turn.ts`)

### Refactoring
- **Single-tool bookmark dispatch replaced by generic registry + dispatch**: `bookmark-tool-dispatch.ts` deleted; all 10 tools defined in `tool-registry.ts` and executed through `tool-dispatch.ts` with per-call error isolation, argument validation, and `maxResults` clamping — eliminates bookmark-specific hardcoding throughout the pipeline (`upstream-runner.ts`, `upstream-turn.ts`, `upstream-pipeline.ts`, `feature-defaults.ts`)
- **Upstream runner state consolidated into `ToolLoopState`**: Scattered mutable variables replaced with a single typed state object, and content resolution uses a discriminated union `ToolContentResolution` for explicit model-vs-fallback tracking (`ai-chat.ts` types)
- **Dead `matchesBookmarkSearchPattern` function and 4 private constants removed**: Superseded by registry-driven `getForcedToolName` but never cleaned up; removed along with the corresponding 17-case test block (`bookmark-tool.ts`, `chat-bookmark-tool-patterns.test.ts`)
- **`TOOL_MAX_RESULTS_DEFAULT` exported as shared constant**: Was duplicated in `bookmark-tool.ts` and `tool-dispatch.ts`; now exported once from `tool-dispatch.ts` and imported where needed (`tool-dispatch.ts`, `bookmark-tool.ts`)

### Tests
- **10 new tests for Harmony token stripping and model output sanitization** (`ai-think-tag-parser.test.ts`)
- **Test harness mocks all 10 searcher modules** for upstream pipeline integration tests (`upstream-pipeline-test-harness.ts`)
- **Tool dispatch extraction and registry lookup unit tests** covering function call extraction, drop logging, validation failures, and parameterized force-pattern tests across all scopes (`chat-tool-dispatch.test.ts`, `chat-tool-registry.test.ts`)
- **Tool choice tests updated** from `forceBookmarkTool: boolean` to `forcedToolName: string` (`chat-bookmark-tool-patterns.test.ts`)

## Breaking Changes
None — the AI chat API contract is unchanged; only internal dispatch routing changed.

## Test plan
- [ ] Verify AI chat triggers `search_bookmarks`, `search_blog`, `search_projects`, and other tools when the user mentions the corresponding content type
- [ ] Confirm forced tool calls on turn 0 still work (`tool_choice:"required"`) and deterministic fallback activates when model skips the tool
- [ ] Check terminal history renders `https://` links as clickable, and markdown links with trailing text display correctly
- [ ] Confirm analytics scripts are absent from the page when `NEXT_PUBLIC_SITE_URL` is unset
- [ ] Run `bun run validate` — 0 errors, 0 warnings
- [ ] Run `bun run test` — all passing