### PR TITLE
fix(observability): harden edge Sentry capture and preserve noscript beacons

### DIFF
--- a/src/instrumentation-edge.ts
+++ b/src/instrumentation-edge.ts
@@ -33,6 +33,17 @@ function redactSensitiveHeaders(
   );
 }
 
+function buildRedactedRequest(request: {
+  path: string;
+  method: string;
+  headers: Record<string, string | string[] | undefined>;
+}): { path: string; method: string; headers: Record<string, string | string[] | undefined> } {
+  return {
+    ...request,
+    headers: redactSensitiveHeaders(request.headers),
+  };
+}
+
 function resolveEdgeDsn(): string | null {
   const privateDsn = process.env.SENTRY_DSN?.trim();
   if (privateDsn && privateDsn.length > 0) {
@@ -116,11 +127,9 @@ export function onRequestError(
   request: { path: string; method: string; headers: Record<string, string | string[] | undefined> },
   context: { routerKind: string; routePath: string; routeType: string },
 ): void {
+  const redactedRequest = buildRedactedRequest(request);
+
   if (!sentryInitialized) {
-    const redactedRequest = {
-      ...request,
-      headers: redactSensitiveHeaders(request.headers),
-    };
     console.error(
       "[EdgeInstrumentation] Sentry SDK not initialized; logging edge request error to console.",
       error,
@@ -136,7 +145,7 @@ export function onRequestError(
 
   Sentry.captureException(error, {
     extra: {
-      request,
+      request: redactedRequest,
       context,
     },
   });


### PR DESCRIPTION
## Summary
This PR hardens error observability in the Edge runtime and preserves no-JS analytics beacon behavior.

## Functional Changes
- Edge runtime initializes Sentry in production when a DSN is configured and captures request-scoped errors with request/context metadata.
- `onRequestError` now returns immediately when Sentry is not initialized, preventing ineffective fall-through capture attempts.
- Fallback edge error logging now redacts sensitive headers before writing request context to console output.
- NoScript analytics tracking remains plain 1x1 vendor pixel requests for reliable no-JS measurement.
- Client error boundary now uses `@sentry/nextjs` consistently across the app.

## Review Follow-Up
- Resolved review findings from `greptile-apps`, `coderabbitai`, and `cursor` with:
  - `74e9b472` `fix(edge): stop capture on uninitialized Sentry`
- Resolved additional `coderabbitai` sensitive-header logging finding with:
  - `2c70acb7` `fix(edge): redact sensitive fallback headers`

## Validation
- `bun run validate` (0 errors, 0 warnings)
- Pre-push checks passed, including build and smoke tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production error reporting and Edge instrumentation; misconfiguration or SDK behavior changes could affect telemetry volume or accidentally capture unexpected request metadata (mitigated here with header redaction and prod-only init).
> 
> **Overview**
> Improves observability consistency by switching the global client error boundary to use `@sentry/nextjs` instead of `@sentry/browser`.
> 
> Replaces the Edge runtime instrumentation no-op with production-only Sentry initialization (DSN and release resolution, trace sampling) and updates `onRequestError` to capture request-scoped failures via `Sentry.captureRequestError`, with an early fallback to console logging that **redacts sensitive headers**.
> 
> Preserves no-JS analytics beacons by rendering Simple Analytics and Clicky `noscript` pixels as raw 1x1 `<img>` HTML via `dangerouslySetInnerHTML` (avoiding Next/image behavior or remotePatterns constraints).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 241589ac19b2b95542a3b5d04984eddd4046de3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully hardens Edge runtime error observability and preserves noscript analytics tracking. The changes are well-implemented and address all previous review findings.

**Key Improvements:**
- Edge runtime now initializes Sentry in production with proper DSN resolution fallback chain and release metadata
- `onRequestError` returns early when Sentry not initialized (line 138), preventing ineffective capture attempts
- Sensitive headers (`authorization`, `cookie`, `set-cookie`, etc.) are redacted in console logging and the `captureException` fallback path
- Noscript tracking pixels use `dangerouslySetInnerHTML` to preserve exact HTML attributes required by vendors
- Standardized on `@sentry/nextjs` import in error boundary

**Security Posture:**
- Header redaction implemented correctly with explicit redaction before logging
- All fallback paths log appropriately per [RC1a]
- No silent error swallowing [RC1b]
- Module follows type safety requirements [TS1]

**Code Quality:**
- All files under 350-line limit [LC1]
- Defensive programming with function existence checks
- Clean separation of concerns between DSN resolution, header redaction, and error capture

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- All previous review comments have been properly addressed (early return on line 138, header redaction on line 148). The code follows repository standards for line limits, type safety, and explicit error logging. Defensive programming patterns are used throughout. No bugs or security issues found.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/error.tsx | Changed Sentry import from `@sentry/browser` to `@sentry/nextjs` for consistency across the application |
| src/components/analytics/analytics.client.tsx | Replaced JSX noscript elements with dangerouslySetInnerHTML to ensure exact HTML attributes for vendor tracking pixels |
| src/instrumentation-edge.ts | Added production Sentry initialization with DSN/release resolution, header redaction, and request-scoped error capture. Previous review findings resolved: early return when not initialized (line 138) and sensitive header redaction in fallback path (line 148) |

</details>



<sub>Last reviewed commit: 241589a</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=23822fbb-4a3d-480a-90b4-1b28f83b089c))

<!-- /greptile_comment -->