### PR TITLE
fix(content-graph, db, cache): exclude non-displayable domains from related candidates, tolerate invalid graph artifacts, bind array params via typed operators, and skip cached path during production build

### DIFF
--- a/__tests__/lib/caching/cache.test.ts
+++ b/__tests__/lib/caching/cache.test.ts
@@ -53,6 +53,27 @@ describe("lib/cache", () => {
       expect(cachedFn).toHaveBeenCalled();
       expect(fallbackFn).toHaveBeenCalled();
     });
+
+    it("should use direct fallback during production build", async () => {
+      const previousPhase = process.env.NEXT_PHASE;
+      process.env.NEXT_PHASE = "phase-production-build";
+      const cachedFn = vi.fn().mockResolvedValue("cached result");
+      const fallbackFn = vi.fn().mockResolvedValue("fallback result");
+
+      try {
+        const result = await withCacheFallback(cachedFn, fallbackFn);
+
+        expect(result).toBe("fallback result");
+        expect(cachedFn).not.toHaveBeenCalled();
+        expect(fallbackFn).toHaveBeenCalled();
+      } finally {
+        if (previousPhase === undefined) {
+          delete process.env.NEXT_PHASE;
+        } else {
+          process.env.NEXT_PHASE = previousPhase;
+        }
+      }
+    });
   });
 
   describe("USE_NEXTJS_CACHE", () => {

--- a/__tests__/lib/content-graph.test.ts
+++ b/__tests__/lib/content-graph.test.ts
@@ -131,6 +131,12 @@ describe("Content Graph Pre-computation", () => {
           content_date: "2024-01-02",
         },
         { domain: "blog", entity_id: "p1", title: "Test Post", content_date: "2024-01-01" },
+        {
+          domain: "opengraph",
+          entity_id: "og1",
+          title: "Cached OpenGraph",
+          content_date: "2024-01-01",
+        },
       ];
 
       // Mock tag content rows returned by the second db.execute call
@@ -161,6 +167,13 @@ describe("Content Graph Pre-computation", () => {
               entityId: "p1",
               title: "Test Post",
               similarity: 0.85,
+              contentDate: "2024-01-01",
+            },
+            {
+              domain: "opengraph",
+              entityId: "og1",
+              title: "Cached OpenGraph",
+              similarity: 0.82,
               contentDate: "2024-01-01",
             },
             {
@@ -240,16 +253,23 @@ describe("Content Graph Pre-computation", () => {
         expect(Object.keys(relatedContent)).toContain("bookmark:b1");
         expect(Object.keys(relatedContent)).toContain("bookmark:b2");
         expect(Object.keys(relatedContent)).toContain("blog:p1");
+        expect(Object.keys(relatedContent)).not.toContain("opengraph:og1");
 
         // Each entry should have related items with required fields
         const b1Related = relatedContent["bookmark:b1"];
         if (b1Related && b1Related.length > 0) {
+          expect(b1Related).toEqual(
+            expect.not.arrayContaining([expect.objectContaining({ type: "opengraph" })]),
+          );
           expect(b1Related[0]).toHaveProperty("type");
           expect(b1Related[0]).toHaveProperty("id");
           expect(b1Related[0]).toHaveProperty("score");
           expect(b1Related[0]).toHaveProperty("title");
         }
       }
+      expect(mockFindSimilarByEntity).not.toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: "og1" }),
+      );
 
       const tagGraphArtifact = artifactsArg?.find(
         (a: { artifactType: string }) => a.artifactType === "tag-graph",

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -121,6 +121,10 @@ export async function withCacheFallback<T>(
   cachedFn: () => Promise<T>,
   fallbackFn: () => Promise<T>,
 ): Promise<T> {
+  if (isCliLikeCacheContext()) {
+    return await fallbackFn();
+  }
+
   try {
     return await cachedFn();
   } catch (error) {

--- a/src/lib/content-graph/build.ts
+++ b/src/lib/content-graph/build.ts
@@ -211,15 +211,16 @@ export async function buildContentGraph(
         sourceId: entity.entity_id,
         limit: MAX_RELATED + 10,
       });
+      const displayableCandidates = candidates.filter(hasRelatedContentDomain);
       const scored = rankEmbeddingCandidates({
         sourceDomain,
-        candidates: candidates.filter(hasRelatedContentDomain),
+        candidates: displayableCandidates,
         bookmarkQualityById,
         maxPerDomain: 5,
         maxTotal: MAX_RELATED,
       });
 
-      relatedContentMappings[contentKey] = scored.map((c) => ({
+      relatedContentMappings[contentKey] = scored.filter(hasRelatedContentDomain).map((c) => ({
         type: c.domain,
         id: c.entityId,
         score: c.score,

--- a/src/lib/content-graph/build.ts
+++ b/src/lib/content-graph/build.ts
@@ -13,9 +13,16 @@ import type { DataFetchConfig, DataFetchOperationSummary } from "@/types/lib";
 import { CONTENT_GRAPH_ARTIFACT_TYPES } from "@/lib/db/schema/content-graph";
 import { findSimilarByEntity } from "@/lib/db/queries/cross-domain-similarity";
 import { rankEmbeddingCandidates } from "@/lib/db/queries/embedding-similarity";
+import { relatedContentTypeSchema, type RelatedContentType } from "@/types/schemas/related-content";
 
 const MAX_RELATED = 20;
 const YIELD_INTERVAL = 10;
+
+function hasRelatedContentDomain<T extends { domain: string }>(
+  row: T,
+): row is T & { domain: RelatedContentType } {
+  return relatedContentTypeSchema.safeParse(row.domain).success;
+}
 
 async function buildTagGraph(
   allContent: Array<{ type: string; id: string; tags?: string[] }>,
@@ -163,7 +170,7 @@ export async function buildContentGraph(
       ORDER BY domain, entity_id
     `);
 
-    let entities = [...embeddingRows];
+    let entities = embeddingRows.filter(hasRelatedContentDomain);
     if (typeof config.testLimit === "number" && config.testLimit > 0) {
       entities = entities.slice(0, config.testLimit);
     }
@@ -182,7 +189,7 @@ export async function buildContentGraph(
 
     const relatedContentMappings: Record<
       string,
-      Array<{ type: string; id: string; score: number; title: string }>
+      Array<{ type: RelatedContentType; id: string; score: number; title: string }>
     > = {};
 
     for (let i = 0; i < entities.length; i++) {
@@ -196,9 +203,7 @@ export async function buildContentGraph(
       const entity = entities[i];
       if (!entity) continue;
 
-      const sourceDomain = entity.domain as Parameters<
-        typeof findSimilarByEntity
-      >[0]["sourceDomain"];
+      const sourceDomain = entity.domain;
       const contentKey = `${entity.domain}:${entity.entity_id}`;
 
       const candidates = await findSimilarByEntity({
@@ -208,7 +213,7 @@ export async function buildContentGraph(
       });
       const scored = rankEmbeddingCandidates({
         sourceDomain,
-        candidates,
+        candidates: candidates.filter(hasRelatedContentDomain),
         bookmarkQualityById,
         maxPerDomain: 5,
         maxTotal: MAX_RELATED,

--- a/src/lib/db/mutations/bookmark-embeddings.ts
+++ b/src/lib/db/mutations/bookmark-embeddings.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { type SQL, sql } from "drizzle-orm";
 import { embedTextsWithEndpointCompatibleModel } from "@/lib/ai/openai-compatible/embeddings-client";
 import { resolveDefaultEndpointCompatibleEmbeddingConfig } from "@/lib/ai/openai-compatible/feature-config";
 import { assertDatabaseWriteAllowed, db } from "@/lib/db/connection";
@@ -119,6 +119,17 @@ function normalizeBookmarkIds(bookmarkIds?: string[]): string[] | undefined {
   return unique.size > 0 ? [...unique] : [];
 }
 
+function buildBookmarkIdFilter(bookmarkIds?: readonly string[]): SQL {
+  if (!bookmarkIds || bookmarkIds.length === 0) {
+    return sql``;
+  }
+  const ids = sql.join(
+    bookmarkIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  return sql` AND b.id IN (${ids})`;
+}
+
 /**
  * Find bookmarks that don't yet have a row in embeddings.
  * Uses LEFT JOIN instead of checking a per-domain embedding column.
@@ -136,8 +147,7 @@ async function readMissingEmbeddingRows(
     WHERE ce.entity_id IS NULL
   `;
 
-  const idFilter =
-    bookmarkIds && bookmarkIds.length > 0 ? sql` AND b.id = ANY(${bookmarkIds})` : sql``;
+  const idFilter = buildBookmarkIdFilter(bookmarkIds);
 
   const rows = await db.execute<{
     id: string;
@@ -167,8 +177,7 @@ async function readMissingEmbeddingRows(
 }
 
 async function countMissingEmbeddings(bookmarkIds?: string[]): Promise<number> {
-  const idFilter =
-    bookmarkIds && bookmarkIds.length > 0 ? sql` AND b.id = ANY(${bookmarkIds})` : sql``;
+  const idFilter = buildBookmarkIdFilter(bookmarkIds);
 
   const rows = await db.execute<{ cnt: number }>(sql`
     SELECT count(*)::int AS cnt

--- a/src/lib/db/queries/content-graph.ts
+++ b/src/lib/db/queries/content-graph.ts
@@ -7,6 +7,7 @@
  */
 
 import { eq } from "drizzle-orm";
+import type { ZodIssue } from "zod/v4";
 import { db } from "@/lib/db/connection";
 import { CONTENT_GRAPH_ARTIFACT_TYPES, contentGraphArtifacts } from "@/lib/db/schema/content-graph";
 import { relatedContentGraphSchema, booksRelatedContentDataSchema } from "@/types/schemas/book";
@@ -17,6 +18,26 @@ import {
   type TagGraph,
 } from "@/types/schemas/related-content";
 import type { BooksRelatedContent, RelatedContentGraph } from "@/types/schemas/book";
+
+let invalidRelatedContentArtifactLogged = false;
+
+function formatZodIssuePath(issue: ZodIssue): string {
+  return issue.path.length > 0 ? issue.path.map(String).join(".") : "<root>";
+}
+
+function logInvalidRelatedContentArtifact(issues: readonly ZodIssue[]): void {
+  if (invalidRelatedContentArtifactLogged) {
+    return;
+  }
+  invalidRelatedContentArtifactLogged = true;
+  const summary = issues
+    .slice(0, 5)
+    .map((issue) => `${formatZodIssuePath(issue)}: ${issue.message}`)
+    .join("; ");
+  console.warn(
+    `[db/queries/content-graph] Invalid related-content artifact; falling back to on-demand related-content. issues=${issues.length}; first=${summary}`,
+  );
+}
 
 /**
  * Read a single content graph artifact by type.
@@ -49,7 +70,12 @@ export async function readRelatedContent(): Promise<RelatedContentGraph | null> 
     return null;
   }
 
-  return relatedContentGraphSchema.parse(payload);
+  const parsed = relatedContentGraphSchema.safeParse(payload);
+  if (!parsed.success) {
+    logInvalidRelatedContentArtifact(parsed.error.issues);
+    return null;
+  }
+  return parsed.data;
 }
 
 /**

--- a/src/lib/db/queries/hybrid-search.ts
+++ b/src/lib/db/queries/hybrid-search.ts
@@ -13,7 +13,7 @@
  * @module db/queries/hybrid-search
  */
 
-import { desc, sql } from "drizzle-orm";
+import { desc, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db/connection";
 import { bookmarks } from "@/lib/db/schema/bookmarks";
 import { CONTENT_EMBEDDING_DIMENSIONS } from "@/lib/db/schema/content-embeddings";
@@ -198,10 +198,7 @@ export async function semanticSearchBookmarks(
   const ids = idRows.map((r) => r.entity_id);
   const scoreMap = new Map(idRows.map((r) => [r.entity_id, Number(r.vec_score)]));
 
-  const bookmarkRows = await db
-    .select()
-    .from(bookmarks)
-    .where(sql`${bookmarks.id} = ANY(${ids})`);
+  const bookmarkRows = await db.select().from(bookmarks).where(inArray(bookmarks.id, ids));
 
   return mapBookmarkSelectsToUnifiedBookmarks(bookmarkRows)
     .map((b) => ({


### PR DESCRIPTION
## Summary

Hardens the related-content graph against two production-observable failure modes — non-displayable domains (e.g. `opengraph`) leaking into related-item lists, and a single corrupt artifact row crashing every consumer of `readRelatedContent` — replaces two fragile JS-array-into-`= ANY($)` driver coercions with typed Drizzle operators in the bookmark-embeddings and hybrid-search query sites, and unblocks `next build` prerender from depending on Next-cache infrastructure that's inert during build.

## Changes

### Bug Fixes

- **Related-content graph no longer attaches non-displayable domains to a source's related list**: `findSimilarByEntity` returns embedding neighbors across every domain in the embedding store, including ones (e.g. `opengraph`) that aren't valid `RelatedContentType` values. Source entities were already filtered, but candidate neighbors were not — so a bookmark could end up with an `opengraph` "related" item, and the resulting artifact would fail `relatedContentGraphSchema` validation downstream. Candidates are now filtered with `hasRelatedContentDomain` before ranking, and the type guard is re-applied on the scored list so `c.domain` narrows to `RelatedContentType` without an `as`-cast (`src/lib/content-graph/build.ts`).

- **`readRelatedContent` falls back to `null` on a corrupt artifact instead of throwing for every caller**: previously used `relatedContentGraphSchema.parse`, which throws on any artifact row that fails validation — a single bad payload (e.g. left over from before the build-time domain filter landed) cascaded into every consumer. Now uses `safeParse`, returns `null` on failure so callers degrade to their on-demand path, and logs the first failure once per process with the top 5 zod issue paths so the bad artifact is observable without flooding logs on hot paths (`src/lib/db/queries/content-graph.ts`).

- **Production-build prerender no longer participates in the Next.js cache layer**: `withCacheFallback` wraps a Next-cached read with a direct fallback so runtime callers can degrade gracefully on cache failure, but during `next build` static generation the cached path inside `unstable_cache` itself participated in prerender, surfacing as `queryWithCache` failures during `/projects/[slug]` export. `isCliLikeCacheContext()` already gates `cacheLife`/`cacheTag`/`revalidateTag` calls inert in CLI/build contexts; the same opt-out is now applied to `withCacheFallback` so the build phase goes straight to `fallbackFn` (`src/lib/cache.ts`).

### Refactoring

- **Embedding-builder validates `entity.domain` at the boundary instead of casting it**: the prior `as Parameters<...>[0][\"sourceDomain\"]` was a type assertion with no runtime check ([TS1d]); a stray domain in the embeddings table would silently propagate. Replaced with a `hasRelatedContentDomain` type guard backed by `relatedContentTypeSchema.safeParse`, with `relatedContentMappings`'s value type tightened from `string` to `RelatedContentType` (`src/lib/content-graph/build.ts`).

- **Bookmark-id filters in raw and Drizzle SQL no longer rely on the driver to coerce JS arrays into PG array literals**: `semanticSearchBookmarks` now uses `inArray(bookmarks.id, ids)` (Drizzle native), and `bookmark-embeddings` extracts a shared `buildBookmarkIdFilter` helper that emits `AND b.id IN (...)` via `sql.join` with one placeholder per id, reused from `readMissingEmbeddingRows` and `countMissingEmbeddings` instead of duplicating the filter at each call site (`src/lib/db/mutations/bookmark-embeddings.ts`, `src/lib/db/queries/hybrid-search.ts`).

## Test Coverage

- New fixtures in `__tests__/lib/content-graph.test.ts` add an `opengraph` entity + opengraph candidate, then assert: it never appears as a source key in the artifact, never as a related item under `bookmark:b1`, and `findSimilarByEntity` is never called with `sourceId: \"og1\"`.
- `__tests__/lib/caching/cache.test.ts` adds a build-phase test that sets/restores `NEXT_PHASE` in `try/finally`; asserts `cachedFn` is never invoked and the fallback's value is returned.

## Breaking Changes

None. `readRelatedContent` returning `null` on invalid payloads is the contract callers already handled (it returns `null` when no row exists); the artifact schema and `RelatedContentType` union are unchanged. `withCacheFallback` already documented `fallbackFn` as the degradation path, now exercised in build phase.

## Files changed

```
__tests__/lib/caching/cache.test.ts          | 21 +++++++++
__tests__/lib/content-graph.test.ts          | 20 +++++++++
src/lib/cache.ts                             |  4 ++
src/lib/content-graph/build.ts               | 20 +++++----
src/lib/db/mutations/bookmark-embeddings.ts  | 19 +++++++--
src/lib/db/queries/content-graph.ts          | 28 +++++++++++-
src/lib/db/queries/hybrid-search.ts          |  7 +--
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes related-content graph generation/validation, cache behavior during `next build`, and SQL filtering semantics, which could alter production recommendations and query results if edge cases were relied upon.
> 
> **Overview**
> Prevents **non-displayable domains** (e.g. `opengraph`) from being included as sources or related candidates when building the related-content artifact by filtering/typing domains via `relatedContentTypeSchema`.
> 
> Makes `readRelatedContent` **tolerant of invalid/corrupt stored artifacts** by switching to `safeParse`, returning `null` (forcing on-demand fallback) and logging the first schema failure once per process.
> 
> Avoids Next.js cache paths in CLI/build contexts by short-circuiting `withCacheFallback` to the direct fallback during `phase-production-build`, and hardens SQL param binding by replacing array `ANY(...)` usage with explicit `IN (...)` construction (bookmark embeddings backfill) and Drizzle `inArray` (semantic bookmark search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20f5dee141dc45fece14aa82373c84cd8b86b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the related-content pipeline against two production-observable failure modes: non-displayable domains (e.g. `opengraph`) leaking into related-item lists, and a single corrupt artifact row crashing every consumer of `readRelatedContent`. It also replaces two fragile `= ANY($)` driver coercions with properly parameterized Drizzle operators, and short-circuits `withCacheFallback` during `next build` so prerender goes straight to the fallback function.

- **`content-graph/build.ts`**: Introduces `hasRelatedContentDomain` type guard backed by `relatedContentTypeSchema.safeParse`; applies it to `embeddingRows`, `candidates`, and the final `scored` list, eliminating the unsafe `as`-cast and preventing non-displayable entities from appearing as sources or related items.
- **`db/queries/content-graph.ts`**: Replaces `relatedContentGraphSchema.parse` with `safeParse` + `null` fallback in `readRelatedContent`, logging the first failure once per process with up to five Zod issue paths.
- **`db/mutations/bookmark-embeddings.ts` / `db/queries/hybrid-search.ts`**: Shared `buildBookmarkIdFilter` helper and `inArray` replace the `= ANY($)` patterns that relied on undocumented driver array coercion.

<h3>Confidence Score: 4/5</h3>

The changes are well-scoped and each fix addresses a concrete, documented failure mode; safe to merge with one follow-up to consider.

All core logic changes are correct and tested. The one gap is that three sibling artifact readers — `readBooksRelatedContent`, `readTagGraph`, and `readContentGraphMetadata` — still call `.parse()` and will throw on a corrupt row, the same crash mode this PR fixed for `readRelatedContent`. It is a non-blocking inconsistency but worth addressing in a follow-up.

src/lib/db/queries/content-graph.ts — the three remaining `.parse()` calls could benefit from the same `safeParse` treatment applied to `readRelatedContent`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/cache.ts | Adds `isCliLikeCacheContext()` early-exit to `withCacheFallback` so the build phase bypasses `unstable_cache` and goes straight to the fallback; clean, minimal change. |
| src/lib/content-graph/build.ts | Adds `hasRelatedContentDomain` type guard; filters `embeddingRows`, `candidates`, and the final `scored` list to exclude non-displayable domains. Removes the unsafe `as`-cast for `sourceDomain`. Logic is correct and the triple-filter is intentional for TS narrowing. |
| src/lib/db/queries/content-graph.ts | Switches `readRelatedContent` to `safeParse` with once-per-process warning; correct approach, but `readBooksRelatedContent`, `readTagGraph`, and `readContentGraphMetadata` still use throwing `.parse()`, leaving them vulnerable to the same crash path. |
| src/lib/db/mutations/bookmark-embeddings.ts | Extracts `buildBookmarkIdFilter` helper that emits `AND b.id IN (...)` with individual Drizzle-parameterized placeholders; replaces fragile `= ANY($)` driver coercion in both `readMissingEmbeddingRows` and `countMissingEmbeddings`. |
| src/lib/db/queries/hybrid-search.ts | Replaces manual `= ANY($)` with Drizzle's `inArray(bookmarks.id, ids)`; straightforward, safe change. |
| __tests__/lib/caching/cache.test.ts | Adds build-phase test for `withCacheFallback`; correctly saves/restores `NEXT_PHASE` in a try/finally block and asserts that `cachedFn` is never invoked. |
| __tests__/lib/content-graph.test.ts | Adds `opengraph` fixture entity and candidate, then asserts it never appears as a source key, never as a related item under `bookmark:b1`, and that `findSimilarByEntity` is never called with `sourceId: "og1"`. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildContentGraph] --> B[Query embeddings table]
    B --> C{hasRelatedContentDomain?}
    C -- No --> D[Skip entity]
    C -- Yes --> E[findSimilarByEntity]
    E --> F[Filter candidates\nhasRelatedContentDomain]
    F --> G[rankEmbeddingCandidates]
    G --> H[Filter scored\nhasRelatedContentDomain]
    H --> I[relatedContentMappings]
    I --> J[persistContentGraphArtifacts]

    J --> K[readRelatedContent at runtime]
    K --> L{safeParse payload}
    L -- invalid --> M[logInvalidRelatedContentArtifact\nonce per process]
    M --> N[return null - on-demand fallback]
    L -- valid --> O[return RelatedContentGraph]

    P[withCacheFallback called] --> Q{isCliLikeCacheContext?}
    Q -- Yes / build phase --> R[fallbackFn directly]
    Q -- No --> S[cachedFn]
    S -- error --> T[fallbackFn]
    S -- ok --> U[return cached value]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/db/queries/content-graph.ts`, line 91 ([link](https://github.com/williamagh/williamcallahan.com/blob/a20f5dee141dc45fece14aa82373c84cd8b86b7a/src/lib/db/queries/content-graph.ts#L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Sibling artifact readers still use throwing `.parse()`**

   `readRelatedContent` was hardened with `safeParse` + `null` fallback, but `readBooksRelatedContent` (line 91), `readTagGraph` (line 104), and `readContentGraphMetadata` (line 117) still call `.parse()`. A corrupt row in any of those artifact types will throw and cascade to every caller — the same failure mode this PR explicitly fixed for `readRelatedContent`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/db/queries/content-graph.ts
   Line: 91

   Comment:
   **Sibling artifact readers still use throwing `.parse()`**

   `readRelatedContent` was hardened with `safeParse` + `null` fallback, but `readBooksRelatedContent` (line 91), `readTagGraph` (line 104), and `readContentGraphMetadata` (line 117) still call `.parse()`. A corrupt row in any of those artifact types will throw and cascade to every caller — the same failure mode this PR explicitly fixed for `readRelatedContent`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%0ALine%3A%2091%0A%0AComment%3A%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=williamagh%2Fwilliamcallahan.com&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%0ALine%3A%2091%0A%0AComment%3A%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Fwilliamcallahan.com%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%0ALine%3A%2091%0A%0AComment%3A%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%3A91%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0A&repo=williamagh%2Fwilliamcallahan.com&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%3A91%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0A&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Fwilliamcallahan.com%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fdb%2Fqueries%2Fcontent-graph.ts%3A91%0A**Sibling%20artifact%20readers%20still%20use%20throwing%20%60.parse%28%29%60**%0A%0A%60readRelatedContent%60%20was%20hardened%20with%20%60safeParse%60%20%2B%20%60null%60%20fallback%2C%20but%20%60readBooksRelatedContent%60%20%28line%2091%29%2C%20%60readTagGraph%60%20%28line%20104%29%2C%20and%20%60readContentGraphMetadata%60%20%28line%20117%29%20still%20call%20%60.parse%28%29%60.%20A%20corrupt%20row%20in%20any%20of%20those%20artifact%20types%20will%20throw%20and%20cascade%20to%20every%20caller%20%E2%80%94%20the%20same%20failure%20mode%20this%20PR%20explicitly%20fixed%20for%20%60readRelatedContent%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib/db/queries/content-graph.ts:91
**Sibling artifact readers still use throwing `.parse()`**

`readRelatedContent` was hardened with `safeParse` + `null` fallback, but `readBooksRelatedContent` (line 91), `readTagGraph` (line 104), and `readContentGraphMetadata` (line 117) still call `.parse()`. A corrupt row in any of those artifact types will throw and cascade to every caller — the same failure mode this PR explicitly fixed for `readRelatedContent`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): skip cached path during prod..."](https://github.com/williamagh/williamcallahan.com/commit/a20f5dee141dc45fece14aa82373c84cd8b86b7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31423584)</sub>

<!-- /greptile_comment -->