### PR TITLE
feat(db): PostgreSQL/pgvector data layer replacing S3/ChromaDB, flicker-free bookmark cards, and surfaced error paths

### DIFF
--- a/docs/plans/2026-02-25-drizzle-postgres-migration.md
+++ b/docs/plans/2026-02-25-drizzle-postgres-migration.md
@@ -126,7 +126,7 @@ git commit -m "feat(db): add Drizzle connection and drizzle-kit config"
 **Files:**
 
 - Create: `src/lib/db/schema/bookmarks.ts`
-- Create: `src/lib/db/schema/index.ts`
+- Modify callers to import schema modules directly (no schema barrel file)
 
 **Context:** The `UnifiedBookmark` Zod schema (`src/types/schemas/bookmark.ts`) has ~35 fields. The Drizzle table must capture all fields needed for DB queries. Nested JSON objects (`content`, `tags`, `logoData`, `assets`) are stored as `jsonb` columns.
 
@@ -236,11 +236,11 @@ export type BookmarkRow = typeof bookmarks.$inferSelect;
 export type BookmarkInsert = typeof bookmarks.$inferInsert;
 ```
 
-**Step 2: Create schema barrel**
+**Step 2: Use direct schema imports**
 
 ```typescript
-// src/lib/db/schema/index.ts
-export { bookmarks, type BookmarkRow, type BookmarkInsert } from "./bookmarks";
+// Example consumer import (no barrel):
+import { bookmarks, type BookmarkRow, type BookmarkInsert } from "@/lib/db/schema/bookmarks";
 ```
 
 **Step 3: Verify typecheck**
@@ -605,7 +605,7 @@ Replace `writeBookmarkMasterFiles()` internals:
 - `writeJsonS3(BOOKMARKS_S3_PATHS.FILE, bookmarks)` -> `upsertBookmarks(mapped)`
 - Remove `writeBookmarksByIdFiles()` (individual JSON files no longer needed)
 - Remove `writeLocalBookmarksCache()` calls
-- Keep `writePaginatedBookmarks()` temporarily for S3 backward compat (mark deprecated)
+- Keep `writePaginatedBookmarks()` only while S3 backward-compatibility is still required, then remove it.
 
 **Step 2: Run tests, validate**
 
@@ -628,7 +628,7 @@ git commit -m "feat(db): wire bookmark persistence to Drizzle (writes)"
 **Files:**
 
 - Create: `src/lib/db/schema/github-activity.ts`
-- Modify: `src/lib/db/schema/index.ts`
+- Modify: `src/lib/db/schema/*.ts`
 - Create: `src/lib/db/queries/github-activity.ts`
 - Create: `src/lib/db/mutations/github-activity.ts`
 - Create: `scripts/migrate-github-s3-to-postgres.ts`
@@ -646,7 +646,7 @@ git commit -m "feat(db): wire bookmark persistence to Drizzle (writes)"
 ```bash
 git add src/lib/db/schema/github-activity.ts src/lib/db/queries/github-activity.ts \
   src/lib/db/mutations/github-activity.ts scripts/migrate-github-s3-to-postgres.ts \
-  src/lib/data-access/github-storage.ts src/lib/db/schema/index.ts
+  src/lib/data-access/github-storage.ts src/lib/db/schema/*.ts
 git commit -m "feat(db): add GitHub activity PostgreSQL schema and data access"
 ```
 
@@ -867,7 +867,7 @@ git commit -m "feat(db): remove remaining bookmark S3 read paths (slug/cache/og/
 **Files:**
 
 - Create: `src/lib/db/schema/search-index-artifacts.ts`
-- Modify: `src/lib/db/schema/index.ts`
+- Modify: `src/lib/db/schema/*.ts`
 - Create: `src/lib/db/queries/search-index-artifacts.ts`
 - Create: `src/lib/db/mutations/search-index-artifacts.ts`
 - Modify: `src/lib/server/data-fetch-manager.ts`
@@ -914,7 +914,7 @@ bun run validate
 **Step 6: Commit**
 
 ```bash
-git add src/lib/db/schema/search-index-artifacts.ts src/lib/db/schema/index.ts \
+git add src/lib/db/schema/search-index-artifacts.ts src/lib/db/schema/*.ts \
   src/lib/db/queries/search-index-artifacts.ts src/lib/db/mutations/search-index-artifacts.ts \
   src/lib/server/data-fetch-manager.ts src/lib/search/loaders/static-content.ts \
   src/lib/search/loaders/dynamic-content.ts scripts/migrate-search-indexes-s3-to-postgres.ts __tests__
@@ -931,7 +931,7 @@ git commit -m "feat(db): migrate search index artifacts from S3 to PostgreSQL"
 
 - Create/Modify exactly as listed in Task 10:
   - `src/lib/db/schema/github-activity.ts`
-  - `src/lib/db/schema/index.ts`
+  - `src/lib/db/schema/*.ts`
   - `src/lib/db/queries/github-activity.ts`
   - `src/lib/db/mutations/github-activity.ts`
   - `scripts/migrate-github-s3-to-postgres.ts`
@@ -957,7 +957,7 @@ bun run validate
 ```bash
 git add src/lib/db/schema/github-activity.ts src/lib/db/queries/github-activity.ts \
   src/lib/db/mutations/github-activity.ts scripts/migrate-github-s3-to-postgres.ts \
-  src/lib/data-access/github-storage.ts src/lib/db/schema/index.ts __tests__
+  src/lib/data-access/github-storage.ts src/lib/db/schema/*.ts __tests__
 git commit -m "feat(db): migrate GitHub activity storage from S3 to PostgreSQL"
 ```
 
@@ -970,7 +970,7 @@ git commit -m "feat(db): migrate GitHub activity storage from S3 to PostgreSQL"
 **Files:**
 
 - Create: `src/lib/db/schema/books-snapshots.ts`
-- Modify: `src/lib/db/schema/index.ts`
+- Modify: `src/lib/db/schema/*.ts`
 - Create: `src/lib/db/queries/books-snapshots.ts`
 - Create: `src/lib/db/mutations/books-snapshots.ts`
 - Modify: `src/lib/books/books-data-access.server.ts`
@@ -1001,7 +1001,7 @@ bun run validate
 **Step 4: Commit**
 
 ```bash
-git add src/lib/db/schema/books-snapshots.ts src/lib/db/schema/index.ts \
+git add src/lib/db/schema/books-snapshots.ts src/lib/db/schema/*.ts \
   src/lib/db/queries/books-snapshots.ts src/lib/db/mutations/books-snapshots.ts \
   src/lib/books/books-data-access.server.ts src/lib/books/generate.ts \
   scripts/migrate-books-s3-to-postgres.ts __tests__
@@ -1017,7 +1017,7 @@ git commit -m "feat(db): migrate books snapshot storage from S3 to PostgreSQL"
 **Files:**
 
 - Create: `src/lib/db/schema/content-graph.ts`
-- Modify: `src/lib/db/schema/index.ts`
+- Modify: `src/lib/db/schema/*.ts`
 - Create: `src/lib/db/queries/content-graph.ts`
 - Create: `src/lib/db/mutations/content-graph.ts`
 - Modify: `src/lib/content-graph/build.ts`
@@ -1049,7 +1049,7 @@ bun run validate
 **Step 4: Commit**
 
 ```bash
-git add src/lib/db/schema/content-graph.ts src/lib/db/schema/index.ts \
+git add src/lib/db/schema/content-graph.ts src/lib/db/schema/*.ts \
   src/lib/db/queries/content-graph.ts src/lib/db/mutations/content-graph.ts \
   src/lib/content-graph/build.ts src/lib/books/related-content.server.ts \
   scripts/migrate-content-graph-s3-to-postgres.ts __tests__
@@ -1065,7 +1065,7 @@ git commit -m "feat(db): migrate content graph persistence from S3 to PostgreSQL
 **Files:**
 
 - Create: `src/lib/db/schema/ai-analysis.ts`
-- Modify: `src/lib/db/schema/index.ts`
+- Modify: `src/lib/db/schema/*.ts`
 - Create: `src/lib/db/queries/ai-analysis.ts`
 - Create: `src/lib/db/mutations/ai-analysis.ts`
 - Modify: `src/lib/ai-analysis/writer.server.ts`
@@ -1096,7 +1096,7 @@ bun run validate
 **Step 4: Commit**
 
 ```bash
-git add src/lib/db/schema/ai-analysis.ts src/lib/db/schema/index.ts \
+git add src/lib/db/schema/ai-analysis.ts src/lib/db/schema/*.ts \
   src/lib/db/queries/ai-analysis.ts src/lib/db/mutations/ai-analysis.ts \
   src/lib/ai-analysis/writer.server.ts src/lib/ai-analysis/reader.server.ts \
   scripts/migrate-ai-analysis-s3-to-postgres.ts __tests__

--- a/docs/plans/2026-02-26-cool-stuff-rebrand-design.md
+++ b/docs/plans/2026-02-26-cool-stuff-rebrand-design.md
@@ -206,7 +206,7 @@ Existing `BookmarkCardClient` enhanced with additional data (all already in Post
 
 ### 6.1 Current State
 
-`calculateSimilarity()` in `src/lib/content-similarity/index.ts` uses heuristic signals:
+`calculateSimilarity()` in `src/lib/content-similarity/*` uses heuristic signals:
 
 - Tag Jaccard: 0.40
 - Token overlap: 0.30

--- a/docs/plans/2026-02-26-embedding-similarity-upgrade-design.md
+++ b/docs/plans/2026-02-26-embedding-similarity-upgrade-design.md
@@ -201,7 +201,7 @@ LIMIT 30;  -- fetch extra for diversity re-ranking
 | Per-domain embedding columns + HNSW indexes | 4 schema files                            | Unified `embeddings` table                            |
 | MiniSearch in-memory indexes                | `search-content.ts`, `search-factory.ts`  | PostgreSQL hybrid search on all domains               |
 | `rerankScoredResultsWithEmbeddings()`       | `search-content.ts:172`                   | Native pgvector in 3-CTE query                        |
-| Heuristic `calculateSimilarity()`           | `content-similarity/index.ts`             | Pre-computed pgvector cosine + blended scoring        |
+| Heuristic `calculateSimilarity()`           | `content-similarity/*`                    | Pre-computed pgvector cosine + blended scoring        |
 | Tag ontology (manual semantic groups)       | `content-similarity/tag-ontology.ts`      | Embeddings capture semantic relationships natively    |
 | `aggregateAllContent()` normalizer          | `content-similarity/aggregator.ts`        | Direct PostgreSQL queries on standardized tables      |
 | `NormalizedContent` intermediary type       | `types/related-content.ts`                | Domain-specific types with shared embedding interface |
@@ -328,7 +328,7 @@ Replace heuristic similarity with pgvector cosine queries:
 
 1. Remove dead code: per-domain embedding constants, MiniSearch imports, NormalizedContent type
 2. Update docs: search.md, architecture/README.md, file-map.md
-3. Delete stale docs: architecture/chroma.md
+3. Confirm stale docs remain deleted: `docs/architecture/chroma.md`
 4. `bun run validate` — zero errors, zero warnings
 5. `bun run build` — production build passes
 6. Manual quality verification: search and related content

--- a/docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md
+++ b/docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md
@@ -627,7 +627,7 @@ Replace MiniSearch-based search functions with PostgreSQL hybrid search.
 - Modify: `src/lib/search/searchers/static-searchers.ts` — rewrite `searchInvestments`, `searchProjects`
 - Modify: `src/lib/search/searchers/dynamic-searchers.ts` — rewrite `searchBooks`
 - Create: `src/lib/search/searchers/blog-search.ts`
-- Modify: `src/lib/search/index.ts` — update exports
+- Modify: `src/lib/search/searchers/tag-search.ts` — update imports for concrete searcher modules
 - Modify: `__tests__/lib/search/search.test.ts`
 
 For each domain:
@@ -677,7 +677,7 @@ Delete now-unused MiniSearch layer.
 
 **Files to modify:**
 
-- `src/lib/search/index.ts` — remove dead re-exports
+- `src/lib/search/searchers/*.ts` — remove dead imports/references after MiniSearch deletion
 - Remaining searcher files — remove dead imports
 
 **Verification:**
@@ -821,7 +821,7 @@ git commit -m "refactor(related-content): hydrate from domain tables, remove agg
 
 **Files to delete:**
 
-- `src/lib/content-similarity/index.ts`
+- `src/lib/content-similarity/*` (legacy files, if present)
 - `src/lib/content-similarity/aggregator.ts`
 - `src/lib/content-similarity/cached-aggregator.ts`
 - `src/lib/content-similarity/tag-ontology.ts`
@@ -849,9 +849,9 @@ git commit -m "refactor: remove heuristic content-similarity engine (replaced by
 - `docs/architecture/README.md` — add embeddings table, new domain tables
 - `docs/file-map.md` — add new files, remove deleted files
 
-**Delete:**
+**Delete (already completed in repo):**
 
-- `docs/architecture/chroma.md` — Chroma was removed long ago
+- `docs/architecture/chroma.md` — removed; verify no reintroduction
 
 ```bash
 git commit -m "docs: update search and architecture docs for unified embedding similarity"


### PR DESCRIPTION
## Summary
All data reads, writes, and vector similarity searches now use PostgreSQL with pgvector instead of S3 JSON files and ChromaDB. Bookmark card images render without flickering or hydration churn. Error paths that were silently swallowed now propagate explicitly.

## Changes

### Features
- **All data persistence backed by PostgreSQL**: Bookmarks, books, thoughts, github activity, opengraph metadata, AI analysis, image manifests, search artifacts, content graphs, and new investment/project/blog-post tables all read from and write to PostgreSQL via Drizzle ORM — S3 JSON and ChromaDB are no longer used at runtime (`src/lib/db/queries/`, `src/lib/db/mutations/`, `src/lib/db/schema/`, `drizzle/`)
- **Hybrid keyword+vector search across all domains**: Search now combines tsvector full-text matching with pgvector cosine similarity (Qwen3-Embedding-4B, 2560-d halfvec) and reranks results, replacing the ChromaDB-only approach (`src/lib/db/queries/hybrid-search.ts`, `src/lib/search/searchers/`)
- **Bookmark search reads from Postgres in production**: The `/api/search/bookmarks` endpoint now queries PostgreSQL directly for keyword and semantic results instead of loading S3 snapshots into memory (`src/app/api/search/bookmarks/route.ts`)
- **Pre-push bookmark integrity check**: `git push` now validates bookmark count consistency between the `bookmarks` table and `bookmark_index_state` via a Node.js probe, blocking pushes on data mismatches (`.husky/pre-push`)
- **New database tables for investments, projects, individual books, and blog posts**: Four new Drizzle schemas with corresponding query/mutation modules and seed scripts expand the PostgreSQL data model (`src/lib/db/schema/investments.ts`, `projects.ts`, `books-individual.ts`, `blog-posts.ts`)
- **AI chat tool dispatch observability**: Forced-tool determinism, per-scope RAG timeouts, and explicit logging for tool selection and upstream errors make AI chat debugging tractable (`src/app/api/ai/chat/`)

### Bug Fixes
- **Bookmark cards no longer flicker on page load**: Mount-gated skeleton swaps caused a visible flash between skeleton and real content during hydration; removing them and the overlay LQIP lets the native blur placeholder render in a single pass (`src/components/features/bookmarks/bookmarks-with-pagination.client.tsx`, `bookmarks-with-options.client.tsx`)
- **Next.js image optimizer restored for CDN asset proxy URLs**: `/api/assets/**` URLs were incorrectly bypassing Next.js optimization; they now receive responsive `srcset` generation and format conversion (`next.config.ts`, `src/lib/utils/cdn-utils.ts`)
- **Errors propagated instead of silently swallowed**: SSE stream throws on failed sends (was discarded), bookmark refresh throws on HTTP errors (was caught and ignored), OpenAI client throws on missing API key (was faking a token), cgroup memory detector retries on transient failures (was permanently caching null) (`src/app/api/ai/chat/[feature]/sse-stream.ts`, `use-bookmark-refresh.ts`, `openai-compatible-client.ts`, `memory-pressure.ts`)
- **AI chat rejects malformed requests explicitly**: Missing `Accept` header returns 406, missing `User-Agent` logs a warning, and tool args without `maxResults` log before defaulting (`src/app/api/ai/chat/[feature]/chat-helpers.ts`, `route.ts`)
- **Script cache-refresh failures are now visible**: Social cache refresh reports success only when HTTP responses are OK, missing prerequisites are logged, and malformed bookmark tags are guarded instead of silently coerced (`scripts/lib/bookmark-artifacts.ts`, refresh scripts)

### Performance
- **In-memory server cache layer removed**: The monolithic `server-cache.ts` and 7 domain-specific cache modules (~1,400 LOC) that held logo, opengraph, github, bookmark, and search data in process memory are replaced by direct database queries with connection pooling (`src/lib/server-cache.ts`, `src/lib/server-cache/` — deleted)
- **Memory management infrastructure removed**: Memory health monitor, memory pressure middleware, memory-aware scheduler, and all `NODE_OPTIONS --max-old-space-size` flags (~1,700 LOC) are gone — no longer needed with database-backed reads instead of in-memory caches (`src/lib/health/memory-health-monitor.ts`, `src/lib/middleware/memory-pressure.ts`, `src/lib/services/memory-aware-scheduler.ts` — deleted)

### Refactoring
- **ChromaDB completely removed**: Client, embedding functions, sync modules, and query layers for books and thoughts are deleted — vector operations now use pgvector natively in PostgreSQL (`src/lib/chroma/`, `src/lib/thoughts/chroma-*.ts`, `src/lib/books/chroma-sync.ts` — deleted)
- **S3 distributed lock and reset infrastructure removed**: Lock contention, S3 cache utilities, and the reset/regenerate pipeline are no longer needed with PostgreSQL transactions providing atomicity (`src/lib/utils/s3-distributed-lock.server.ts`, `src/lib/s3-cache-utils.ts`, `src/lib/s3-reset/` — deleted)
- **GitHub activity storage migrated from S3 to PostgreSQL**: CSV checksums and weekly repo stats are now read/written via `github_activity_store` and `github_repo_weekly_stats` tables; cascading S3 key fallback removed (`src/lib/data-access/github-storage.ts`, `github-public-api.ts`)
- **Types derived from Zod schemas instead of manual duplication**: `AiGateTokenPayloadV1`, `BookmarkSlugMapping`, `AiChatModelStreamEvent`, and terminal search types now use `z.infer<>` from schemas in `types/schemas/`; three sets of identical `AnalysisStatus`/`AnalysisState` dead code removed (`src/types/schemas/`)
- **Bookmark client components split and refresh logic extracted**: `useBookmarkRefresh` hook encapsulates ~80 lines of duplicated abort-controlled refresh logic shared by both bookmark views (`src/components/features/bookmarks/`)
- **Magic literals replaced with named constants**: `APPROX_CHARS_PER_TOKEN`, `MAX_NORMALIZED_LIST_ITEMS`, `DEFAULT_BOOKMARKS_PAGE_SIZE`, `OG_TITLE_MAX_LENGTH`, and 8 other business constants extracted from inline numbers (`src/app/api/ai/`, `scripts/lib/`)

### Documentation
- **19 Drizzle migration files document the full schema evolution**: From initial embedding rename through investments, projects, blog-posts, and content-embeddings tables (`drizzle/0000_*.sql` through `drizzle/0018_*.sql`)
- **Architecture docs updated for PostgreSQL data model**: Caching, data access, bookmarks, github activity, search, and image handling docs reflect the new database-first architecture (`docs/architecture/`, `docs/features/`)
- **Image flickering fix design documented**: Root cause analysis of 7 flicker sources and the approved fix approach (`docs/plans/2026-02-26-image-flickering-fix-design.md`, `*-plan.md`)
- **Embedding similarity upgrade and memory management removal plans**: Design rationale for Qwen3-Embedding-4B adoption and justification for removing memory management (`docs/plans/2026-02-25-*.md`, `2026-02-26-embedding-*.md`)

## Breaking Changes
- `DATABASE_URL` is required for pre-push integrity checks and all database-backed workflows
- Bun runtime is prohibited for scripts connecting to PostgreSQL (use Node.js with `*.node.mjs` extension) per `[RT1]`
- S3 JSON persistence, ChromaDB, distributed locks, and in-memory server cache APIs are removed — all callers must use the `src/lib/db/` query/mutation modules

## Related Issues
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core persistence/integrity assumptions around bookmarks and other datasets (moving checks/mocks/tests to PostgreSQL state) and adds push/build-time behavior that now depends on `DATABASE_URL` and Node-based Postgres connectivity.
> 
> **Overview**
> This PR shifts multiple workflows and tests from S3/memory-cache/Chroma assumptions to **PostgreSQL-backed state**, including bookmark index/slug-mapping/tag paging, search (mocking `searchBookmarksFtsPage`), content-graph artifact reads/writes, and books dataset access.
> 
> Developer/runtime tooling is updated to support the new DB-first model: `.env-example` adds `DATABASE_URL` (and an optional embedding model hint), Docker build secrets now optionally mount `DATABASE_URL`, and Husky hooks now (a) re-stage files after `oxlint --fix` and (b) run a **Node + `postgres` integrity probe** on pre-push that compares `bookmarks` vs `bookmark_index_state`.
> 
> A number of legacy tests and mocks tied to S3, in-process `server-cache`, memory-pressure middleware, and Chroma indexing are removed or rewritten, and UI image tests are updated for the new single-pass blur placeholder behavior and to stop bypassing optimization for `/api/assets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5338564756507319e6c71f57253742ccdb7cc1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->