### PR TITLE
fix(bookmarks): prevent /bookmarks prerender bailout and intermittent 500 loads

### DIFF
--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -31,7 +31,13 @@ export function generateMetadata(): Metadata {
  * freshness comes from the bookmark data fetches that opt into `no-store` semantics instead of build-time snapshots.
  */
 
-export default function BookmarksPage() {
+export default async function BookmarksPage({
+  searchParams,
+}: Readonly<{ searchParams: Promise<Record<string, string | string[] | undefined>> }>) {
+  // Ensure request data is read before any downstream code that may synchronously
+  // access current time (Next.js `next-prerender-current-time` constraint).
+  await searchParams;
+
   const pageMetadata = PAGE_METADATA.bookmarks;
 
   // Generate JSON-LD schema for the bookmarks page


### PR DESCRIPTION
## Summary
`/bookmarks` could intermittently return HTTP 500 because Next.js raised a `next-prerender-current-time` static-generation bailout during render evaluation. This change consumes request `searchParams` at page entry so the route executes in a request-aware path and no longer triggers that bailout.

## Changes

### Bug Fixes
- **`/bookmarks` now loads reliably instead of intermittently failing with 500**: the page component accepts async `searchParams` and awaits them before downstream render logic, preventing the prerender-time bailout (`src/app/bookmarks/page.tsx`).
- **Request context is established before route logic executes**: reading request data first aligns the route with Next.js prerender guard expectations for current-time access (`src/app/bookmarks/page.tsx`).

## Breaking Changes
None

## Verification
- Reproduced failing production behavior before fix: repeated `/bookmarks` requests returned `500` with `NEXT_STATIC_GEN_BAILOUT` and `next-prerender-current-time` in container logs.
- After applying the source fix and redeploying, repeated `/bookmarks` requests returned `200`, and the bailout pattern stopped.
- Local gates passed for the change: `bun run validate`, `bun run build:only`.

## References
- https://nextjs.org/docs/messages/next-prerender-current-time
- `node_modules/next/dist/server/node-environment-extensions/utils.js:34`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small, localized change to the `/bookmarks` page entrypoint; main risk is subtle rendering/perf behavior change from making the page async.
> 
> **Overview**
> Fixes intermittent `/bookmarks` HTTP 500s caused by a Next.js static-generation bailout (`next-prerender-current-time`) during render.
> 
> `BookmarksPage` is now `async`, accepts `searchParams` (as a Promise), and `await`s it immediately to force request context to be established before downstream logic executes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3213b0e43df5783f9af884a3bb88e5c8e00870da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves intermittent HTTP 500 errors on `/bookmarks` by establishing request context before render evaluation.

**Root Cause**
Next.js raised a static generation bailout during prerender because downstream bookmark code (`src/lib/bookmarks/utils.ts:25`) synchronously accesses current time via `getMonotonicTime()`. Without request context, this triggers the `next-prerender-current-time` constraint.

**Solution**
- Made `BookmarksPage` async and added `searchParams` prop
- Awaits `searchParams` at component entry to establish request context
- This signals to Next.js that the route should execute in dynamic request mode, preventing the bailout

**Impact**
- `/bookmarks` now loads reliably without HTTP 500 errors
- Type-safe: uses correct Next.js 16 async `searchParams` signature
- Well-documented: inline comment explains the constraint being addressed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The fix correctly addresses the root cause using Next.js's recommended pattern for establishing request context. The change is minimal (3 lines), type-safe, well-documented, and verified through local testing. No logical issues, security concerns, or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/bookmarks/page.tsx | Made component async and added `await searchParams` to establish request context before render, preventing Next.js prerender bailout |

</details>



<sub>Last reviewed commit: 3213b0e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->