### PR TITLE
Add RSS feed, update metadata, refine styling, refactor bookmarks

### DIFF
--- a/__tests__/__mocks__/next/server.ts
+++ b/__tests__/__mocks__/next/server.ts
@@ -97,7 +97,6 @@ export class NextResponse {
   status: number;
   headers: ReturnType<typeof makeCaseInsensitiveHeaders>;
   cookies: { set: (cookie: CookieOptions) => void };
-  json?: () => Promise<unknown>;
 
   constructor(body?: unknown, init: { status?: number; headers?: Record<string, string> } = {}) {
     this.body = body;
@@ -116,13 +115,42 @@ export class NextResponse {
     };
   }
 
+  async text(): Promise<string> {
+    if (this.body instanceof ReadableStream) {
+      const reader = this.body.getReader();
+      const decoder = new TextDecoder();
+      let result = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        result += decoder.decode(value);
+      }
+      return result;
+    }
+    return String(this.body ?? "");
+  }
+
+  async json<T = unknown>(): Promise<T> {
+    const text = await this.text();
+    return JSON.parse(text);
+  }
+
+  async blob(): Promise<Blob> {
+    const text = await this.text();
+    return new Blob([text]);
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    const text = await this.text();
+    return new TextEncoder().encode(text).buffer;
+  }
+
   static json<T>(
     data: T,
     init: { status?: number; headers?: Record<string, string> } = {},
   ): NextResponse {
     const response = new NextResponse(JSON.stringify(data), init);
     response.headers.set("content-type", "application/json");
-    response.json = () => Promise.resolve(data);
     return response;
   }
 

--- a/__tests__/__mocks__/next/server.ts
+++ b/__tests__/__mocks__/next/server.ts
@@ -123,8 +123,9 @@ export class NextResponse {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        result += decoder.decode(value);
+        result += decoder.decode(value, { stream: true });
       }
+      result += decoder.decode();
       return result;
     }
     return String(this.body ?? "");

--- a/__tests__/api/bookmarks-feed.test.ts
+++ b/__tests__/api/bookmarks-feed.test.ts
@@ -195,7 +195,7 @@ describe("RSS feed route", () => {
     ]);
 
     const response = await getFeedRoute();
-    const xml = String(response.body);
+    const xml = await new Response(response.body).text();
 
     expect(response.headers.get("Content-Type")).toContain("application/rss+xml");
     expect(mockGetBookmarksPage).toHaveBeenCalledWith(1, 100);
@@ -225,7 +225,7 @@ describe("RSS feed route", () => {
     ]);
 
     const response = await getFeedRoute();
-    const xml = String(response.body);
+    const xml = await new Response(response.body).text();
 
     expect(response.status).toBe(200);
     expect(xml).toContain("Valid bookmark");

--- a/__tests__/api/bookmarks-feed.test.ts
+++ b/__tests__/api/bookmarks-feed.test.ts
@@ -1,5 +1,7 @@
-import { GET } from "@/app/api/bookmarks/route";
+import { GET as getBookmarksRoute } from "@/app/api/bookmarks/route";
+import { GET as getFeedRoute } from "@/app/feed.xml/route";
 import { getBookmarksIndex, getBookmarksPage } from "@/lib/bookmarks/service.server";
+import { getAllPostsMeta } from "@/lib/blog";
 import { getDiscoveryRankedBookmarks } from "@/lib/db/queries/discovery-scores";
 import { loadSlugMapping } from "@/lib/bookmarks/slug-manager";
 import type { BookmarkSlugMapping, UnifiedBookmark } from "@/types";
@@ -9,13 +11,28 @@ vi.mock("@/lib/bookmarks/slug-manager");
 vi.mock("@/lib/db/queries/discovery-scores");
 vi.mock("@/lib/db/queries/discovery-grouped");
 vi.mock("@/lib/db/queries/embedding-similarity");
+vi.mock("@/lib/blog");
+vi.mock("@/data/metadata", () => ({
+  metadata: {
+    title: "William & Co ]]> Feed",
+    description: "Personal <site> & journal ]]> entries",
+    site: { url: "https://williamcallahan.com" },
+  },
+}));
 
 const mockGetBookmarksPage = vi.mocked(getBookmarksPage);
 const mockGetBookmarksIndex = vi.mocked(getBookmarksIndex);
 const mockGetDiscoveryRankedBookmarks = vi.mocked(getDiscoveryRankedBookmarks);
 const mockLoadSlugMapping = vi.mocked(loadSlugMapping);
+const mockGetAllPostsMeta = vi.mocked(getAllPostsMeta);
 
-function createBookmark(id: string, dateBookmarked: string): UnifiedBookmark {
+type FeedPost = Awaited<ReturnType<typeof getAllPostsMeta>>[number];
+
+function createBookmark(
+  id: string,
+  dateBookmarked: string,
+  overrides: Partial<UnifiedBookmark> = {},
+): UnifiedBookmark {
   return {
     id,
     slug: `slug-${id}`,
@@ -24,7 +41,27 @@ function createBookmark(id: string, dateBookmarked: string): UnifiedBookmark {
     description: `Description ${id}`,
     tags: [],
     dateBookmarked,
+    sourceUpdatedAt: "2026-02-27T00:00:00.000Z",
+    ...overrides,
   } as UnifiedBookmark;
+}
+
+function createPost(
+  slug: string,
+  publishedAt: string,
+  overrides: Partial<FeedPost> = {},
+): FeedPost {
+  return {
+    id: slug,
+    slug,
+    title: `Post ${slug}`,
+    excerpt: `Excerpt ${slug}`,
+    publishedAt,
+    content: {} as FeedPost["content"],
+    author: { id: "will", name: "William Callahan" },
+    tags: [],
+    ...overrides,
+  } as FeedPost;
 }
 
 function createSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugMapping {
@@ -76,7 +113,7 @@ describe("Bookmark feed modes", () => {
     mockGetBookmarksPage.mockResolvedValue(latestBookmarks);
     mockLoadSlugMapping.mockResolvedValue(createSlugMapping(latestBookmarks));
 
-    const response = await GET(
+    const response = await getBookmarksRoute(
       new Request("http://localhost/api/bookmarks?feed=latest&page=1&limit=20"),
     );
     const payload = await response.json();
@@ -107,7 +144,7 @@ describe("Bookmark feed modes", () => {
       createSlugMapping(ranked.map((entry) => entry.bookmark as UnifiedBookmark)),
     );
 
-    const response = await GET(
+    const response = await getBookmarksRoute(
       new Request("http://localhost/api/bookmarks?feed=discover&page=1&limit=4"),
     );
     const payload = await response.json();
@@ -126,12 +163,76 @@ describe("Bookmark feed modes", () => {
   it("returns 500 error when discover ranking fails (no silent fallbacks)", async () => {
     mockGetDiscoveryRankedBookmarks.mockRejectedValueOnce(new Error("relation missing"));
 
-    const response = await GET(
+    const response = await getBookmarksRoute(
       new Request("http://localhost/api/bookmarks?feed=discover&page=1&limit=20"),
     );
 
     expect(response.status).toBe(500);
     const payload = await response.json();
     expect(payload.error).toBe("Failed to fetch bookmarks");
+  });
+});
+
+describe("RSS feed route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the bounded bookmark page query and escapes XML-safe output", async () => {
+    mockGetAllPostsMeta.mockResolvedValue([
+      createPost("alpha", "2026-02-28T10:00:00.000Z", {
+        title: "AI ]]> Notes & Learnings",
+        excerpt: "Context ]]> and <tags> & more",
+      }),
+    ]);
+    mockGetBookmarksPage.mockResolvedValue([
+      createBookmark("bookmark-1", "2026-02-27T10:00:00.000Z", {
+        url: "https://example.com/bookmark-1?x=1&y=2",
+        title: "Bookmark ]]> Title",
+        description: "",
+        summary: "Bookmark summary ]]> <xml> & more",
+      }),
+    ]);
+
+    const response = await getFeedRoute();
+    const xml = String(response.body);
+
+    expect(response.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect(mockGetBookmarksPage).toHaveBeenCalledWith(1, 100);
+    expect(xml).toContain("<title><![CDATA[William & Co ]]]]><![CDATA[> Feed]]></title>");
+    expect(xml).toContain(
+      "<description><![CDATA[Personal <site> & journal ]]]]><![CDATA[> entries]]></description>",
+    );
+    expect(xml).toContain("<title><![CDATA[📝 AI ]]]]><![CDATA[> Notes & Learnings]]></title>");
+    expect(xml).toContain(
+      "<description><![CDATA[Context ]]]]><![CDATA[> and <tags> & more]]></description>",
+    );
+    expect(xml).toContain("<link>https://williamcallahan.com/bookmarks/slug-bookmark-1</link>");
+    expect(xml).toContain(
+      "<description><![CDATA[Bookmark summary ]]]]><![CDATA[> <xml> & more]]></description>",
+    );
+  });
+
+  it("skips entries with invalid dates instead of silently defaulting them", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockGetAllPostsMeta.mockResolvedValue([
+      createPost("invalid-post", "not-a-date", { title: "Invalid post" }),
+    ]);
+    mockGetBookmarksPage.mockResolvedValue([
+      createBookmark("valid-bookmark", "2026-02-27T10:00:00.000Z", { title: "Valid bookmark" }),
+      createBookmark("invalid-bookmark", "bad-date", { title: "Invalid bookmark" }),
+    ]);
+
+    const response = await getFeedRoute();
+    const xml = String(response.body);
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain("Valid bookmark");
+    expect(xml).not.toContain("Invalid post");
+    expect(xml).not.toContain("Invalid bookmark");
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/__tests__/api/bookmarks/tag-filtering.test.ts
+++ b/__tests__/api/bookmarks/tag-filtering.test.ts
@@ -4,7 +4,6 @@
 
 import { GET } from "@/app/api/bookmarks/route";
 import {
-  getBookmarks,
   getBookmarksByTag,
   getBookmarksIndex,
   getBookmarksPage,
@@ -23,7 +22,6 @@ vi.mock("@/lib/bookmarks/slug-manager");
 vi.mock("@/lib/db/queries/discovery-scores");
 vi.mock("@/lib/db/queries/embedding-similarity");
 
-const mockGetBookmarks = vi.mocked(getBookmarks);
 const mockGetBookmarksByTag = vi.mocked(getBookmarksByTag);
 const mockGetBookmarksIndex = vi.mocked(getBookmarksIndex);
 const mockGetBookmarksPage = vi.mocked(getBookmarksPage);
@@ -140,7 +138,7 @@ describe("Bookmark API Tag Filtering", () => {
     mockGetBookmarkById.mockImplementation(async (id) => {
       return mockBookmarks.find((b) => b.id === id) ?? null;
     });
-    mockGetBookmarksPage.mockImplementation(async (page) => {
+    mockGetBookmarksPage.mockImplementation(async () => {
       return mockBookmarks;
     });
   });

--- a/__tests__/app/bookmarks/page/page-number.test.tsx
+++ b/__tests__/app/bookmarks/page/page-number.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from "react";
 import { vi } from "vitest";
 import { render } from "@testing-library/react";
+import type { DiscoverFeedWrapperProps } from "@/types/features/discovery";
 
 // Manually mock the entire data access layer for this test suite
 vi.mock("@/lib/bookmarks/bookmarks-data-access.server", () => ({
@@ -84,7 +85,7 @@ vi.mock("@/components/features/bookmarks/discover-feed.client", () => ({
 vi.mock("@/components/features/bookmarks/discover-feed-wrapper.server", () => {
   return {
     __esModule: true,
-    DiscoverFeedWrapper: (props: any) => {
+    DiscoverFeedWrapper: (props: DiscoverFeedWrapperProps) => {
       // Call it synchronously to register the invocation for vitest
       mockGetDiscoveryGroupedBookmarks({
         sectionPage: props.sectionPage,

--- a/__tests__/app/bookmarks/page/page-number.test.tsx
+++ b/__tests__/app/bookmarks/page/page-number.test.tsx
@@ -81,6 +81,22 @@ vi.mock("@/components/features/bookmarks/discover-feed.client", () => ({
   DiscoverFeed: () => <div data-testid="discover-feed" />,
 }));
 
+vi.mock("@/components/features/bookmarks/discover-feed-wrapper.server", () => {
+  return {
+    __esModule: true,
+    DiscoverFeedWrapper: (props: any) => {
+      // Call it synchronously to register the invocation for vitest
+      mockGetDiscoveryGroupedBookmarks({
+        sectionPage: props.sectionPage,
+        sectionsPerPage: props.sectionsPerPage,
+        recencyDays: props.recencyDays,
+      });
+      return <div data-testid="discover-feed" />;
+    },
+    DiscoverFeedSkeleton: () => <div data-testid="discover-feed-skeleton" />,
+  };
+});
+
 vi.mock("@/lib/db/queries/discovery-grouped", () => ({
   __esModule: true,
   getDiscoveryGroupedBookmarks: mockGetDiscoveryGroupedBookmarks,

--- a/__tests__/lib/content-graph.test.ts
+++ b/__tests__/lib/content-graph.test.ts
@@ -8,6 +8,8 @@
 import { DataFetchManager } from "@/lib/server/data-fetch-manager";
 import { writeContentGraphArtifacts } from "@/lib/db/mutations/content-graph";
 import type { MockedFunction } from "vitest";
+import type { BlogPost } from "@/types/blog";
+import type { BookmarksIndex, UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock DB mutations for content graph persistence
 vi.mock("@/lib/db/mutations/content-graph");
@@ -59,6 +61,55 @@ vi.mock("drizzle-orm", () => ({
 const mockWriteContentGraphArtifacts = writeContentGraphArtifacts as MockedFunction<
   typeof writeContentGraphArtifacts
 >;
+
+function createBlogPost(id: string, overrides: Partial<BlogPost> = {}): BlogPost {
+  return {
+    id,
+    slug: id,
+    title: `Post ${id}`,
+    excerpt: `Excerpt ${id}`,
+    content: {
+      compiledSource: "",
+      scope: {},
+      frontmatter: {},
+    },
+    publishedAt: "2024-01-01",
+    author: { id: "will", name: "William Callahan" },
+    tags: [],
+    ...overrides,
+  };
+}
+
+function createBookmark(id: string, overrides: Partial<UnifiedBookmark> = {}): UnifiedBookmark {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: `Bookmark ${id}`,
+    description: `Description ${id}`,
+    slug: `slug-${id}`,
+    tags: [],
+    dateBookmarked: "2024-01-01T00:00:00.000Z",
+    sourceUpdatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createBookmarksIndex(
+  count: number,
+  overrides: Partial<BookmarksIndex> = {},
+): BookmarksIndex {
+  return {
+    count,
+    totalPages: count > 0 ? 1 : 0,
+    pageSize: 24,
+    lastModified: "2024-01-01T00:00:00.000Z",
+    lastFetchedAt: 1_704_067_200_000,
+    lastAttemptedAt: 1_704_067_200_000,
+    checksum: "test-checksum",
+    changeDetected: false,
+    ...overrides,
+  };
+}
 
 describe("Content Graph Pre-computation", () => {
   let manager: DataFetchManager;
@@ -140,26 +191,21 @@ describe("Content Graph Pre-computation", () => {
 
       // Mock blog posts and projects for metadata
       const { getAllPostsMeta } = await import("@/lib/blog");
-      (getAllPostsMeta as MockedFunction<typeof getAllPostsMeta>).mockResolvedValue([
-        {
-          id: "test-post",
-          slug: "test-post",
+      vi.mocked(getAllPostsMeta).mockResolvedValue([
+        createBlogPost("test-post", {
           title: "Test Post",
           tags: ["javascript"],
           publishedAt: "2024-01-01",
-        },
-      ] as any);
+        }),
+      ]);
 
       const { refreshBookmarks } = await import("@/lib/bookmarks/service.server");
       const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
       const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
 
-      (getBookmarks as any).mockResolvedValue([{ id: "b1" }, { id: "b2" }]);
-      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
-        count: 2,
-        lastFetchedAt: Date.now(),
-      });
-      (refreshBookmarks as any).mockResolvedValue([{ id: "b1" }, { id: "b2" }]);
+      vi.mocked(getBookmarks).mockResolvedValue([createBookmark("b1"), createBookmark("b2")]);
+      vi.mocked(getBookmarksIndexFromDatabase).mockResolvedValue(createBookmarksIndex(2));
+      vi.mocked(refreshBookmarks).mockResolvedValue([createBookmark("b1"), createBookmark("b2")]);
       mockWriteContentGraphArtifacts.mockResolvedValue(undefined);
 
       // Run the content graph build
@@ -259,18 +305,15 @@ describe("Content Graph Pre-computation", () => {
       );
 
       const { getAllPostsMeta } = await import("@/lib/blog");
-      (getAllPostsMeta as any).mockResolvedValue([]);
+      vi.mocked(getAllPostsMeta).mockResolvedValue([]);
 
       const { refreshBookmarks } = await import("@/lib/bookmarks/service.server");
       const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
       const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
 
-      (getBookmarks as any).mockResolvedValue([{ id: "1" }, { id: "2" }]);
-      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
-        count: 2,
-        lastFetchedAt: Date.now(),
-      });
-      (refreshBookmarks as any).mockResolvedValue([{ id: "1" }, { id: "2" }]);
+      vi.mocked(getBookmarks).mockResolvedValue([createBookmark("1"), createBookmark("2")]);
+      vi.mocked(getBookmarksIndexFromDatabase).mockResolvedValue(createBookmarksIndex(2));
+      vi.mocked(refreshBookmarks).mockResolvedValue([createBookmark("1"), createBookmark("2")]);
       mockWriteContentGraphArtifacts.mockResolvedValue(undefined);
 
       await manager.fetchData({
@@ -323,12 +366,9 @@ describe("Content Graph Pre-computation", () => {
       const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
       const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
 
-      (getBookmarks as any).mockResolvedValue([]);
-      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
-        count: 0,
-        lastFetchedAt: Date.now(),
-      });
-      (refreshBookmarks as any).mockRejectedValue(new Error("API Error"));
+      vi.mocked(getBookmarks).mockResolvedValue([]);
+      vi.mocked(getBookmarksIndexFromDatabase).mockResolvedValue(createBookmarksIndex(0));
+      vi.mocked(refreshBookmarks).mockRejectedValue(new Error("API Error"));
 
       const result = await manager.fetchData({
         bookmarks: true,

--- a/__tests__/lib/content-graph.test.ts
+++ b/__tests__/lib/content-graph.test.ts
@@ -16,6 +16,12 @@ vi.mock("@/lib/bookmarks/bookmarks-data-access.server");
 vi.mock("@/lib/blog");
 vi.mock("@/lib/utils/logger");
 vi.mock("@/lib/search/index-builder");
+vi.mock("@/lib/db/queries/bookmarks");
+vi.mock("@/lib/db/mutations/search-index-artifacts");
+vi.mock("@/lib/db/mutations/image-manifests");
+vi.mock("@/lib/s3/objects", () => ({
+  listS3Objects: vi.fn().mockResolvedValue([]),
+}));
 vi.mock("@/data/projects", () => ({
   projects: [],
 }));
@@ -133,13 +139,27 @@ describe("Content Graph Pre-computation", () => {
       );
 
       // Mock blog posts and projects for metadata
-      const { getAllPosts } = await import("@/lib/blog");
-      (getAllPosts as MockedFunction<typeof getAllPosts>).mockResolvedValue([
-        { slug: "test-post", title: "Test Post", tags: ["javascript"], publishedAt: "2024-01-01" },
+      const { getAllPostsMeta } = await import("@/lib/blog");
+      (getAllPostsMeta as MockedFunction<typeof getAllPostsMeta>).mockResolvedValue([
+        {
+          id: "test-post",
+          slug: "test-post",
+          title: "Test Post",
+          tags: ["javascript"],
+          publishedAt: "2024-01-01",
+        },
       ] as any);
 
       const { refreshBookmarks } = await import("@/lib/bookmarks/service.server");
-      (refreshBookmarks as any).mockResolvedValue([]);
+      const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
+      const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
+
+      (getBookmarks as any).mockResolvedValue([{ id: "b1" }, { id: "b2" }]);
+      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
+        count: 2,
+        lastFetchedAt: Date.now(),
+      });
+      (refreshBookmarks as any).mockResolvedValue([{ id: "b1" }, { id: "b2" }]);
       mockWriteContentGraphArtifacts.mockResolvedValue(undefined);
 
       // Run the content graph build
@@ -238,11 +258,19 @@ describe("Content Graph Pre-computation", () => {
           })),
       );
 
-      const { getAllPosts } = await import("@/lib/blog");
-      (getAllPosts as any).mockResolvedValue([]);
+      const { getAllPostsMeta } = await import("@/lib/blog");
+      (getAllPostsMeta as any).mockResolvedValue([]);
 
       const { refreshBookmarks } = await import("@/lib/bookmarks/service.server");
-      (refreshBookmarks as any).mockResolvedValue([]);
+      const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
+      const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
+
+      (getBookmarks as any).mockResolvedValue([{ id: "1" }, { id: "2" }]);
+      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
+        count: 2,
+        lastFetchedAt: Date.now(),
+      });
+      (refreshBookmarks as any).mockResolvedValue([{ id: "1" }, { id: "2" }]);
       mockWriteContentGraphArtifacts.mockResolvedValue(undefined);
 
       await manager.fetchData({
@@ -293,8 +321,13 @@ describe("Content Graph Pre-computation", () => {
 
       const { refreshBookmarks } = await import("@/lib/bookmarks/service.server");
       const { getBookmarks } = await import("@/lib/bookmarks/bookmarks-data-access.server");
+      const { getBookmarksIndexFromDatabase } = await import("@/lib/db/queries/bookmarks");
 
       (getBookmarks as any).mockResolvedValue([]);
+      (getBookmarksIndexFromDatabase as any).mockResolvedValue({
+        count: 0,
+        lastFetchedAt: Date.now(),
+      });
       (refreshBookmarks as any).mockRejectedValue(new Error("API Error"));
 
       const result = await manager.fetchData({

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,7 +1,7 @@
 import type { Project } from "@/types/project";
 
 // Remember to update this date whenever the projects data or the Projects page design changes
-export const updatedAt = "2026-02-09";
+export const updatedAt = "2026-04-06";
 
 export const projects: Project[] = [
   {
@@ -68,8 +68,7 @@ export const projects: Project[] = [
     description:
       "Web app that merges search with an AI chat assistant: select results, then ask GPT/Groq/Gemini using that grounded context. Built with Next.js, TypeScript, Convex Database, and Vercel AI SDK, with heavy server-side scraping/parsing to filter only relevant context.",
     shortSummary: "AI-powered web search with a contextual chat assistant",
-    url: "https://researchly.fyi",
-    githubUrl: "https://github.com/WilliamAGH/Researchly",
+    url: "https://researchly.chat",
     imageKey: "images/other/projects/searchAI.png",
     tags: [
       "AI",
@@ -90,6 +89,18 @@ export const projects: Project[] = [
       "Python",
       "Vercel AI SDK",
     ],
+    cvFeatured: true,
+  },
+  {
+    id: "Ensemble",
+    name: "Ensemble",
+    description:
+      "Multi-agent collaborative research interface where AI agents deliberate, react, and build on each other's reasoning in real time. A companion app to Researchly that surfaces richer insights through agent ensemble dynamics. Built with Svelte 5, Convex, and Tailwind CSS.",
+    shortSummary: "Multi-agent collaborative research with real-time AI deliberation",
+    url: "https://researchly.chat/ensemble/",
+    imageKey: "images/other/projects/ensemble-app.png",
+    tags: ["AI", "Multi-Agent", "Research Tool", "Collaborative", "Real-time", "Web App", "Svelte"],
+    techStack: ["Svelte 5", "TypeScript", "Convex Database", "Tailwind CSS", "Vite"],
     cvFeatured: true,
   },
   {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint:ox:typeaware": "oxlint -c config/oxlintrc.json --type-aware .",
     "lint:ast-grep": "ast-grep scan -c config/sgconfig.yml && echo 'No ast-grep violations found'",
     "lint:fix": "oxlint -c config/oxlintrc.json --fix . && eslint . --config config/eslint.config.ts --fix",
-    "type-check": "bunx tsc --noEmit",
+    "type-check": "node ./node_modules/next/dist/bin/next typegen && bunx tsc --noEmit",
     "type-check:tests": "bunx tsc --noEmit --project __tests__/tsconfig.json",
     "guard:runtime-json-s3-ops": "bash -c 'set -euo pipefail; if rg -n \"(getObject|putObject|deleteFromS3|listS3Objects|readBinaryS3|writeBinaryS3)\\\\(\\\\s*[\\\"\\x27]json/\" src --glob \"!src/lib/s3/**\"; then echo \"[Runtime JSON S3 Guard] Found forbidden json/* S3 object operations in src/. Use PostgreSQL-backed stores.\"; exit 1; fi'",
     "check:file-size": "bash -c 'fail=0; for f in $(find . -type f \\( -name \"*.ts\" -o -name \"*.tsx\" \\) ! -name \"*.d.ts\" | grep -v \"node_modules/\" | grep -v \".next/\"); do lines=$(wc -l < \"$f\"); if [ $lines -gt 350 ]; then echo \"[File Size Warning] $f exceeds $lines lines (limit: 350)\"; fail=1; fi; done; if [ $fail -ne 0 ]; then echo \"[File Size Check] Files exceed 350 lines — run bun run check:file-size for details\"; fi; exit 0'",

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,15 +1,36 @@
 import { NextResponse } from "next/server";
 import { getAllPostsMeta } from "@/lib/blog";
-import { getBookmarks } from "@/lib/bookmarks/bookmarks-data-access.server";
+import { getBookmarksPage } from "@/lib/bookmarks/service.server";
 import { metadata } from "@/data/metadata";
-import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
-interface FeedItem {
-  title: string;
-  url: string;
-  date: Date;
-  description: string;
-  category: "Blog" | "Bookmark";
+const MAX_FEED_ITEMS = 100;
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+const wrapCdata = (value: string): string =>
+  `<![CDATA[${value.replaceAll("]]>", "]]]]><![CDATA[>")}]]>`;
+
+const pickDescription = (...values: Array<string | null | undefined>): string | null => {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+};
+
+function parseFeedDate(rawValue: string, label: string): Date | null {
+  const date = new Date(rawValue);
+  if (Number.isNaN(date.getTime())) {
+    console.error(`[feed.xml] Skipping ${label} because the date is invalid: ${rawValue}`);
+    return null;
+  }
+  return date;
 }
 
 // Next.js 16 + cacheComponents means pages are dynamic by default.
@@ -18,47 +39,65 @@ interface FeedItem {
 export async function GET() {
   const [posts, bookmarks] = await Promise.all([
     getAllPostsMeta(false), // exclude drafts
-    getBookmarks({ skipExternalFetch: true }), // fast local/cache fetch
+    getBookmarksPage(1, MAX_FEED_ITEMS), // lightweight, bounded fetch for feed generation
   ]);
 
   const siteUrl = metadata.site.url;
+  const feedUrl = `${siteUrl}/feed.xml`;
+  const generatedAt = new Date().toUTCString();
 
-  const feedItems: FeedItem[] = [
-    ...posts.map((post) => ({
-      title: post.title,
-      url: `${siteUrl}/blog/${post.slug}`,
-      date: post.publishedAt ? new Date(post.publishedAt) : new Date(),
-      description: post.excerpt || "",
-      category: "Blog" as const,
-    })),
-    ...(bookmarks as UnifiedBookmark[]).map((bookmark) => ({
-      title: bookmark.title,
-      url: `${siteUrl}/bookmarks/${bookmark.slug}`,
-      date: new Date(bookmark.dateBookmarked),
-      description: bookmark.description || bookmark.summary || "",
-      category: "Bookmark" as const,
-    })),
+  const feedItems = [
+    ...posts.flatMap((post) => {
+      const date = parseFeedDate(post.publishedAt, `blog post "${post.slug}"`);
+      if (!date) return [];
+      return [
+        {
+          title: post.title,
+          url: `${siteUrl}/blog/${post.slug}`,
+          date,
+          description: pickDescription(post.excerpt),
+          category: "Blog" as const,
+        },
+      ];
+    }),
+    ...bookmarks.flatMap((bookmark) => {
+      const date = parseFeedDate(bookmark.dateBookmarked, `bookmark "${bookmark.id}"`);
+      if (!date) return [];
+      return [
+        {
+          title: bookmark.title,
+          url: `${siteUrl}/bookmarks/${bookmark.slug}`,
+          date,
+          description: pickDescription(bookmark.description, bookmark.summary),
+          category: "Bookmark" as const,
+        },
+      ];
+    }),
   ];
 
   // Sort chronologically newest first
   feedItems.sort((a, b) => b.date.getTime() - a.date.getTime());
 
   // Cap at 100 to prevent unbounded XML growth over time
-  const latestItems = feedItems.slice(0, 100);
+  const latestItems = feedItems.slice(0, MAX_FEED_ITEMS);
 
   const rssItems = latestItems
     .map((item) => {
       // Prepending an indicator is an idiomatic pattern for combined feeds
       const titlePrefix = item.category === "Bookmark" ? "🔖 " : "📝 ";
+      const descriptionNode = item.description
+        ? `
+      <description>${wrapCdata(item.description)}</description>`
+        : "";
 
       return `
     <item>
-      <title><![CDATA[${titlePrefix}${item.title}]]></title>
-      <link>${item.url}</link>
-      <guid isPermaLink="true">${item.url}</guid>
+      <title>${wrapCdata(`${titlePrefix}${item.title}`)}</title>
+      <link>${escapeXml(item.url)}</link>
+      <guid isPermaLink="true">${escapeXml(item.url)}</guid>
       <pubDate>${item.date.toUTCString()}</pubDate>
-      <description><![CDATA[${item.description}]]></description>
-      <category>${item.category}</category>
+      ${descriptionNode}
+      <category>${escapeXml(item.category)}</category>
     </item>`;
     })
     .join("");
@@ -66,13 +105,13 @@ export async function GET() {
   const rssFeed = `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>${metadata.title}</title>
-    <link>${siteUrl}</link>
-    <description>${metadata.description}</description>
+    <title>${wrapCdata(metadata.title)}</title>
+    <link>${escapeXml(siteUrl)}</link>
+    <description>${wrapCdata(metadata.description)}</description>
     <language>en-us</language>
     <generator>WilliamCallahan.com</generator>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${siteUrl}/feed.xml" rel="self" type="application/rss+xml"/>
+    <lastBuildDate>${generatedAt}</lastBuildDate>
+    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>
     ${rssItems}
   </channel>
 </rss>`;

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { getAllPostsMeta } from "@/lib/blog";
+import { getBookmarks } from "@/lib/bookmarks/bookmarks-data-access.server";
+import { metadata } from "@/data/metadata";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
+
+interface FeedItem {
+  title: string;
+  url: string;
+  date: Date;
+  description: string;
+  category: "Blog" | "Bookmark";
+}
+
+// Next.js 16 + cacheComponents means pages are dynamic by default.
+// API routes (`app/api/**/route.ts` and general Route Handlers) are exempt from `use cache`.
+// We use HTTP caching headers (Cache-Control) to cache the feed output at the CDN/Edge.
+export async function GET() {
+  const [posts, bookmarks] = await Promise.all([
+    getAllPostsMeta(false), // exclude drafts
+    getBookmarks({ skipExternalFetch: true }), // fast local/cache fetch
+  ]);
+
+  const siteUrl = metadata.site.url;
+
+  const feedItems: FeedItem[] = [
+    ...posts.map((post) => ({
+      title: post.title,
+      url: `${siteUrl}/blog/${post.slug}`,
+      date: post.publishedAt ? new Date(post.publishedAt) : new Date(),
+      description: post.excerpt || "",
+      category: "Blog" as const,
+    })),
+    ...(bookmarks as UnifiedBookmark[]).map((bookmark) => ({
+      title: bookmark.title,
+      url: `${siteUrl}/bookmarks/${bookmark.slug}`,
+      date: new Date(bookmark.dateBookmarked),
+      description: bookmark.description || bookmark.summary || "",
+      category: "Bookmark" as const,
+    })),
+  ];
+
+  // Sort chronologically newest first
+  feedItems.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  // Cap at 100 to prevent unbounded XML growth over time
+  const latestItems = feedItems.slice(0, 100);
+
+  const rssItems = latestItems
+    .map((item) => {
+      // Prepending an indicator is an idiomatic pattern for combined feeds
+      const titlePrefix = item.category === "Bookmark" ? "🔖 " : "📝 ";
+
+      return `
+    <item>
+      <title><![CDATA[${titlePrefix}${item.title}]]></title>
+      <link>${item.url}</link>
+      <guid isPermaLink="true">${item.url}</guid>
+      <pubDate>${item.date.toUTCString()}</pubDate>
+      <description><![CDATA[${item.description}]]></description>
+      <category>${item.category}</category>
+    </item>`;
+    })
+    .join("");
+
+  const rssFeed = `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${metadata.title}</title>
+    <link>${siteUrl}</link>
+    <description>${metadata.description}</description>
+    <language>en-us</language>
+    <generator>WilliamCallahan.com</generator>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${siteUrl}/feed.xml" rel="self" type="application/rss+xml"/>
+    ${rssItems}
+  </channel>
+</rss>`;
+
+  return new NextResponse(rssFeed, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,10 +81,9 @@
   }
 }
 
-/* Smooth scrolling */
+/* Scroll padding for anchor links under the sticky header */
 html {
-  scroll-behavior: smooth;
-  scroll-padding-top: 100px; /* Accounts for fixed header */
+  scroll-padding-top: 100px;
 }
 
 /* Terminal text selection */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -113,12 +113,7 @@ export const metadata: Metadata = {
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html
-      lang="en"
-      data-scroll-behavior="smooth"
-      suppressHydrationWarning
-      className={cn("scroll-smooth")}
-    >
+    <html lang="en" suppressHydrationWarning className={cn("scroll-smooth")}>
       <head>
         <meta name="darkreader-lock" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -220,7 +215,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 Theme transitions are now handled by next-themes disableTransitionOnChange. */}
             <div className="min-h-screen bg-white dark:bg-[#1a1b26] text-gray-900 dark:text-gray-100">
               <ErrorBoundary silent>
-                <header className="relative w-full bg-white/80 dark:bg-[#232530]/90 backdrop-blur-sm z-[1000]">
+                <header className="relative w-full bg-white/95 dark:bg-[#232530]/95 z-[1000]">
                   {/* overflow-visible allows nav dropdowns to extend beyond header bounds */}
                   <div className="w-full max-w-[95%] xl:max-w-[1400px] 2xl:max-w-[1800px] mx-auto px-4 py-4 flex items-center justify-between gap-4">
                     {/* Navigation should shrink if needed, but prioritize it */}

--- a/src/components/features/bookmarks/bookmark-card.client.tsx
+++ b/src/components/features/bookmarks/bookmark-card.client.tsx
@@ -80,7 +80,7 @@ export function BookmarkCardClient(props: BookmarkCardClientProps): JSX.Element 
   if (isCompact) {
     const COMPACT_TAG_LIMIT = 3;
     return (
-      <div className="relative flex h-[23rem] flex-col overflow-hidden rounded-2xl bg-white/50 shadow-xl ring-0 backdrop-blur-lg transition-all duration-200 hover:scale-[1.005] hover:shadow-2xl dark:bg-gray-800/50">
+      <div className="relative flex h-[23rem] flex-col overflow-hidden rounded-2xl bg-white shadow-xl ring-0 transition-[box-shadow,transform] duration-200 hover:scale-[1.005] hover:shadow-2xl dark:bg-gray-800">
         <div className="relative w-full aspect-video overflow-hidden rounded-t-2xl bg-gray-100 dark:bg-gray-800">
           {effectiveInternalHref ? (
             <Link
@@ -175,7 +175,7 @@ export function BookmarkCardClient(props: BookmarkCardClientProps): JSX.Element 
 
   return (
     <div
-      className={`relative flex flex-col bg-white/50 dark:bg-gray-800/50 backdrop-blur-lg ring-0 rounded-3xl overflow-hidden shadow-xl hover:shadow-2xl transform transition-all duration-200 hover:scale-[1.005] ${
+      className={`relative flex flex-col bg-white dark:bg-gray-800 ring-0 rounded-3xl overflow-hidden shadow-xl hover:shadow-2xl transition-[box-shadow,transform] duration-200 hover:scale-[1.005] ${
         isHero ? "md:shadow-2xl" : ""
       }`}
     >

--- a/src/components/features/bookmarks/bookmarks-with-pagination.client.tsx
+++ b/src/components/features/bookmarks/bookmarks-with-pagination.client.tsx
@@ -48,7 +48,6 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
   feedMode = "discover",
   internalHrefs,
 }) => {
-  const [mounted, setMounted] = useState(false);
   const [selectedTag, setSelectedTag] = useState<string | null>(initialTag || null);
   const router = useRouter();
   const pathname = usePathname();
@@ -109,7 +108,6 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
   const { trackImpression } = useEngagementTracker();
 
   useEffect(() => {
-    setMounted(true);
     if (initialPage > 1) goToPage(initialPage);
   }, [initialPage, goToPage]);
 
@@ -220,7 +218,6 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
               disabled={isRefreshing}
               className="flex-shrink-0 p-2 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               aria-label="Refresh Bookmarks"
-              style={{ visibility: mounted ? "visible" : "hidden" }}
             >
               {isRefreshing ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -248,27 +245,23 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
         </div>
       )}
 
-      {mounted && showPaginationNav && (
-        <BookmarkPaginationNav {...paginationProps} className="mb-6" />
-      )}
+      {showPaginationNav && <BookmarkPaginationNav {...paginationProps} className="mb-6" />}
 
       <div className="mb-6">
-        {mounted ? (
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-            <p className="text-gray-500 dark:text-gray-400">
-              {resultsCountText}
-              {selectedTag && ` tagged with "${selectedTag}"`}
-              {lastRefreshed && (
-                <span className="text-xs text-gray-400 dark:text-gray-500 ml-2">
-                  · refreshed {lastRefreshed.toLocaleTimeString()}
-                </span>
-              )}
-            </p>
-            {isDevelopment && <span />}
-          </div>
-        ) : (
-          <div className="h-6 w-48 bg-gray-200 dark:bg-gray-700 rounded" suppressHydrationWarning />
-        )}
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <p className="text-gray-500 dark:text-gray-400">
+            {resultsCountText}
+            {selectedTag && ` tagged with "${selectedTag}"`}
+            {lastRefreshed && (
+              <span
+                className="text-xs text-gray-400 dark:text-gray-500 ml-2"
+                suppressHydrationWarning
+              >
+                · refreshed {lastRefreshed.toLocaleTimeString()}
+              </span>
+            )}
+          </p>
+        </div>
       </div>
 
       {error && (

--- a/src/components/features/bookmarks/bookmarks-with-pagination.client.tsx
+++ b/src/components/features/bookmarks/bookmarks-with-pagination.client.tsx
@@ -48,6 +48,7 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
   feedMode = "discover",
   internalHrefs,
 }) => {
+  const [mounted, setMounted] = useState(false);
   const [selectedTag, setSelectedTag] = useState<string | null>(initialTag || null);
   const router = useRouter();
   const pathname = usePathname();
@@ -108,6 +109,9 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
   const { trackImpression } = useEngagementTracker();
 
   useEffect(() => {
+    setMounted(true);
+  }, []);
+  useEffect(() => {
     if (initialPage > 1) goToPage(initialPage);
   }, [initialPage, goToPage]);
 
@@ -158,7 +162,7 @@ export const BookmarksWithPagination: React.FC<BookmarksWithPaginationClientProp
     if (selectedTag && currentPageRef.current !== 1) goToPage(1);
   }, [selectedTag, initialPage, goToPage]);
 
-  const useUrlPagination = globalThis.window !== undefined && baseUrl !== "/bookmarks";
+  const useUrlPagination = mounted && baseUrl !== "/bookmarks";
   const showPaginationNav = !enableInfiniteScroll;
 
   const paginatedSlice = (items: UnifiedBookmark[]): UnifiedBookmark[] => {

--- a/src/components/features/bookmarks/discover-feed.client.tsx
+++ b/src/components/features/bookmarks/discover-feed.client.tsx
@@ -255,7 +255,7 @@ export function DiscoverFeed({ data }: Readonly<DiscoverFeedProps>) {
   return (
     <div className="w-full max-w-[95%] xl:max-w-[1400px] 2xl:max-w-[1800px] mx-auto px-4">
       <nav
-        className="sticky top-0 z-30 bg-background/80 backdrop-blur-sm border-b border-border -mx-4 px-4 py-2 mb-8"
+        className="sticky top-0 z-30 bg-background/95 border-b border-border -mx-4 px-4 py-2 mb-8"
         aria-label="Topic navigation"
       >
         <div className="flex items-center gap-3 mb-1.5">


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, with a focus on UI polish, performance, and new functionality. Notably, it adds a combined RSS feed for blog posts and bookmarks, refines the bookmarks UI for better hydration and style consistency, and updates project data with a new project entry and link changes. It also includes minor CSS and layout adjustments for a more consistent user experience.

**New Features:**

* Added a new combined RSS feed at `/feed.xml` that aggregates the latest 100 blog posts and bookmarks, with clear category indicators and proper HTTP caching headers. (`src/app/feed.xml/route.ts`)
* Added the "Ensemble" project to the projects list, including all metadata and tagging. (`data/projects.ts`)

**Bookmarks UI Improvements:**

* Removed unnecessary client-side mounting logic and conditional rendering in the bookmarks pagination component, improving hydration and SSR consistency. (`src/components/features/bookmarks/bookmarks-with-pagination.client.tsx`) [[1]](diffhunk://#diff-2753c3ff8a728419732b9aba840d9796fa066c1430be239e80518a95aaaf9d46L51) [[2]](diffhunk://#diff-2753c3ff8a728419732b9aba840d9796fa066c1430be239e80518a95aaaf9d46L112) [[3]](diffhunk://#diff-2753c3ff8a728419732b9aba840d9796fa066c1430be239e80518a95aaaf9d46L223) [[4]](diffhunk://#diff-2753c3ff8a728419732b9aba840d9796fa066c1430be239e80518a95aaaf9d46L251-L271)
* Updated bookmark card styles to remove glassmorphism (backdrop blur and transparency), using solid backgrounds for better visual consistency. (`src/components/features/bookmarks/bookmark-card.client.tsx`) [[1]](diffhunk://#diff-924fc6128acc5a9ee79138ba90dd3418665095a62e18231875ff8ccf86fb32a2L83-R83) [[2]](diffhunk://#diff-924fc6128acc5a9ee79138ba90dd3418665095a62e18231875ff8ccf86fb32a2L178-R178)

**UI and Layout Adjustments:**

* Made sticky headers and navigation bars more opaque for improved readability and consistency. (`src/app/layout.tsx`, `src/components/features/bookmarks/discover-feed.client.tsx`) [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L223-R218) [[2]](diffhunk://#diff-8d337900069ae63f475bec87a0adf613bb0678c20cf8efa5bde7bc7324393402L258-R258)
* Adjusted scroll padding and removed redundant smooth-scrolling styles for anchor link accuracy under the sticky header. (`src/app/globals.css`, `src/app/layout.tsx`) [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L84-R86) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L116-R116)

**Project Data Updates:**

* Updated the "Researchly" project URL to `https://researchly.chat` and removed the GitHub link. (`data/projects.ts`)
* Updated the `updatedAt` date in the projects data to reflect recent changes. (`data/projects.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public `GET /feed.xml` route and adjusts client-side pagination/hydration behavior for bookmarks, which could impact caching/output correctness and navigation state. Other changes are largely styling and test/mock updates with low blast radius.
> 
> **Overview**
> Adds a new combined RSS endpoint at `GET /feed.xml` that aggregates blog posts and bookmarks, **bounds output to 100 items**, sorts newest-first, skips invalid dates, escapes XML/CDATA edge cases, and sets CDN-friendly `Cache-Control` headers.
> 
> Updates tests and Next.js mocks to support stream-backed `NextResponse` bodies, and extends coverage to validate RSS escaping/date-skipping behavior.
> 
> Refines bookmarks UI behavior and styling: simplifies hydration gating in `BookmarksWithPagination` (URL pagination only), removes glassmorphism/backdrop blur from bookmark cards, and increases sticky header/nav opacity for readability. Also updates projects data (new “Ensemble” entry, Researchly URL change, updated timestamp) and runs Next.js `typegen` as part of `type-check`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc3bd9076ba4edef61627f4cd61b275ed2c5155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a combined RSS feed at `/feed.xml`, refines the bookmarks UI (drops glassmorphism, reduces hydration mismatch), updates project data, and improves the test infrastructure. Both issues flagged in the prior review round (unsafe `getBookmarks` type assertion and raw-interpolated channel-level XML fields) are fully resolved — the route now uses `getBookmarksPage(1, 100)` with confirmed `DESC` ordering and `wrapCdata`/`escapeXml` throughout.

The one remaining gap is RSS autodiscovery: the `/feed.xml` endpoint is live but no `alternates.types` entry was added to the root layout metadata, so browsers and feed readers can't auto-detect it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previous blocking concerns addressed; only a P2 autodiscovery enhancement remains.

Both prior P1 findings (type assertion, channel-level XML escaping) are resolved. The only remaining finding is a P2 RSS autodiscovery omission that doesn't affect correctness or security. Test coverage for the new route is solid.

src/app/layout.tsx — missing `alternates.types` RSS autodiscovery entry

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/feed.xml/route.ts | New RSS route combining blog posts and bookmarks; previous concerns (type assertion, channel CDATA escaping) addressed; uses bounded `getBookmarksPage(1, 100)` with DESC ordering confirmed in DB layer |
| __tests__/__mocks__/next/server.ts | Adds `text()`, `json()`, `blob()`, and `arrayBuffer()` body readers to the mock; removes the old instance-level `json?` optional property; correctly handles both string and ReadableStream bodies |
| __tests__/api/bookmarks-feed.test.ts | New RSS feed tests cover CDATA escaping (including `]]>` splitting), bounded page query, invalid-date skipping, and bookmark feed modes — well-structured and comprehensive |
| src/components/features/bookmarks/bookmarks-with-pagination.client.tsx | Trims mounted-state gating to only guard `useUrlPagination`; adds `suppressHydrationWarning` on the timestamp span; SSR-safe tag pagination restored |
| src/app/layout.tsx | Header opacity raised to 95%; new RSS feed at `/feed.xml` added but no `alternates.types` RSS autodiscovery added to the metadata export |
| src/app/globals.css | Adds `scroll-padding-top: 100px` on `html` for sticky-header anchor accuracy; clean minimal change |
| data/projects.ts | Adds Ensemble project entry; updates Researchly URL and removes GitHub link; bumps `updatedAt` |
| __tests__/app/bookmarks/page/page-number.test.tsx | Mocks updated to target `discover-feed-wrapper.server` instead of the client component, matching current data-access paths |
| __tests__/lib/content-graph.test.ts | Mock paths updated to current bookmark data-access modules; no logic changes |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Feed Reader / Browser
    participant CDN as CDN/Edge
    participant Route as /feed.xml route
    participant DB as Bookmarks DB
    participant Blog as Blog FS

    Client->>CDN: GET /feed.xml
    alt Cache hit (s-maxage=3600)
        CDN-->>Client: 200 application/rss+xml (cached)
    else Cache miss / stale
        CDN->>Route: GET /feed.xml
        Route->>DB: getBookmarksPage(1, 100) [DESC dateBookmarked]
        Route->>Blog: getAllPostsMeta(false)
        DB-->>Route: up to 100 newest bookmarks
        Blog-->>Route: all published posts
        Route->>Route: merge, sort by date DESC, slice(0, 100)
        Route->>Route: escapeXml / wrapCdata XML serialisation
        Route-->>CDN: 200 RSS XML + Cache-Control: s-maxage=3600, swr=86400
        CDN-->>Client: 200 application/rss+xml
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fapp%2Flayout.tsx%3A101-105%0A**RSS%20feed%20autodiscovery%20not%20wired%20up**%0A%0AThe%20new%20%60%2Ffeed.xml%60%20route%20exists%20but%20no%20%60%3Clink%20rel%3D%22alternate%22%20type%3D%22application%2Frss%2Bxml%22%3E%60%20is%20injected%20into%20the%20page%20%60%3Chead%3E%60.%20Without%20this%2C%20browsers%20and%20feed%20aggregators%20that%20rely%20on%20autodiscovery%20%28e.g.%20Feedly%2C%20NetNewsWire%29%20won't%20find%20the%20feed%20when%20a%20user%20visits%20the%20site.%20The%20Next.js%20metadata%20API%20supports%20this%20natively%20via%20%60alternates.types%60%3A%0A%0A%60%60%60ts%0Aalternates%3A%20%7B%0A%20%20types%3A%20%7B%0A%20%20%20%20%22application%2Frss%2Bxml%22%3A%20%5B%7B%20url%3A%20%22%2Ffeed.xml%22%2C%20title%3A%20%22William%20Callahan%20%E2%80%93%20RSS%20Feed%22%20%7D%5D%2C%0A%20%20%7D%2C%0A%20%20...%28process.env.NODE_ENV%20%3D%3D%3D%20%22production%22%20%26%26%20%7B%0A%20%20%20%20canonical%3A%20%22https%3A%2F%2Fwilliamcallahan.com%22%2C%0A%20%20%7D%29%2C%0A%7D%2C%0A%60%60%60%0A%0A&repo=williamagh%2Fwilliamcallahan.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fapp%2Flayout.tsx%3A101-105%0A**RSS%20feed%20autodiscovery%20not%20wired%20up**%0A%0AThe%20new%20%60%2Ffeed.xml%60%20route%20exists%20but%20no%20%60%3Clink%20rel%3D%22alternate%22%20type%3D%22application%2Frss%2Bxml%22%3E%60%20is%20injected%20into%20the%20page%20%60%3Chead%3E%60.%20Without%20this%2C%20browsers%20and%20feed%20aggregators%20that%20rely%20on%20autodiscovery%20%28e.g.%20Feedly%2C%20NetNewsWire%29%20won't%20find%20the%20feed%20when%20a%20user%20visits%20the%20site.%20The%20Next.js%20metadata%20API%20supports%20this%20natively%20via%20%60alternates.types%60%3A%0A%0A%60%60%60ts%0Aalternates%3A%20%7B%0A%20%20types%3A%20%7B%0A%20%20%20%20%22application%2Frss%2Bxml%22%3A%20%5B%7B%20url%3A%20%22%2Ffeed.xml%22%2C%20title%3A%20%22William%20Callahan%20%E2%80%93%20RSS%20Feed%22%20%7D%5D%2C%0A%20%20%7D%2C%0A%20%20...%28process.env.NODE_ENV%20%3D%3D%3D%20%22production%22%20%26%26%20%7B%0A%20%20%20%20canonical%3A%20%22https%3A%2F%2Fwilliamcallahan.com%22%2C%0A%20%20%7D%29%2C%0A%7D%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Fwilliamcallahan.com%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fapp%2Flayout.tsx%3A101-105%0A**RSS%20feed%20autodiscovery%20not%20wired%20up**%0A%0AThe%20new%20%60%2Ffeed.xml%60%20route%20exists%20but%20no%20%60%3Clink%20rel%3D%22alternate%22%20type%3D%22application%2Frss%2Bxml%22%3E%60%20is%20injected%20into%20the%20page%20%60%3Chead%3E%60.%20Without%20this%2C%20browsers%20and%20feed%20aggregators%20that%20rely%20on%20autodiscovery%20%28e.g.%20Feedly%2C%20NetNewsWire%29%20won't%20find%20the%20feed%20when%20a%20user%20visits%20the%20site.%20The%20Next.js%20metadata%20API%20supports%20this%20natively%20via%20%60alternates.types%60%3A%0A%0A%60%60%60ts%0Aalternates%3A%20%7B%0A%20%20types%3A%20%7B%0A%20%20%20%20%22application%2Frss%2Bxml%22%3A%20%5B%7B%20url%3A%20%22%2Ffeed.xml%22%2C%20title%3A%20%22William%20Callahan%20%E2%80%93%20RSS%20Feed%22%20%7D%5D%2C%0A%20%20%7D%2C%0A%20%20...%28process.env.NODE_ENV%20%3D%3D%3D%20%22production%22%20%26%26%20%7B%0A%20%20%20%20canonical%3A%20%22https%3A%2F%2Fwilliamcallahan.com%22%2C%0A%20%20%7D%29%2C%0A%7D%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/layout.tsx
Line: 101-105

Comment:
**RSS feed autodiscovery not wired up**

The new `/feed.xml` route exists but no `<link rel="alternate" type="application/rss+xml">` is injected into the page `<head>`. Without this, browsers and feed aggregators that rely on autodiscovery (e.g. Feedly, NetNewsWire) won't find the feed when a user visits the site. The Next.js metadata API supports this natively via `alternates.types`:

```ts
alternates: {
  types: {
    "application/rss+xml": [{ url: "/feed.xml", title: "William Callahan – RSS Feed" }],
  },
  ...(process.env.NODE_ENV === "production" && {
    canonical: "https://williamcallahan.com",
  }),
},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["test(types): tighten bookmark test fixtu..."](https://github.com/williamagh/williamcallahan.com/commit/abc3bd9076ba4edef61627f4cd61b275ed2c5155) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28099128)</sub>

<!-- /greptile_comment -->