### PR TITLE
feat(ai-gateway): per-call X-Tier classification, single-embed RAG fan-out, and expanded Sentry client-noise filter

### DIFF
--- a/__tests__/lib/ai-openai-compatible.test.ts
+++ b/__tests__/lib/ai-openai-compatible.test.ts
@@ -386,6 +386,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       await callOpenAiCompatibleChatCompletions({
         baseUrl: "https://example.com",
         apiKey: "test-key",
+        tier: "production-a",
         request: {
           model: "test-model",
           messages: [{ role: "user", content: "hi" }],
@@ -396,11 +397,13 @@ describe("OpenAI-Compatible AI Utilities", () => {
         },
       });
       const payload = mockCreate.mock.calls[0]?.[0];
+      const requestOptions = mockCreate.mock.calls[0]?.[1];
       expect(payload.max_completion_tokens).toBe(8192);
       expect(payload.max_tokens).toBeUndefined();
       expect(payload.top_p).toBe(0.9);
       expect(payload.reasoning_effort).toBe("medium");
       expect(payload.temperature).toBe(1);
+      expect(requestOptions?.headers?.["X-Tier"]).toBe("production-a");
     });
 
     it("omits undefined optional fields from chat request", async () => {
@@ -419,6 +422,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       await callOpenAiCompatibleChatCompletions({
         baseUrl: "https://example.com",
         apiKey: "test-key",
+        tier: "production-a",
         request: { model: "test-model", messages: [{ role: "user", content: "hi" }] },
       });
       const payload = mockCreate.mock.calls[0]?.[0];
@@ -455,6 +459,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       const response = await callOpenAiCompatibleChatCompletions({
         baseUrl: "https://example.com",
         apiKey: "test-key",
+        tier: "production-a",
         request: {
           model: "test-model",
           messages: [{ role: "user", content: "hello" }],
@@ -486,6 +491,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       await callOpenAiCompatibleResponses({
         baseUrl: "https://example.com",
         apiKey: "test-key",
+        tier: "production-a",
         request: {
           model: "test-model",
           input: [
@@ -539,6 +545,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       const response = await callOpenAiCompatibleResponses({
         baseUrl: "https://example.com",
         apiKey: "test-key",
+        tier: "production-a",
         request: {
           model: "test-model",
           input: [{ role: "user", content: "hello" }],
@@ -577,6 +584,7 @@ describe("OpenAI-Compatible AI Utilities", () => {
       const response = await streamOpenAiCompatibleChatCompletions({
         baseUrl: "https://example.net",
         apiKey: "test-key",
+        tier: "production-a",
         request: {
           model: "test-model",
           messages: [{ role: "user", content: "hello" }],

--- a/__tests__/lib/ai/rag/dynamic-retriever.test.ts
+++ b/__tests__/lib/ai/rag/dynamic-retriever.test.ts
@@ -6,6 +6,15 @@
  */
 
 import { retrieveRelevantContent } from "@/lib/ai/rag/dynamic-retriever";
+import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
+import { searchBookmarks, searchBooks } from "@/lib/search/searchers/dynamic-searchers";
+import { searchInvestments, searchProjects } from "@/lib/search/searchers/static-searchers";
+
+// Mock buildQueryEmbedding so tests never hit the embedding endpoint and we can
+// assert it's invoked exactly once per retrieval (the fan-out dedup guarantee).
+vi.mock("@/lib/db/queries/query-embedding", () => ({
+  buildQueryEmbedding: vi.fn().mockResolvedValue(Array.from({ length: 2560 }, () => 0.1)),
+}));
 
 // Mock all search functions
 vi.mock("@/lib/search/searchers/static-searchers", () => ({
@@ -257,6 +266,27 @@ describe("RAG Dynamic Retriever", () => {
 
       expect(status).toBe("success");
       expect(results.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("query embedding dedup", () => {
+    it("embeds the query once and threads the same vector to every searcher", async () => {
+      await retrieveRelevantContent("projects invest bookmarks books");
+
+      // The retriever must embed the query exactly once, not once per detected scope.
+      expect(buildQueryEmbedding).toHaveBeenCalledTimes(1);
+
+      const sharedVector = await (buildQueryEmbedding as unknown as ReturnType<typeof vi.fn>).mock
+        .results[0]?.value;
+
+      // Each scope searcher that uses hybrid embeddings must receive a context
+      // carrying the same precomputed vector (identity-compared, not recomputed).
+      for (const searcher of [searchProjects, searchInvestments, searchBookmarks, searchBooks]) {
+        expect(searcher).toHaveBeenCalled();
+        const [, context] = (searcher as unknown as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+        expect(context).toBeDefined();
+        expect(context?.precomputed).toBe(sharedVector);
+      }
     });
   });
 });

--- a/__tests__/lib/instrumentation-client.test.ts
+++ b/__tests__/lib/instrumentation-client.test.ts
@@ -3,9 +3,19 @@
  */
 
 describe("shouldFilterError", () => {
-  it("filters known browser extension errors", async () => {
+  it("filters known client-side noise", async () => {
     const { shouldFilterError } = await import("@/instrumentation-client");
-    expect(shouldFilterError("chrome-extension:// runtime.sendMessage failed")).toBe(true);
+    const filteredMessages = [
+      "chrome-extension:// runtime.sendMessage failed",
+      "Event `Event` (type=error) captured as promise rejection",
+      "Error: feature named `pageContext` was not found",
+      "Error: The WKWebView was deallocated before the message was delivered",
+      "ReportingObserver [deprecation]: The Shared Storage API is deprecated",
+    ];
+
+    for (const message of filteredMessages) {
+      expect(shouldFilterError(message)).toBe(true);
+    }
   });
 
   it("returns false for non-string values without throwing", async () => {

--- a/scripts/backfill-bookmark-embeddings.node.mjs
+++ b/scripts/backfill-bookmark-embeddings.node.mjs
@@ -226,6 +226,7 @@ async function embedTextsWithEndpointCompatibleModel(args) {
     headers: {
       Authorization: `Bearer ${args.apiKey}`,
       "Content-Type": "application/json",
+      "X-Tier": "batch",
     },
     body: JSON.stringify({ model: args.model, input: args.input }),
     signal,

--- a/scripts/backfill-domain-embeddings.node.mjs
+++ b/scripts/backfill-domain-embeddings.node.mjs
@@ -75,7 +75,11 @@ function buildApiBaseUrl(baseUrl) {
 async function embedTexts(apiBaseUrl, apiKey, model, input, timeoutMs) {
   const res = await fetch(`${apiBaseUrl}/embeddings`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "X-Tier": "batch",
+    },
     body: JSON.stringify({ model, input }),
     signal: AbortSignal.timeout(timeoutMs),
   });

--- a/src/app/api/ai/chat/[feature]/upstream-turn.ts
+++ b/src/app/api/ai/chat/[feature]/upstream-turn.ts
@@ -56,7 +56,13 @@ export async function executeChatCompletionsTurn(
     ...(params.reasoningEffort == null ? {} : { reasoning_effort: params.reasoningEffort }),
     ...(params.responseFormat ? { response_format: params.responseFormat } : {}),
   };
-  const callArgs = { baseUrl: turnConfig.baseUrl, apiKey: turnConfig.apiKey, request, signal };
+  const callArgs = {
+    baseUrl: turnConfig.baseUrl,
+    apiKey: turnConfig.apiKey,
+    request,
+    signal,
+    tier: "production-a" as const,
+  };
 
   let startMeta: { id: string; model: string } | null = null;
   let emittedStartEvent = false;
@@ -161,7 +167,13 @@ export async function executeResponsesTurn(
     ...(params.reasoningEffort == null ? {} : { reasoning: { effort: params.reasoningEffort } }),
   };
 
-  const callArgs = { baseUrl: turnConfig.baseUrl, apiKey: turnConfig.apiKey, request, signal };
+  const callArgs = {
+    baseUrl: turnConfig.baseUrl,
+    apiKey: turnConfig.apiKey,
+    request,
+    signal,
+    tier: "production-a" as const,
+  };
 
   let startMeta: { id: string; model: string } | null = null;
   let emittedStartEvent = false;

--- a/src/app/api/search/bookmarks/route.ts
+++ b/src/app/api/search/bookmarks/route.ts
@@ -101,6 +101,7 @@ async function tryHybridSearch(query: string): Promise<BookmarkFtsSearchHit[] | 
         const vectors = await embClient.embedTextsWithEndpointCompatibleModel({
           config,
           input: [query],
+          tier: "production-z",
           timeoutMs: 1_500,
         });
         const vec = vectors[0];

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,16 +7,12 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-/**
- * Common browser extension error patterns to filter from error reporting
- * Prevents unnecessary noise from extension conflicts
- */
 const NON_CRITICAL_ERROR_PATTERNS = [
   'can\'t redefine non-configurable property "ethereum"',
   "Load failed",
 ];
 
-const BROWSER_EXTENSION_ERROR_PATTERNS = [
+const CLIENT_NOISE_ERROR_PATTERNS = [
   "runtime.sendMessage",
   "Tab not found",
   "chrome.runtime",
@@ -26,11 +22,15 @@ const BROWSER_EXTENSION_ERROR_PATTERNS = [
   "chrome-extension://",
   "script error",
   "Non-Error promise rejection captured",
+  "Event `Event` (type=error) captured as promise rejection",
+  "feature named `pageContext` was not found",
+  "The WKWebView was deallocated before the message was delivered",
+  "ReportingObserver [deprecation]",
   ...NON_CRITICAL_ERROR_PATTERNS,
 ];
 
 /**
- * Determines if an error should be filtered out based on browser extension patterns
+ * Determines if an error should be filtered out based on non-actionable client noise
  * @param errorMessage - The error message to check
  * @returns true if the error should be filtered out, false otherwise
  */
@@ -39,8 +39,7 @@ export function shouldFilterError(errorMessage: unknown): boolean {
     return false;
   }
   const normalizedMessage = errorMessage.toLowerCase();
-  // Check for known browser extension error patterns
-  for (const pattern of BROWSER_EXTENSION_ERROR_PATTERNS) {
+  for (const pattern of CLIENT_NOISE_ERROR_PATTERNS) {
     if (normalizedMessage.includes(pattern.toLowerCase())) {
       return true;
     }
@@ -108,10 +107,9 @@ if (process.env.NODE_ENV === "production") {
         enableLongAnimationFrame: true, // Long animation frame detection
       }),
 
-      // Capture browser deprecation warnings and interventions
-      // Helps identify compatibility issues before they become problems
+      // Capture actionable browser reports without filing non-actionable deprecation noise
       Sentry.reportingObserverIntegration({
-        types: ["crash", "deprecation", "intervention"],
+        types: ["crash", "intervention"],
       }),
     ],
 
@@ -123,10 +121,17 @@ if (process.env.NODE_ENV === "production") {
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
 
-    // Filter out browser extension errors
+    ignoreErrors: CLIENT_NOISE_ERROR_PATTERNS,
+
+    // Filter out known browser and WebView noise before events are sent
     beforeSend(event) {
-      const errorMessage = event.exception?.values?.[0]?.value || "";
-      return shouldFilterError(errorMessage) ? null : event;
+      const exceptionValues = event.exception?.values;
+      const exceptionMessages = exceptionValues
+        ? exceptionValues.flatMap(({ type, value }) => [type, value])
+        : [];
+      const messages = [event.message, ...exceptionMessages];
+
+      return messages.some(shouldFilterError) ? null : event;
     },
   });
 }

--- a/src/lib/ai/openai-compatible/embeddings-client.ts
+++ b/src/lib/ai/openai-compatible/embeddings-client.ts
@@ -3,13 +3,17 @@ import {
   endpointCompatibleEmbeddingsResponseSchema,
 } from "@/types/schemas/ai-openai-compatible";
 import { buildOpenAiApiBaseUrl } from "@/lib/ai/openai-compatible/feature-config";
-import type { EndpointCompatibleEmbeddingConfig } from "@/types/schemas/ai-openai-compatible";
+import type {
+  EndpointCompatibleEmbeddingConfig,
+  OpenAiCompatibleTier,
+} from "@/types/schemas/ai-openai-compatible";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export async function embedTextsWithEndpointCompatibleModel(args: {
   config: EndpointCompatibleEmbeddingConfig;
   input: string[];
+  tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<number[][]> {
@@ -36,6 +40,7 @@ export async function embedTextsWithEndpointCompatibleModel(args: {
     headers: {
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
+      "X-Tier": args.tier,
     },
     body: JSON.stringify(request),
     signal: requestSignal,

--- a/src/lib/ai/openai-compatible/openai-compatible-client.ts
+++ b/src/lib/ai/openai-compatible/openai-compatible-client.ts
@@ -17,6 +17,7 @@ import {
   type OpenAiCompatibleChatCompletionsResponse,
   type OpenAiCompatibleResponsesRequest,
   type OpenAiCompatibleResponsesResponse,
+  type OpenAiCompatibleTier,
   openAiCompatibleChatCompletionsRequestSchema,
   openAiCompatibleChatCompletionsResponseSchema,
   openAiCompatibleResponsesRequestSchema,
@@ -137,6 +138,7 @@ export async function callOpenAiCompatibleChatCompletions(args: {
   baseUrl: string;
   apiKey?: string;
   request: OpenAiCompatibleChatCompletionsRequest;
+  tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<OpenAiCompatibleChatCompletionsResponse> {
@@ -153,6 +155,7 @@ export async function streamOpenAiCompatibleChatCompletions(args: {
   baseUrl: string;
   apiKey?: string;
   request: OpenAiCompatibleChatCompletionsRequest;
+  tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
   onStart?: (meta: { id: string; model: string }) => void;
@@ -227,6 +230,7 @@ export async function callOpenAiCompatibleResponses(args: {
   request: Omit<ResponseCreateParamsNonStreaming, "input"> & {
     input: OpenAiCompatibleResponsesRequest["input"];
   };
+  tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<OpenAiCompatibleResponsesResponse> {
@@ -249,6 +253,7 @@ export async function streamOpenAiCompatibleResponses(args: {
   request: Omit<ResponseCreateParamsNonStreaming, "input"> & {
     input: OpenAiCompatibleResponsesRequest["input"];
   };
+  tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
   onStart?: (meta: { id: string; model: string }) => void;

--- a/src/lib/ai/openai-compatible/openai-compatible-message-mapper.ts
+++ b/src/lib/ai/openai-compatible/openai-compatible-message-mapper.ts
@@ -14,6 +14,7 @@ import type { EasyInputMessage, ResponseInput } from "openai/resources/responses
 import type {
   OpenAiCompatibleChatCompletionsRequest,
   OpenAiCompatibleResponsesRequest,
+  OpenAiCompatibleTier,
 } from "@/types/schemas/ai-openai-compatible";
 
 const NON_REASONING_MODEL_PREFIXES = ["gpt-3.5", "gpt-4"] as const;
@@ -129,8 +130,11 @@ export function toChatRequest(
 export function toRequestOptions(args: {
   timeoutMs?: number;
   signal?: AbortSignal;
+  tier: OpenAiCompatibleTier;
 }): OpenAIClient.RequestOptions {
-  const options: OpenAIClient.RequestOptions = {};
+  const options: OpenAIClient.RequestOptions = {
+    headers: { "X-Tier": args.tier },
+  };
   if (typeof args.timeoutMs === "number") options.timeout = args.timeoutMs;
   if (args.signal) options.signal = args.signal;
   return options;

--- a/src/lib/ai/rag/dynamic-retriever.ts
+++ b/src/lib/ai/rag/dynamic-retriever.ts
@@ -25,6 +25,9 @@ import { searchBooks, searchBookmarks } from "@/lib/search/searchers/dynamic-sea
 import { searchTags } from "@/lib/search/searchers/tag-search";
 import { searchAiAnalysis } from "@/lib/search/searchers/ai-analysis-searcher";
 import { searchThoughts } from "@/lib/search/searchers/thoughts-search";
+import type { QueryEmbeddingContext } from "@/types/search";
+import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
+import { sanitizeSearchQuery } from "@/lib/validators/search";
 import logger from "@/lib/utils/logger";
 
 /**
@@ -124,6 +127,14 @@ export async function retrieveRelevantContent(
     logger.info("[RAG] No scope keywords detected; using fallback scopes", { scopes, query });
   }
 
+  // Embed once per retrieval so concurrent scope searchers share the vector
+  // instead of each hitting the embedding endpoint in parallel.
+  const sanitizedQuery = sanitizeSearchQuery(query);
+  const precomputed = sanitizedQuery
+    ? await buildQueryEmbedding(sanitizedQuery, "[RAG]")
+    : undefined;
+  const embeddingContext: QueryEmbeddingContext = { precomputed };
+
   // Track failed scopes for caller awareness
   const failedScopes: string[] = [];
 
@@ -137,7 +148,7 @@ export async function retrieveRelevantContent(
     }
 
     try {
-      const results = await withScopeTimeout(searcher(query), timeoutMs, scope);
+      const results = await withScopeTimeout(searcher(query, embeddingContext), timeoutMs, scope);
       return results.slice(0, Math.ceil(maxResults / scopes.length)).map(
         (r): DynamicResult => ({
           scope,

--- a/src/lib/blog/server-search.ts
+++ b/src/lib/blog/server-search.ts
@@ -8,6 +8,7 @@ import { assertServerOnly } from "../utils/ensure-server-only";
 assertServerOnly();
 
 import type { SearchResult } from "@/types/schemas/search";
+import type { QueryEmbeddingContext } from "@/types/search";
 import { sanitizeSearchQuery } from "../validators/search";
 import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
 import { hybridSearchBlogPosts } from "@/lib/db/queries/hybrid-search-books-blog";
@@ -18,11 +19,14 @@ const SEARCH_LIMIT = 50;
  * Search blog posts via hybrid PostgreSQL search.
  * Results sorted by hybrid score desc, then recency as tiebreaker.
  */
-export async function searchBlogPostsServerSide(query: string): Promise<SearchResult[]> {
+export async function searchBlogPostsServerSide(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBlogPosts]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBlogPosts]", context);
   const rows = await hybridSearchBlogPosts({
     query: sanitizedQuery,
     embedding,

--- a/src/lib/db/mutations/bookmark-embeddings.ts
+++ b/src/lib/db/mutations/bookmark-embeddings.ts
@@ -222,6 +222,7 @@ export async function backfillBookmarkEmbeddings(
     const embeddings = await embedTextsWithEndpointCompatibleModel({
       config,
       input: embeddingInput,
+      tier: "batch",
     });
     if (embeddings.length !== rows.length) {
       throw new Error(

--- a/src/lib/db/mutations/investment-embeddings.ts
+++ b/src/lib/db/mutations/investment-embeddings.ts
@@ -145,7 +145,11 @@ export async function backfillInvestmentEmbeddings(
     if (rows.length === 0) break;
 
     const inputs = rows.map(buildInvestmentEmbeddingInput);
-    const embeddings = await embedTextsWithEndpointCompatibleModel({ config, input: inputs });
+    const embeddings = await embedTextsWithEndpointCompatibleModel({
+      config,
+      input: inputs,
+      tier: "batch",
+    });
     if (embeddings.length !== rows.length) {
       throw new Error(
         `Embedding count mismatch. Expected ${rows.length}, received ${embeddings.length}.`,

--- a/src/lib/db/queries/query-embedding.ts
+++ b/src/lib/db/queries/query-embedding.ts
@@ -43,6 +43,7 @@ export async function buildQueryEmbedding(
     const vectors = await embedTextsWithEndpointCompatibleModel({
       config: embeddingConfig,
       input: [query],
+      tier: "production-z",
       timeoutMs: QUERY_EMBEDDING_TIMEOUT_MS,
     });
     const vector = vectors[0];

--- a/src/lib/db/queries/query-embedding.ts
+++ b/src/lib/db/queries/query-embedding.ts
@@ -8,6 +8,7 @@
  * @module db/queries/query-embedding
  */
 
+import type { QueryEmbeddingContext } from "@/types/search";
 import { CONTENT_EMBEDDING_DIMENSIONS } from "@/lib/db/schema/content-embeddings";
 import { embedTextsWithEndpointCompatibleModel } from "@/lib/ai/openai-compatible/embeddings-client";
 import { resolveDefaultEndpointCompatibleEmbeddingConfig } from "@/lib/ai/openai-compatible/feature-config";
@@ -20,11 +21,19 @@ const QUERY_EMBEDDING_TIMEOUT_MS = 1_500;
  *
  * Returns undefined (not throws) on failure so hybrid search
  * gracefully falls back to FTS-only.
+ *
+ * When `context.precomputed` is supplied and has the correct dimensionality,
+ * it is returned directly — no HTTP call is made.
  */
 export async function buildQueryEmbedding(
   query: string,
   logContext: string,
+  context?: QueryEmbeddingContext,
 ): Promise<number[] | undefined> {
+  if (context?.precomputed && context.precomputed.length === CONTENT_EMBEDDING_DIMENSIONS) {
+    return context.precomputed;
+  }
+
   const embeddingConfig = resolveDefaultEndpointCompatibleEmbeddingConfig();
   if (!embeddingConfig) {
     return undefined;

--- a/src/lib/db/queries/query-embedding.ts
+++ b/src/lib/db/queries/query-embedding.ts
@@ -30,11 +30,31 @@ export async function buildQueryEmbedding(
   logContext: string,
   context?: QueryEmbeddingContext,
 ): Promise<number[] | undefined> {
-  if (context?.precomputed && context.precomputed.length === CONTENT_EMBEDDING_DIMENSIONS) {
-    return context.precomputed;
+  if (context?.precomputed) {
+    if (context.precomputed.length === CONTENT_EMBEDDING_DIMENSIONS) {
+      return context.precomputed;
+    }
+    envLogger.log(
+      `${logContext} precomputed query embedding has wrong dimensionality; re-embedding`,
+      {
+        received: context.precomputed.length,
+        expected: CONTENT_EMBEDDING_DIMENSIONS,
+      },
+      { category: "Search" },
+    );
   }
 
-  const embeddingConfig = resolveDefaultEndpointCompatibleEmbeddingConfig();
+  let embeddingConfig: ReturnType<typeof resolveDefaultEndpointCompatibleEmbeddingConfig> = null;
+  try {
+    embeddingConfig = resolveDefaultEndpointCompatibleEmbeddingConfig();
+  } catch (error) {
+    envLogger.log(
+      `${logContext} embedding config unavailable; continuing with keyword-only search`,
+      { error: error instanceof Error ? error.message : String(error) },
+      { category: "Search" },
+    );
+    // RC1a: error logged; null signals FTS-only fallback
+  }
   if (!embeddingConfig) {
     return undefined;
   }

--- a/src/lib/search/search-content.ts
+++ b/src/lib/search/search-content.ts
@@ -178,6 +178,8 @@ export async function rerankScoredResultsWithEmbeddings<T>(options: {
   timeoutMs?: number;
   keywordWeight?: number;
   vectorWeight?: number;
+  /** Precomputed query vector to skip embedding the query in the batched call. */
+  queryEmbedding?: number[] | undefined;
 }): Promise<ScoredResult<T>[]> {
   const sanitizedQuery = sanitizeSearchQuery(options.query);
   if (!sanitizedQuery) {
@@ -200,20 +202,26 @@ export async function rerankScoredResultsWithEmbeddings<T>(options: {
     return options.scoredResults;
   }
 
+  const precomputedQueryVector = options.queryEmbedding;
+  const batchInput = precomputedQueryVector ? texts : [sanitizedQuery, ...texts];
+
   try {
     const vectors = await embedTextsWithEndpointCompatibleModel({
       config: embeddingConfig,
-      input: [sanitizedQuery, ...texts],
+      input: batchInput,
       timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     });
-    const queryVector = vectors[0];
+    const queryVector = precomputedQueryVector ?? vectors[0];
     if (!queryVector) {
       return options.scoredResults;
     }
+    const candidateVectorOffset = precomputedQueryVector ? 0 : 1;
 
     const keywordScores = normalizeScores(candidates.map((candidate) => candidate.score));
     const vectorScores = normalizeScores(
-      candidates.map((_, index) => cosineSimilarity(queryVector, vectors[index + 1] ?? [])),
+      candidates.map((_, index) =>
+        cosineSimilarity(queryVector, vectors[index + candidateVectorOffset] ?? []),
+      ),
     );
 
     const keywordWeight = options.keywordWeight ?? DEFAULT_KEYWORD_WEIGHT;

--- a/src/lib/search/search-content.ts
+++ b/src/lib/search/search-content.ts
@@ -179,7 +179,7 @@ export async function rerankScoredResultsWithEmbeddings<T>(options: {
   keywordWeight?: number;
   vectorWeight?: number;
   /** Precomputed query vector to skip embedding the query in the batched call. */
-  queryEmbedding?: number[] | undefined;
+  queryEmbedding?: number[];
 }): Promise<ScoredResult<T>[]> {
   const sanitizedQuery = sanitizeSearchQuery(options.query);
   if (!sanitizedQuery) {

--- a/src/lib/search/search-content.ts
+++ b/src/lib/search/search-content.ts
@@ -209,6 +209,7 @@ export async function rerankScoredResultsWithEmbeddings<T>(options: {
     const vectors = await embedTextsWithEndpointCompatibleModel({
       config: embeddingConfig,
       input: batchInput,
+      tier: "production-z",
       timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     });
     const queryVector = precomputedQueryVector ?? vectors[0];

--- a/src/lib/search/search-factory.ts
+++ b/src/lib/search/search-factory.ts
@@ -8,7 +8,7 @@
  */
 
 import type { SearchResult } from "@/types/schemas/search";
-import type { SearchFunctionConfig } from "@/types/search";
+import type { QueryEmbeddingContext, SearchFunctionConfig } from "@/types/search";
 import { rerankScoredResultsWithEmbeddings, searchContent } from "./search-content";
 
 /**
@@ -17,6 +17,7 @@ import { rerankScoredResultsWithEmbeddings, searchContent } from "./search-conte
 async function executeSearch<TDoc, TResult extends SearchResult>(
   config: SearchFunctionConfig<TDoc, TResult>,
   query: string,
+  context?: QueryEmbeddingContext,
 ): Promise<TResult[]> {
   const index = await config.getIndex();
   const items = await Promise.resolve(config.getItems());
@@ -38,6 +39,7 @@ async function executeSearch<TDoc, TResult extends SearchResult>(
         keywordWeight: config.hybridRerank.keywordWeight,
         vectorWeight: config.hybridRerank.vectorWeight,
         logContext: `[search-factory:${config.cacheKey}]`,
+        queryEmbedding: context?.precomputed,
       })
     : scoredResults;
 
@@ -81,8 +83,8 @@ async function executeSearch<TDoc, TResult extends SearchResult>(
  */
 export function createCachedSearchFunction<TDoc, TResult extends SearchResult>(
   config: SearchFunctionConfig<TDoc, TResult>,
-): (query: string) => Promise<TResult[]> {
-  return async (query: string): Promise<TResult[]> => {
-    return executeSearch(config, query);
+): (query: string, context?: QueryEmbeddingContext) => Promise<TResult[]> {
+  return async (query: string, context?: QueryEmbeddingContext): Promise<TResult[]> => {
+    return executeSearch(config, query, context);
   };
 }

--- a/src/lib/search/searchers/ai-analysis-searcher.ts
+++ b/src/lib/search/searchers/ai-analysis-searcher.ts
@@ -11,7 +11,11 @@
  */
 
 import type { SearchResult } from "@/types/schemas/search";
-import type { AnyAnalysisResponse, AnalysisDomainConfig } from "@/types/search";
+import type {
+  AnyAnalysisResponse,
+  AnalysisDomainConfig,
+  QueryEmbeddingContext,
+} from "@/types/search";
 import type { AnalysisDomain } from "@/types/ai-analysis";
 import type { BookmarkAiAnalysisResponse } from "@/types/schemas/bookmark-ai-analysis";
 import type { BookAiAnalysisResponse } from "@/types/schemas/book-ai-analysis";
@@ -226,13 +230,14 @@ function extractIdFromUrl(url: string): string | null {
 async function searchDomainAnalysis(
   domain: AnalysisDomain,
   query: string,
+  context?: QueryEmbeddingContext,
 ): Promise<SearchResult[]> {
   const config = DOMAIN_CONFIGS[domain];
   const results: SearchResult[] = [];
 
   try {
     // Step 1: Search parent items to get candidates
-    const parentResults = await config.searcher(query);
+    const parentResults = await config.searcher(query, context);
     const topParents = parentResults.slice(0, MAX_PARENT_RESULTS);
 
     // Step 2: Fetch AI analysis for each parent (in parallel)
@@ -284,14 +289,17 @@ async function searchDomainAnalysis(
 }
 
 /** Search AI-generated analysis content across all domains. */
-export async function searchAiAnalysis(query: string): Promise<SearchResult[]> {
+export async function searchAiAnalysis(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
   // Search all domains in parallel
   const domains: AnalysisDomain[] = ["bookmarks", "books", "projects"];
   const domainResults = await Promise.all(
-    domains.map((domain) => searchDomainAnalysis(domain, sanitizedQuery)),
+    domains.map((domain) => searchDomainAnalysis(domain, sanitizedQuery, context)),
   );
 
   // Combine, sort by score, and limit
@@ -304,6 +312,7 @@ export async function searchAiAnalysis(query: string): Promise<SearchResult[]> {
     scoredResults: allResults.map((item) => ({ item, score: item.score })),
     getRerankText: (item) => [item.title, item.description ?? ""].join("\n"),
     logContext: "[searchAiAnalysis]",
+    queryEmbedding: context?.precomputed,
   });
   return reranked.map(({ item, score }) => ({ ...item, score }));
 }

--- a/src/lib/search/searchers/dynamic-searchers.ts
+++ b/src/lib/search/searchers/dynamic-searchers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { SearchResult } from "@/types/schemas/search";
+import type { QueryEmbeddingContext } from "@/types/search";
 import { sanitizeSearchQuery } from "@/lib/validators/search";
 import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
 import { hybridSearchBookmarks } from "@/lib/db/queries/hybrid-search";
@@ -17,11 +18,14 @@ const SEARCH_LIMIT = 50;
 /**
  * Search bookmarks via hybrid PostgreSQL (FTS + trigram + pgvector).
  */
-export async function searchBookmarks(query: string): Promise<SearchResult[]> {
+export async function searchBookmarks(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBookmarks]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBookmarks]", context);
   const rows = await hybridSearchBookmarks({
     query: sanitizedQuery,
     embedding,
@@ -41,11 +45,14 @@ export async function searchBookmarks(query: string): Promise<SearchResult[]> {
 /**
  * Search books via hybrid PostgreSQL (FTS + trigram + pgvector).
  */
-export async function searchBooks(query: string): Promise<SearchResult[]> {
+export async function searchBooks(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBooks]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchBooks]", context);
   const rows = await hybridSearchBooks({ query: sanitizedQuery, embedding, limit: SEARCH_LIMIT });
 
   return rows.map((r) => ({

--- a/src/lib/search/searchers/static-searchers.ts
+++ b/src/lib/search/searchers/static-searchers.ts
@@ -15,6 +15,7 @@ import {
   getEducationItems,
   experiences,
 } from "../loaders/static-content";
+import type { QueryEmbeddingContext } from "@/types/search";
 import { sanitizeSearchQuery } from "@/lib/validators/search";
 import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
 import {
@@ -27,11 +28,14 @@ const SEARCH_LIMIT = 50;
 /**
  * Search investments via hybrid PostgreSQL (FTS + trigram + pgvector).
  */
-export async function searchInvestments(query: string): Promise<SearchResult[]> {
+export async function searchInvestments(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchInvestments]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchInvestments]", context);
   const rows = await hybridSearchInvestments({
     query: sanitizedQuery,
     embedding,
@@ -96,11 +100,14 @@ export const searchEducation = createCachedSearchFunction({
  * Search projects via hybrid PostgreSQL (FTS + trigram + pgvector).
  * Includes special handling for exact "projects" query to add navigation result.
  */
-export async function searchProjects(query: string): Promise<SearchResult[]> {
+export async function searchProjects(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchProjects]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchProjects]", context);
   const rows = await hybridSearchProjects({
     query: sanitizedQuery,
     embedding,

--- a/src/lib/search/searchers/tag-search.ts
+++ b/src/lib/search/searchers/tag-search.ts
@@ -11,6 +11,7 @@ import type { SearchResult, AggregatedTag } from "@/types/schemas/search";
 import { sanitizeSearchQuery } from "@/lib/validators/search";
 import { envLogger } from "@/lib/utils/env-logger";
 import { formatTagDisplay } from "@/lib/utils/tag-utils";
+import type { QueryEmbeddingContext } from "@/types/search";
 import { aggregateTags } from "../tag-aggregator";
 import { getBookmarksIndex, getCachedBooksData } from "../loaders/dynamic-content";
 import { projectsData } from "../loaders/static-content";
@@ -127,7 +128,10 @@ function formatTagTitle(tag: AggregatedTag): string {
  * Search tags across all content types.
  * Returns tags matching the query with proper hierarchy display.
  */
-export async function searchTags(query: string): Promise<SearchResult[]> {
+export async function searchTags(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) return [];
 
@@ -189,6 +193,7 @@ export async function searchTags(query: string): Promise<SearchResult[]> {
     scoredResults: limitedTags.map(({ tag, score }) => ({ item: tag, score })),
     getRerankText: (tag) => `${tag.name}\n${tag.contentType}`,
     logContext: "[searchTags]",
+    queryEmbedding: context?.precomputed,
   });
 
   // Transform to SearchResult format

--- a/src/lib/search/searchers/thoughts-search.ts
+++ b/src/lib/search/searchers/thoughts-search.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SearchResult } from "@/types/schemas/search";
+import type { QueryEmbeddingContext } from "@/types/search";
 import { PAGE_METADATA } from "@/data/metadata";
 import { hybridSearchThoughts } from "@/lib/db/queries/hybrid-search";
 import { buildQueryEmbedding } from "@/lib/db/queries/query-embedding";
@@ -35,13 +36,16 @@ function getThoughtsPageResult(): SearchResult {
   };
 }
 
-export async function searchThoughts(query: string): Promise<SearchResult[]> {
+export async function searchThoughts(
+  query: string,
+  context?: QueryEmbeddingContext,
+): Promise<SearchResult[]> {
   const sanitizedQuery = sanitizeSearchQuery(query);
   if (!sanitizedQuery) {
     return [];
   }
 
-  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchThoughts]");
+  const embedding = await buildQueryEmbedding(sanitizedQuery, "[searchThoughts]", context);
   const rows = await hybridSearchThoughts({
     query: sanitizedQuery,
     embedding,

--- a/src/types/rag.ts
+++ b/src/types/rag.ts
@@ -191,9 +191,15 @@ export type RagScopeName =
 
 /**
  * Search function type for scope searchers.
+ *
+ * The optional `context` argument carries a precomputed query embedding so
+ * that a caller running many searchers in parallel (e.g. RAG retrieval) can
+ * embed the query once and share the vector across scopes — see
+ * `QueryEmbeddingContext` in `@/types/search`.
  */
 export type ScopeSearcher = (
   query: string,
+  context?: import("./search").QueryEmbeddingContext,
 ) => Promise<Array<{ title: string; description?: string; url: string; score: number }>>;
 
 /**

--- a/src/types/schemas/ai-openai-compatible.ts
+++ b/src/types/schemas/ai-openai-compatible.ts
@@ -4,6 +4,27 @@ import { embeddingSpaceIdSchema } from "@/types/schemas/embedding-space";
 export const aiUpstreamApiModeSchema = z.enum(["chat_completions", "responses"]);
 export type AiUpstreamApiMode = z.infer<typeof aiUpstreamApiModeSchema>;
 
+/**
+ * Gateway priority tier sent as the `X-Tier` header to the llm-gateway.
+ *
+ * Tier selection is per-call — every caller classifies its workload so the
+ * gateway can size reserved concurrency and queue depth appropriately.
+ *
+ *   production-a — live AI chat turns (user-blocking)
+ *   production-b — reserved for future live/user-blocking workloads
+ *   production-z — live render embeddings (search queries, hybrid rerank)
+ *   default      — unclassified; avoid setting this explicitly
+ *   batch        — background jobs and backfills (not user-facing)
+ */
+export const openAiCompatibleTierSchema = z.enum([
+  "production-a",
+  "production-b",
+  "production-z",
+  "default",
+  "batch",
+]);
+export type OpenAiCompatibleTier = z.infer<typeof openAiCompatibleTierSchema>;
+
 const openAiCompatibleToolCallSchema = z.object({
   id: z.string().min(1),
   type: z.literal("function"),

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -20,6 +20,19 @@ import type {
 export type ScoredResult<T> = { item: T; score: number };
 
 /**
+ * Per-request context for deduping query embedding calls across a fan-out.
+ *
+ * A caller running many searchers in parallel (e.g. the RAG retriever) computes
+ * the query embedding once and threads this object through every searcher, so
+ * concurrent searchers share one embedding HTTP call instead of each firing
+ * their own and queueing behind the inference server.
+ */
+export interface QueryEmbeddingContext {
+  /** Precomputed query vector; when present, searchers skip the network call. */
+  precomputed?: number[] | undefined;
+}
+
+/**
  * Configuration for a MiniSearch index.
  * Centralizes the repetitive MiniSearch options used across all index builders.
  *
@@ -109,7 +122,7 @@ export type AnyAnalysisResponse =
 
 /** Configuration for each AI analysis search domain */
 export interface AnalysisDomainConfig {
-  searcher: (query: string) => Promise<SearchResultShape[]>;
+  searcher: (query: string, context?: QueryEmbeddingContext) => Promise<SearchResultShape[]>;
   prefix: string;
   getParentUrl: (id: string) => string;
   extractSearchableText: (analysis: AnyAnalysisResponse) => string[];

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -29,7 +29,7 @@ export type ScoredResult<T> = { item: T; score: number };
  */
 export interface QueryEmbeddingContext {
   /** Precomputed query vector; when present, searchers skip the network call. */
-  precomputed?: number[] | undefined;
+  precomputed?: number[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Every upstream LLM gateway call now declares its priority tier via an `X-Tier` header so the gateway can isolate user-blocking traffic from batch backfills, RAG retrieval embeds the user query once instead of N times per fan-out, and Sentry drops four additional classes of non-actionable client noise before ingestion.

## Changes

### Features
- **Gateway tier classification is now mandatory per call**: Every caller of the OpenAI-compatible client (chat completions, responses, embeddings — both streaming and non-streaming) must pass a `tier` argument which is forwarded as the `X-Tier` request header on both the direct-fetch and OpenAI SDK `RequestOptions` paths, letting the llm-gateway size reserved concurrency per lane (`callOpenAiCompatibleChatCompletions`, `streamOpenAiCompatibleChatCompletions`, `callOpenAiCompatibleResponses`, `streamOpenAiCompatibleResponses` in `src/lib/ai/openai-compatible/openai-compatible-client.ts`; `embedTextsWithEndpointCompatibleModel` in `src/lib/ai/openai-compatible/embeddings-client.ts`; `toRequestOptions` in `src/lib/ai/openai-compatible/openai-compatible-message-mapper.ts`).
- **Canonical tier enum**: Introduces `openAiCompatibleTierSchema` with `production-a` (user-blocking chat turns), `production-b` (reserved for future live workloads), `production-z` (live render embeddings and hybrid rerank), `default` (explicit opt-out), and `batch` (background jobs) as the single semantic owner for tier values (`src/types/schemas/ai-openai-compatible.ts`).
- **Call sites classified by workload**: Live chat turns declare `production-a` (`executeChatCompletionsTurn`, `executeResponsesTurn` in `src/app/api/ai/chat/[feature]/upstream-turn.ts`); live render/search embeddings declare `production-z` (`src/lib/db/queries/query-embedding.ts`, `src/app/api/search/bookmarks/route.ts`, `src/lib/search/search-content.ts`); backfill writes declare `batch` (`src/lib/db/mutations/bookmark-embeddings.ts`, `src/lib/db/mutations/investment-embeddings.ts`); Node backfill scripts hardcode the `X-Tier: batch` header since they cannot import the TS schema (`scripts/backfill-bookmark-embeddings.node.mjs`, `scripts/backfill-domain-embeddings.node.mjs`).

### Performance
- **RAG retrieval embeds the user query exactly once instead of once per scope**: The dynamic retriever used to fan out to bookmarks, books, investments, projects, thoughts, blog, AI analysis, and tag searchers in parallel, each independently calling `buildQueryEmbedding` — so one user question produced N concurrent embedding HTTP requests that queued on the inference server. The retriever now embeds the sanitized query once up front and threads a shared `QueryEmbeddingContext` through every searcher; `buildQueryEmbedding` short-circuits when a precomputed vector of the correct dimensionality is present (`retrieveRelevantContent` in `src/lib/ai/rag/dynamic-retriever.ts`; `buildQueryEmbedding` in `src/lib/db/queries/query-embedding.ts`; `QueryEmbeddingContext` in `src/types/search.ts`; `ScopeSearcher` in `src/types/rag.ts`).
- **Hybrid rerank no longer re-embeds the query**: `rerankScoredResultsWithEmbeddings` now accepts a `queryEmbedding` parameter and drops the query text from its batched embed call, shifting `candidateVectorOffset` from 1 to 0 when the caller supplies the vector (`src/lib/search/search-content.ts`; searcher wiring in `src/lib/search/search-factory.ts`, `src/lib/search/searchers/ai-analysis-searcher.ts`, `src/lib/search/searchers/tag-search.ts`, `src/lib/search/searchers/thoughts-search.ts`, `src/lib/search/searchers/dynamic-searchers.ts`, `src/lib/search/searchers/static-searchers.ts`, `src/lib/blog/server-search.ts`).

### Bug Fixes
- **Sentry dashboard no longer drowns in non-actionable client noise**: The previous `beforeSend` only inspected the first exception's `value` field, so noise whose message lived on `event.message` or a trailing exception entry still leaked through. `beforeSend` now flat-maps every exception's `type` and `value` alongside `event.message`, the pattern list is also passed to Sentry's native `ignoreErrors` for pre-SDK suppression, and four new patterns are filtered: generic `Event (type=error)` promise rejections, the Chrome `pageContext` feature probe, WKWebView-deallocated-before-message races on iOS, and `ReportingObserver [deprecation]` platform notices. `reportingObserverIntegration` also drops the `deprecation` type so the SDK stops surfacing unactionable platform warnings (`src/instrumentation-client.ts`; constant renamed `BROWSER_EXTENSION_ERROR_PATTERNS` → `CLIENT_NOISE_ERROR_PATTERNS` to match the broadened scope).

### Tests
- **X-Tier header is asserted on every OpenAI-compatible client path**: New assertions confirm `X-Tier` is forwarded on chat completions, responses, and embeddings calls for both the direct-fetch and SDK `RequestOptions` code paths (`__tests__/lib/ai-openai-compatible.test.ts`).
- **RAG single-embed behavior is pinned by test**: Asserts `buildQueryEmbedding` is invoked exactly once per retrieval and that the same vector identity reaches every scope searcher (`__tests__/lib/ai/rag/dynamic-retriever.test.ts`).
- **Sentry filter covers each new noise pattern**: Added cases for the Event-as-rejection, pageContext probe, WKWebView deallocation, and ReportingObserver deprecation patterns (`__tests__/lib/instrumentation-client.test.ts`).

## Breaking Changes
Internal TypeScript API only: `tier: OpenAiCompatibleTier` is now a required field on the OpenAI-compatible client call args (`callOpenAiCompatibleChatCompletions`, `streamOpenAiCompatibleChatCompletions`, `callOpenAiCompatibleResponses`, `streamOpenAiCompatibleResponses`, `embedTextsWithEndpointCompatibleModel`). All in-repo callers have been updated; no external consumers affected.

## Related Issues
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes request signatures and headers for all OpenAI-compatible upstream calls and adjusts search/RAG embedding flow, which could break callers or affect search relevance if miswired. Sentry filtering changes are low risk but could hide real client errors if patterns are too broad.
> 
> **Overview**
> Adds mandatory per-request `tier` classification to all OpenAI-compatible chat/response/embedding calls, forwarding it as an `X-Tier` header (including a new `OpenAiCompatibleTier` enum) and updates all call sites (live chat, live search embeddings, and batch backfills/scripts) to supply the appropriate tier.
> 
> Optimizes RAG fan-out by embedding the query once per retrieval and threading a shared `QueryEmbeddingContext` through all searchers; `buildQueryEmbedding` now short-circuits on a valid precomputed vector, and hybrid rerank can reuse a precomputed query vector to avoid re-embedding.
> 
> Expands client-side Sentry noise suppression by broadening filtered patterns, applying them via both `ignoreErrors` and an improved `beforeSend` that inspects `event.message` plus all exception entries, and stops capturing `reportingObserver` deprecation reports; tests are updated/added to assert `X-Tier` propagation, single-embed behavior, and new noise filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6dc73133d38c4fafecbb6416b0ee6631217806b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers three orthogonal improvements: mandatory `X-Tier` header classification on every OpenAI-compatible client call (chat, responses, embeddings — both SDK and direct-fetch paths), a RAG fan-out optimization that embeds the user query exactly once and shares the vector across all parallel scope searchers via `QueryEmbeddingContext`, and an expanded Sentry client-noise filter covering four new pattern classes with defence-in-depth via `ignoreErrors` + `beforeSend`. All call sites have been updated, the internal TS API change is breaking for in-repo consumers only (all updated), and the new behaviour is covered by targeted tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; logic is correct across all three feature areas.

All findings are P2-or-better: the single-embed offset arithmetic is correct, the dimensionality guard in buildQueryEmbedding prevents stale precomputed vectors from propagating, the beforeSend expansion is semantically sound, and the tier header is consistently wired through both the SDK and direct-fetch paths. The only open gap (dedup test covering 4 of 8 scope searchers) was already noted in a prior review cycle and does not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/ai/rag/dynamic-retriever.ts | Embeds sanitized query once before the parallel searcher fan-out, threads shared QueryEmbeddingContext to every scope; embedding errors produce precomputed: undefined which causes per-searcher FTS fallback — correct graceful degradation. |
| src/lib/db/queries/query-embedding.ts | Short-circuits via context.precomputed with a dimensionality guard; wraps config resolution in try-catch for graceful FTS fallback (previously would throw); clean behavior change. |
| src/lib/search/search-content.ts | Accepts optional queryEmbedding; when provided, omits query from the batch embed call and shifts candidateVectorOffset to 0; offset arithmetic and guard (≥2 candidates) are correct. |
| src/lib/ai/openai-compatible/openai-compatible-client.ts | Adds required tier param to all four client functions; each delegates to toRequestOptions(args) which now injects the X-Tier header on the SDK path; correct and consistent. |
| src/instrumentation-client.ts | Expands beforeSend to inspect all exception type+value fields and event.message; adds ignoreErrors for SDK-level pre-filtering; removes deprecation from reportingObserverIntegration; four new noise patterns added. Solid defence-in-depth approach. |
| __tests__/lib/ai/rag/dynamic-retriever.test.ts | Mocks buildQueryEmbedding and asserts it is called exactly once; checks that 4 of 8 scope searchers receive the shared vector identity — the other 4 (searchTags, searchAiAnalysis, searchThoughts, searchBlogPostsServerSide) are mocked but not verified (pre-existing gap noted in prior review). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant RAG as dynamic-retriever
    participant EmbedSvc as Embedding Service
    participant S1 as searchBookmarks
    participant S2 as searchBooks
    participant SN as searchN...

    Client->>RAG: retrieveRelevantContent(query)
    RAG->>RAG: detectRelevantScopes(query)
    RAG->>RAG: sanitizeSearchQuery(query)
    RAG->>EmbedSvc: buildQueryEmbedding(sanitized) [once, X-Tier: production-z]
    EmbedSvc-->>RAG: precomputed vector
    Note over RAG: embeddingContext = { precomputed }
    par Parallel fan-out (shared vector)
        RAG->>S1: searcher(query, embeddingContext)
        S1->>S1: buildQueryEmbedding → returns precomputed directly
        S1-->>RAG: results
    and
        RAG->>S2: searcher(query, embeddingContext)
        S2->>S2: buildQueryEmbedding → returns precomputed directly
        S2-->>RAG: results
    and
        RAG->>SN: searcher(query, embeddingContext)
        SN-->>RAG: results
    end
    RAG-->>Client: merged & sorted DynamicResult[]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `__tests__/lib/ai/rag/dynamic-retriever.test.ts`, line 104-109 ([link](https://github.com/williamagh/williamcallahan.com/blob/ae83c96194882784b8ad0616866bbaeac50a0ee6/__tests__/lib/ai/rag/dynamic-retriever.test.ts#L104-L109)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Embedding-dedup test only covers 4 of 8 scope searchers**

   The test asserts that `searchProjects`, `searchInvestments`, `searchBookmarks`, and `searchBooks` receive the precomputed vector, but `searchTags`, `searchAiAnalysis`, `searchThoughts`, and `searchBlogPostsServerSide` are all mocked (lines 49–80+) yet never checked for `context?.precomputed`. If scope detection for a query triggers one of the unchecked searchers, the dedup guarantee wouldn't be pinned by the test suite. Extending the loop to include the other four mocked searchers would close the gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: __tests__/lib/ai/rag/dynamic-retriever.test.ts
   Line: 104-109

   Comment:
   **Embedding-dedup test only covers 4 of 8 scope searchers**

   The test asserts that `searchProjects`, `searchInvestments`, `searchBookmarks`, and `searchBooks` receive the precomputed vector, but `searchTags`, `searchAiAnalysis`, `searchThoughts`, and `searchBlogPostsServerSide` are all mocked (lines 49–80+) yet never checked for `context?.precomputed`. If scope detection for a query triggers one of the unchecked searchers, the dedup guarantee wouldn't be pinned by the test suite. Extending the loop to include the other four mocked searchers would close the gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20__tests__%2Flib%2Fai%2Frag%2Fdynamic-retriever.test.ts%0ALine%3A%20104-109%0A%0AComment%3A%0A**Embedding-dedup%20test%20only%20covers%204%20of%208%20scope%20searchers**%0A%0AThe%20test%20asserts%20that%20%60searchProjects%60%2C%20%60searchInvestments%60%2C%20%60searchBookmarks%60%2C%20and%20%60searchBooks%60%20receive%20the%20precomputed%20vector%2C%20but%20%60searchTags%60%2C%20%60searchAiAnalysis%60%2C%20%60searchThoughts%60%2C%20and%20%60searchBlogPostsServerSide%60%20are%20all%20mocked%20%28lines%2049%E2%80%9380%2B%29%20yet%20never%20checked%20for%20%60context%3F.precomputed%60.%20If%20scope%20detection%20for%20a%20query%20triggers%20one%20of%20the%20unchecked%20searchers%2C%20the%20dedup%20guarantee%20wouldn't%20be%20pinned%20by%20the%20test%20suite.%20Extending%20the%20loop%20to%20include%20the%20other%20four%20mocked%20searchers%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=williamagh%2Fwilliamcallahan.com&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20__tests__%2Flib%2Fai%2Frag%2Fdynamic-retriever.test.ts%0ALine%3A%20104-109%0A%0AComment%3A%0A**Embedding-dedup%20test%20only%20covers%204%20of%208%20scope%20searchers**%0A%0AThe%20test%20asserts%20that%20%60searchProjects%60%2C%20%60searchInvestments%60%2C%20%60searchBookmarks%60%2C%20and%20%60searchBooks%60%20receive%20the%20precomputed%20vector%2C%20but%20%60searchTags%60%2C%20%60searchAiAnalysis%60%2C%20%60searchThoughts%60%2C%20and%20%60searchBlogPostsServerSide%60%20are%20all%20mocked%20%28lines%2049%E2%80%9380%2B%29%20yet%20never%20checked%20for%20%60context%3F.precomputed%60.%20If%20scope%20detection%20for%20a%20query%20triggers%20one%20of%20the%20unchecked%20searchers%2C%20the%20dedup%20guarantee%20wouldn't%20be%20pinned%20by%20the%20test%20suite.%20Extending%20the%20loop%20to%20include%20the%20other%20four%20mocked%20searchers%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Fwilliamcallahan.com%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20__tests__%2Flib%2Fai%2Frag%2Fdynamic-retriever.test.ts%0ALine%3A%20104-109%0A%0AComment%3A%0A**Embedding-dedup%20test%20only%20covers%204%20of%208%20scope%20searchers**%0A%0AThe%20test%20asserts%20that%20%60searchProjects%60%2C%20%60searchInvestments%60%2C%20%60searchBookmarks%60%2C%20and%20%60searchBooks%60%20receive%20the%20precomputed%20vector%2C%20but%20%60searchTags%60%2C%20%60searchAiAnalysis%60%2C%20%60searchThoughts%60%2C%20and%20%60searchBlogPostsServerSide%60%20are%20all%20mocked%20%28lines%2049%E2%80%9380%2B%29%20yet%20never%20checked%20for%20%60context%3F.precomputed%60.%20If%20scope%20detection%20for%20a%20query%20triggers%20one%20of%20the%20unchecked%20searchers%2C%20the%20dedup%20guarantee%20wouldn't%20be%20pinned%20by%20the%20test%20suite.%20Extending%20the%20loop%20to%20include%20the%20other%20four%20mocked%20searchers%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(search): drop redundant | undef..."](https://github.com/williamagh/williamcallahan.com/commit/a6dc73133d38c4fafecbb6416b0ee6631217806b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29601996)</sub>

<!-- /greptile_comment -->