### PR TITLE
Update chat tool tests, refactor metadata, update docs, image sizing

### DIFF
--- a/docs/standards/nextjs-framework.md
+++ b/docs/standards/nextjs-framework.md
@@ -184,12 +184,13 @@ rg "<Image" --type tsx -A5 | rg -v "sizes="
 ```
 
 **Error Symptoms:**
-| Pattern | Result |
-|---------|--------|
-| `buildCachedImageUrl(cdnUrl)` + `unoptimized` | No optimization, full-size images served |
-| Missing `sizes` on responsive `<Image>` | Browser downloads largest srcset variant |
-| Direct external URL without proxy | `/_next/image` rejects as not in remotePatterns |
-| `<Image>` for noscript tracking pixel | Fails if domain not in remotePatterns |
+
+| Pattern                                       | Result                                          |
+| --------------------------------------------- | ----------------------------------------------- |
+| `buildCachedImageUrl(cdnUrl)` + `unoptimized` | No optimization, full-size images served        |
+| Missing `sizes` on responsive `<Image>`       | Browser downloads largest srcset variant        |
+| Direct external URL without proxy             | `/_next/image` rejects as not in remotePatterns |
+| `<Image>` for noscript tracking pixel         | Fails if domain not in remotePatterns           |
 
 ### 5. Link Prefetch Behavior (Next.js 16)
 


### PR DESCRIPTION
This pull request includes several improvements and clarifications to AI chat tool detection, project metadata, and image optimization documentation and policies. The most significant changes are enhancements to the AI chat tool registry's keyword matching logic, updates to project URLs and names for accuracy, and comprehensive updates to Next.js image optimization documentation and enforcement across the codebase.

**AI Chat Tool Registry Improvements:**

* Expanded the `forcePattern` regular expressions for `search_investments`, `search_experience`, and `search_education` tools to match a wider range of suffixes and related terms (e.g., "investments", "funding", "employment", "certifications") for more accurate tool detection. ([src/app/api/ai/chat/[feature]/tool-registry.tsL69-R70](diffhunk://#diff-89a47b88cfec1229518a624f93aa6027804fefc47a4dbc10224a82e31e513834L69-R70), [src/app/api/ai/chat/[feature]/tool-registry.tsL81-R90](diffhunk://#diff-89a47b88cfec1229518a624f93aa6027804fefc47a4dbc10224a82e31e513834L81-R90))
* Added new test cases to verify correct tool detection for suffixed forms (e.g., "investments", "funding", "employment history", "certifications") and to ensure false positives are avoided. [[1]](diffhunk://#diff-572ee1183163d21f15d7d5502eda87894812fc2004d7dc3fe61ce413b01e9c48R56-R75) [[2]](diffhunk://#diff-572ee1183163d21f15d7d5502eda87894812fc2004d7dc3fe61ce413b01e9c48R84-R85)

**Project Metadata Updates:**

* Updated the `Researchly` (formerly `searchAI`) and `ComposerAI` project entries in `data/projects.ts` to use new names, URLs, and GitHub links. Adjusted references in tests and documentation accordingly. [[1]](diffhunk://#diff-84f9b099f6948c8d63feb5fc9dce1cca170fc1e603116e06ae1989a426c55cecL66-R72) [[2]](diffhunk://#diff-84f9b099f6948c8d63feb5fc9dce1cca170fc1e603116e06ae1989a426c55cecL101-R102) [[3]](diffhunk://#diff-69aca94b7b0cfe8e73224f6811bbec4dabc9cdc95cb6ab299945fb286db3b43eL46-R48) [[4]](diffhunk://#diff-69aca94b7b0cfe8e73224f6811bbec4dabc9cdc95cb6ab299945fb286db3b43eL108-R108) [[5]](diffhunk://#diff-1a76cc7b49735d844308d426ba11954833cbb4180ed4bb5c12932347a3fc0c45L51-R51)

**Image Optimization and Next.js Policy Documentation:**

* Overhauled image handling documentation to clarify and enforce Next.js 16+ image optimization policies:
  - Documented that the optimizer now serves WebP/AVIF, and that the `sizes` prop is required for all responsive images, with recommended usage for fixed-size images. [[1]](diffhunk://#diff-d10cf22423fb7e1ee53efc53d6f3e85a42655ffc9ff886fa413ddd6958456427L159-R209) [[2]](diffhunk://#diff-99a55b16c0212c43a0ab0301bf2e59acd949013b89a3fb202f5fa99344a9f061L125-R142) [[3]](diffhunk://#diff-2e6c49515c9eee0fa3c1c80877e725061f45c18b02fca5b5083f854ef08722e9L158-R165)
  - Updated canonical helper function usage: `getOptimizedImageSrc()` is now the only recommended way to generate image URLs; `buildCachedImageUrl()` is deprecated and should not be used. [[1]](diffhunk://#diff-d10cf22423fb7e1ee53efc53d6f3e85a42655ffc9ff886fa413ddd6958456427L159-R209) [[2]](diffhunk://#diff-2e6c49515c9eee0fa3c1c80877e725061f45c18b02fca5b5083f854ef08722e9L158-R165)
  - Added detection commands for finding deprecated usage and missing `sizes` props, and clarified error symptoms. [[1]](diffhunk://#diff-d10cf22423fb7e1ee53efc53d6f3e85a42655ffc9ff886fa413ddd6958456427L159-R209) [[2]](diffhunk://#diff-2e6c49515c9eee0fa3c1c80877e725061f45c18b02fca5b5083f854ef08722e9L179-R192)
  - Specified that analytics tracking pixels must use plain `<img>` tags, not `<Image>`, if the domain is not in `remotePatterns`. [[1]](diffhunk://#diff-d10cf22423fb7e1ee53efc53d6f3e85a42655ffc9ff886fa413ddd6958456427L159-R209) [[2]](diffhunk://#diff-99a55b16c0212c43a0ab0301bf2e59acd949013b89a3fb202f5fa99344a9f061L125-R142) [[3]](diffhunk://#diff-2e6c49515c9eee0fa3c1c80877e725061f45c18b02fca5b5083f854ef08722e9L179-R192)
  - Updated stack map and optimizer configuration details to reflect current Next.js and CDN setup. [[1]](diffhunk://#diff-d10cf22423fb7e1ee53efc53d6f3e85a42655ffc9ff886fa413ddd6958456427L135-R135) [[2]](diffhunk://#diff-99a55b16c0212c43a0ab0301bf2e59acd949013b89a3fb202f5fa99344a9f061L91-R91)

**Codebase Cleanup:**

* Removed unused import of `Image` from `next/image` in the analytics client component, as tracking pixels should use plain `<img>`.
* Centralized the `TOOL_MAX_RESULTS_DEFAULT` constant to ensure consistent tool result limits. ([src/app/api/ai/chat/[feature]/tool-dispatch.tsL23-R23](diffhunk://#diff-682efc2574389fe1ea68371775926f5adfbaa72c71be94234c406496229bde45L23-R23))

These changes improve AI tool accuracy, keep project and documentation references up to date, and ensure robust, maintainable image optimization practices throughout the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly regex/test/doc updates plus small, localized runtime tweaks (analytics pixels, OG cache-busting, image `sizes`) with limited blast radius; main risk is minor behavior changes in forced-tool selection and cache-busting URLs.
> 
> **Overview**
> Improves AI chat forced-tool detection by expanding `forcePattern` matching for investments/experience/education (handling suffixes like “funding”, “employment”, “certifications”) and adds/adjusts tests to cover new matches and avoid false positives.
> 
> Refreshes project metadata and references (`searchAI` → `Researchly`, Composer URLs/GitHub) across data and RAG context tests.
> 
> Tightens Next.js image/analytics behavior: adds missing `sizes` on several `<Image>` usages, switches noscript tracking pixels from `next/image` to plain `<img>`, and updates docs to codify the optimizer contract and deprecate `buildCachedImageUrl()` in favor of `getOptimizedImageSrc()`.
> 
> Makes OG cache-busting deterministic for Next.js 16 prerendering by using `FIXED_BUILD_TIMESTAMP` instead of runtime timing, and centralizes the tool result default limit by importing `TOOL_MAX_RESULTS_DEFAULT` from `bookmark-tool`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77ed7334cfa34166b45f511038a237fe30293b3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhances AI chat tool detection by expanding regex patterns for suffixed forms (`investments`, `funding`, `employment`, `certifications`), updates project metadata (renamed `searchAI` → `Researchly`, updated `ComposerAI` URLs), and tightens image optimization compliance by adding missing `sizes` props, switching analytics tracking pixels from `<Image>` to `<img>`, deprecating `buildCachedImageUrl()`, and replacing `getMonotonicTime()` with `FIXED_BUILD_TIMESTAMP` for Next.js 16 deterministic prerendering.

**Key Changes:**
- AI tool registry now matches broader keyword variations (e.g., "funding" → `search_investments`, "employment" → `search_experience`)
- Image optimization aligned with `[IMG1]` policy: all `<Image>` components now have `sizes` props, tracking pixels use plain `<img>` tags
- OG cache-busting uses build timestamp instead of runtime time for static rendering compatibility
- Comprehensive documentation updates across three architecture docs clarify Next.js 16 image optimizer behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risks
- All changes follow established patterns, maintain type safety, and are covered by tests. Regex expansions are backward-compatible additions. Image optimization changes enforce documented policies. OG cache-busting fix ensures Next.js 16 prerender compatibility. No breaking changes or risky refactors.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| __tests__/api/ai/chat-tool-registry.test.ts | Added test cases for suffixed forms (investments, funding, employment, certifications) and false-positive guards (investigate, fundamental) |
| src/app/api/ai/chat/[feature]/tool-registry.ts | Expanded forcePattern regexes for search_investments, search_experience, search_education to capture suffixed/related terms |
| src/components/analytics/analytics.client.tsx | Removed Image import, switched noscript tracking pixels to plain img tags, standardized window access to globalThis |
| src/lib/seo/og-validation.ts | Replaced getMonotonicTime with FIXED_BUILD_TIMESTAMP for Next.js 16 prerendering determinism in cache-busting URLs |
| src/lib/utils/cdn-utils.ts | Marked buildCachedImageUrl as deprecated, improved null-safety with optional chaining, standardized globalThis usage |
| docs/architecture/image-handling.md | Comprehensive update to image optimization matrix, documented sizes prop policy, deprecated buildCachedImageUrl, added tracking pixel guidance |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Query] --> B{getForcedToolName checks forcePattern}
    B -->|Match: invest/funding/portfolio| C[search_investments]
    B -->|Match: employ/jobs/career| D[search_experience]
    B -->|Match: education/certif| E[search_education]
    B -->|No match| F[LLM chooses tool]
    
    G[Image Source] --> H{isOurCdnUrl?}
    H -->|Yes: CDN URL| I[Direct to next/image]
    H -->|No: External| J[Proxy via /api/cache/images]
    I --> K[Sharp optimization + WebP/AVIF]
    J --> L[Stream bytes unoptimized]
    
    M[OG Image Cache Busting] --> N[FIXED_BUILD_TIMESTAMP]
    N --> O[buildDay = timestamp / 86400000]
    O --> P[URL + ?v=buildDay]
    
    Q[Analytics Pixels] --> R{Domain in remotePatterns?}
    R -->|No| S[Use plain img tag]
    R -->|Yes| T[Could use Image but unnecessary]
    S --> U[Avoid optimizer request]
```

<sub>Last reviewed commit: 77ed733</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->