### PR TITLE
docs: replace incorrect cache-invalidation, JSONB-FTS, and test-coverage guidance with correct patterns

### DIFF
--- a/__tests__/lib/endpoint-compatible-embedding-config.test.ts
+++ b/__tests__/lib/endpoint-compatible-embedding-config.test.ts
@@ -1,4 +1,26 @@
+import { embedTextsWithEndpointCompatibleModel } from "@/lib/ai/openai-compatible/embeddings-client";
 import { resolveDefaultEndpointCompatibleEmbeddingConfig } from "@/lib/ai/openai-compatible/feature-config";
+import {
+  endpointCompatibleEmbeddingsRequestSchema,
+  type EndpointCompatibleEmbeddingConfig,
+  type EndpointCompatibleEmbeddingsRequest,
+} from "@/types/schemas/ai-openai-compatible";
+
+const embeddingConfig: EndpointCompatibleEmbeddingConfig = {
+  model: "text-embedding-qwen3-embedding-4b",
+  baseUrl: "https://example.test",
+  apiKey: "test-key",
+  embeddingSpaceId: "qwen3-embedding-4b",
+};
+
+function readEmbeddingRequest(init: RequestInit | undefined): EndpointCompatibleEmbeddingsRequest {
+  const body = init?.body;
+  if (typeof body !== "string") {
+    throw new TypeError("Expected stringified embedding request body.");
+  }
+  const parsed: unknown = JSON.parse(body);
+  return endpointCompatibleEmbeddingsRequestSchema.parse(parsed);
+}
 
 describe("resolveDefaultEndpointCompatibleEmbeddingConfig", () => {
   const originalEnv = { ...process.env };
@@ -12,6 +34,7 @@ describe("resolveDefaultEndpointCompatibleEmbeddingConfig", () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
   });
 
   it("returns null when AI_DEFAULT_EMBEDDING_MODEL is unset", () => {
@@ -47,5 +70,72 @@ describe("resolveDefaultEndpointCompatibleEmbeddingConfig", () => {
     expect(() => resolveDefaultEndpointCompatibleEmbeddingConfig()).toThrow(
       "AI_DEFAULT_EMBEDDING_MODEL is set but AI_DEFAULT_OPENAI_API_KEY is missing.",
     );
+  });
+});
+
+describe("embedTextsWithEndpointCompatibleModel", () => {
+  it("preserves OpenAI embedding response order by index", async () => {
+    const requests: EndpointCompatibleEmbeddingsRequest[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = readEmbeddingRequest(init);
+      requests.push(request);
+      const data = request.input
+        .map((_, index) => ({
+          object: "embedding",
+          embedding: [index, 10 - index],
+          index,
+        }))
+        .toReversed();
+      return Response.json({ object: "list", data });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const embeddings = await embedTextsWithEndpointCompatibleModel({
+      config: embeddingConfig,
+      input: ["alpha", "beta"],
+      tier: "batch",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requests[0]).toMatchObject({
+      model: "text-embedding-qwen3-embedding-4b",
+      input: ["alpha", "beta"],
+    });
+    expect(embeddings).toEqual([
+      [0, 10],
+      [1, 9],
+    ]);
+  });
+
+  it("splits oversized logical inputs and pools chunk vectors", async () => {
+    const requests: EndpointCompatibleEmbeddingsRequest[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = readEmbeddingRequest(init);
+      requests.push(request);
+      const vectors = [
+        [1, 0],
+        [0, 1],
+        [0, 2],
+      ];
+      const data = request.input.map((_, index) => {
+        const embedding = vectors[index];
+        if (!embedding) throw new Error(`Missing test embedding for index ${index}.`);
+        return { object: "embedding", embedding, index };
+      });
+      return Response.json({ object: "list", data });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const embeddings = await embedTextsWithEndpointCompatibleModel({
+      config: embeddingConfig,
+      input: ["a".repeat(32_769), "short"],
+      tier: "batch",
+    });
+
+    expect(requests[0]?.input).toHaveLength(3);
+    expect(embeddings).toHaveLength(2);
+    expect(embeddings[0]?.[0]).toBeCloseTo(Math.SQRT1_2);
+    expect(embeddings[0]?.[1]).toBeCloseTo(Math.SQRT1_2);
+    expect(embeddings[1]).toEqual([0, 2]);
   });
 });

--- a/docs/architecture/ai-services.md
+++ b/docs/architecture/ai-services.md
@@ -99,6 +99,7 @@ For a route param `feature`, the server resolves configuration with this precede
   - `AI_DEFAULT_OPENAI_API_KEY`
 - Used for:
   - PostgreSQL bookmark embedding backfill (`bun run bookmarks:embeddings:backfill`, executed via Node script `scripts/backfill-bookmark-embeddings.node.mjs`)
+- The shared app/server embeddings client sends OpenAI-style array inputs and splits oversized logical inputs into endpoint-safe chunks before posting. Chunk vectors are pooled back into one vector per original input so callers keep stable count/order parity.
 
 ## OpenAI SDK Notes
 

--- a/docs/architecture/ai-services.md
+++ b/docs/architecture/ai-services.md
@@ -169,4 +169,4 @@ All requests to `POST /api/ai/chat/[feature]` are queued by upstream target so w
 - `__tests__/api/ai/chat-upstream-pipeline-tools.test.ts` asserts tool-call rounds and deterministic search fallback behavior.
 - `__tests__/api/ai/chat-upstream-pipeline-analysis-validation.test.ts` verifies JSON/schema retry paths, coercion, and fallback normalization for bookmark analysis.
 - `__tests__/components/ui/terminal/commands.test.ts` confirms terminal one-shot flow against the SSE-only contract.
-- `__tests__/lib/ai-openai-compatible.test.ts` exercises browser SSE parsing and OpenAI-compatible transport behavior.
+- `__tests__/lib/ai-openai-compatible.test.ts` exercises browser SSE parsing, OpenAI-compatible transport behavior, and client-side analysis persistence (persistAnalysis success/error paths).

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -16,7 +16,7 @@ See `docs/architecture/caching.mmd` for the current write/read/supporting flow.
 
 | Domain                   | Source of truth                                             | Cached read path                                   | Invalidation                                                |
 | ------------------------ | ----------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------- |
-| Bookmarks                | PostgreSQL read model (`src/lib/db/*`)                      | `"use cache"` functions + tag-labeled RSC reads    | `revalidateTag("bookmarks")`, slug/tag-specific tags        |
+| Bookmarks                | PostgreSQL read model (`src/lib/db/*`)                      | `"use cache"` functions + tag-labeled RSC reads    | `invalidateNextJsBookmarksCache()` (dataset, slug, tag, search caches), slug/tag-specific tags |
 | Blog + Related Content   | Repository content + PostgreSQL content-graph artifacts     | Server read functions with `cacheLife/cacheTag`    | `revalidateTag("blog")`, `revalidateTag("related-content")` |
 | GitHub Activity          | PostgreSQL `github_activity_store` (JSON payload documents) | RSC summaries/pages using cache tags               | `revalidateTag("github-activity")`                          |
 | Images/Logos/OG metadata | S3 objects + manifests                                      | Cache-tagged server accessors and manifest loaders | tag invalidation + key-level refresh                        |
@@ -60,9 +60,10 @@ export function invalidateDomainData() {
 
 Common tag strategy:
 
-- `bookmarks`
+- `bookmarks` (and related: `bookmarks-db-full`, `bookmarks-s3-full`, `bookmarks-index`, `bookmarks-tag-slugs`, `bookmark-slug-mapping`, `bookmarks-slugs`)
 - `bookmark-{slug}`
 - `bookmarks-tag-{slug}`
+- `search-index`
 - `related-content`
 - `blog`
 - `github-activity`

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -14,12 +14,12 @@ See `docs/architecture/caching.mmd` for the current write/read/supporting flow.
 
 ### Domain Responsibilities
 
-| Domain                   | Source of truth                                             | Cached read path                                   | Invalidation                                                |
-| ------------------------ | ----------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------- |
-| Bookmarks                | PostgreSQL read model (`src/lib/db/*`)                      | `"use cache"` functions + tag-labeled RSC reads    | `invalidateNextJsBookmarksCache()` (dataset, slug, tag, search caches), slug/tag-specific tags |
-| Blog + Related Content   | Repository content + PostgreSQL content-graph artifacts     | Server read functions with `cacheLife/cacheTag`    | `revalidateTag("blog")`, `revalidateTag("related-content")` |
-| GitHub Activity          | PostgreSQL `github_activity_store` (JSON payload documents) | RSC summaries/pages using cache tags               | `revalidateTag("github-activity")`                          |
-| Images/Logos/OG metadata | S3 objects + manifests                                      | Cache-tagged server accessors and manifest loaders | tag invalidation + key-level refresh                        |
+| Domain                   | Source of truth                                             | Cached read path                                   | Invalidation                                                                               |
+| ------------------------ | ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Bookmarks                | PostgreSQL read model (`src/lib/db/*`)                      | `"use cache"` functions + tag-labeled RSC reads    | `invalidateNextJsBookmarksCache()` (dataset, slug, and tag caches), slug/tag-specific tags |
+| Blog + Related Content   | Repository content + PostgreSQL content-graph artifacts     | Server read functions with `cacheLife/cacheTag`    | `revalidateTag("blog")`, `revalidateTag("related-content")`                                |
+| GitHub Activity          | PostgreSQL `github_activity_store` (JSON payload documents) | RSC summaries/pages using cache tags               | `revalidateTag("github-activity")`                                                         |
+| Images/Logos/OG metadata | S3 objects + manifests                                      | Cache-tagged server accessors and manifest loaders | tag invalidation + key-level refresh                                                       |
 
 ### Route Policy
 
@@ -60,10 +60,10 @@ export function invalidateDomainData() {
 
 Common tag strategy:
 
-- `bookmarks` (and related: `bookmarks-db-full`, `bookmarks-s3-full`, `bookmarks-index`, `bookmarks-tag-slugs`, `bookmark-slug-mapping`, `bookmarks-slugs`)
-- `bookmark-{slug}`
-- `bookmarks-tag-{slug}`
-- `search-index`
+- `bookmarks`, `bookmarks-db-full`, `bookmarks-index-sz-{pageSize}`
+- `bookmarks-page-{pageNumber}`, `bookmarks-page-{pageNumber}-sz-{pageSize}`
+- `bookmarks-tag-slugs`, `bookmarks-tag-{slug}`, and tag page/index variants
+- `bookmark-slug-mapping`
 - `related-content`
 - `blog`
 - `github-activity`

--- a/docs/file-map.md
+++ b/docs/file-map.md
@@ -188,7 +188,7 @@ File/Path Functionality Description
   - [x] `analysis-client-utils.ts` `ai-shared-services` - Shared client utilities for AI analysis (LLM JSON parsing via `JSON.parse`, PostgreSQL persistence)
   - [x] **openai-compatible/**
     - [x] `feature-config.ts` `ai-shared-services` - Per-feature env resolution, preferred-model resolution, and shared upstream queue-key builder
-    - [x] `embeddings-client.ts` `ai-shared-services` - Endpoint-compatible `/v1/embeddings` client for batch embedding generation
+    - [x] `embeddings-client.ts` `ai-shared-services` - Endpoint-compatible `/v1/embeddings` client for chunk-safe batch embedding generation
     - [x] `gate-token.ts` `ai-shared-services` - HMAC-signed short-lived token helpers plus shared request origin/cookie/auth extraction helpers
     - [x] `browser-client.ts` `ai-shared-services` - Browser helper to mint token + call AI chat route with SSE-only consumption
     - [x] `openai-compatible-client.ts` `ai-shared-services` - Native OpenAI SDK transport for `chat.completions` and `responses`

--- a/docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md
+++ b/docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md
@@ -420,7 +420,7 @@ Same pattern as investments.
 
 **Step 1-8:** Follow identical pattern as Task 6. Schema columns: id, name, slug, description, short_summary, url, github_url, image_key, tags (jsonb), tech_stack (jsonb), note, cv_featured. FTS: A=name, B=short_summary+description, C=tags. Embedding input: Name, ShortSummary, Description, Tags, TechStack, Note.
 
-**Note on tsvector with jsonb tags:** Since `tags` is jsonb, use `to_tsvector('english', coalesce(tags::text, ''))` in the GENERATED ALWAYS expression.
+**Note on tsvector with jsonb tags:** Since `tags` is jsonb (array of strings or objects), extracting tags for FTS requires `jsonb_array_elements`. For simple string arrays, use a subquery or unnest pattern; for mixed string/object arrays (like bookmarks), use `CASE` with `jsonb_typeof` to handle both formats. The simple cast `tags::text` is unreliable and may produce incorrect results.
 
 ```bash
 git commit -m "feat(db): add projects table with FTS/trigram and unified embedding support"

--- a/src/lib/ai/openai-compatible/embeddings-client.ts
+++ b/src/lib/ai/openai-compatible/embeddings-client.ts
@@ -9,18 +9,123 @@ import type {
 } from "@/types/schemas/ai-openai-compatible";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const RECOMMENDED_INPUT_TOKENS = 8_192;
+const APPROXIMATE_CHARS_PER_TOKEN = 4;
+const INPUT_CHUNK_CHAR_LIMIT = RECOMMENDED_INPUT_TOKENS * APPROXIMATE_CHARS_PER_TOKEN;
+
+function findChunkEnd(text: string, start: number, hardEnd: number): number {
+  if (hardEnd >= text.length) return hardEnd;
+  for (let index = hardEnd; index > start; index -= 1) {
+    const char = text[index - 1];
+    if (char && /\s/.test(char)) return index;
+  }
+  return hardEnd;
+}
+
+function splitEmbeddingInput(text: string): string[] {
+  if (text.length <= INPUT_CHUNK_CHAR_LIMIT) return [text];
+
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    const hardEnd = Math.min(start + INPUT_CHUNK_CHAR_LIMIT, text.length);
+    const end = findChunkEnd(text, start, hardEnd);
+    const chunk = text.slice(start, end).trim();
+    if (chunk.length > 0) chunks.push(chunk);
+    start = end;
+    while (start < text.length && /\s/.test(text[start] ?? "")) start += 1;
+  }
+  return chunks;
+}
+
+function buildEmbeddingInputPlan(input: string[]): {
+  input: string[];
+  ranges: Array<[number, number]>;
+} {
+  const plannedInput: string[] = [];
+  const ranges: Array<[number, number]> = [];
+
+  for (const text of input) {
+    const start = plannedInput.length;
+    plannedInput.push(...splitEmbeddingInput(text));
+    ranges.push([start, plannedInput.length]);
+  }
+
+  return { input: plannedInput, ranges };
+}
+
+function orderResponseEmbeddings(
+  data: Array<{ index: number; embedding: number[] }>,
+  expectedCount: number,
+): number[][] {
+  const ordered: number[][] = [];
+  for (const item of data) {
+    if (item.index >= expectedCount || ordered[item.index]) {
+      throw new Error(`Invalid embedding response index: ${item.index}.`);
+    }
+    ordered[item.index] = item.embedding;
+  }
+  const complete: number[][] = [];
+  for (let index = 0; index < expectedCount; index += 1) {
+    const embedding = ordered[index];
+    if (!embedding) {
+      throw new Error(
+        `Embedding count mismatch. Expected ${expectedCount}, received ${data.length}.`,
+      );
+    }
+    complete.push(embedding);
+  }
+  return complete;
+}
+
+function poolChunkEmbeddings(embeddings: number[][]): number[] {
+  const first = embeddings[0];
+  if (!first) throw new Error("Cannot pool empty embedding chunks.");
+  if (embeddings.length === 1) return first;
+
+  const summed = Array.from({ length: first.length }, () => 0);
+  for (const embedding of embeddings) {
+    if (embedding.length !== first.length) {
+      throw new Error("Cannot pool embedding chunks with different dimensions.");
+    }
+    for (let index = 0; index < embedding.length; index += 1) {
+      const value = embedding[index];
+      if (value === undefined || !Number.isFinite(value)) {
+        throw new TypeError(`Embedding contains non-finite value at index ${index}.`);
+      }
+      const current = summed[index];
+      if (current === undefined) {
+        throw new Error(`Missing embedding accumulator at index ${index}.`);
+      }
+      summed[index] = current + value;
+    }
+  }
+
+  let norm = 0;
+  const averaged = summed.map((value) => {
+    const average = value / embeddings.length;
+    norm += average * average;
+    return average;
+  });
+  const magnitude = Math.sqrt(norm);
+  return magnitude > 0 ? averaged.map((value) => value / magnitude) : averaged;
+}
 
 export async function embedTextsWithEndpointCompatibleModel(args: {
   config: EndpointCompatibleEmbeddingConfig;
   input: string[];
+  dimensions?: number;
   tier: OpenAiCompatibleTier;
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<number[][]> {
-  const request = endpointCompatibleEmbeddingsRequestSchema.parse({
+  const parsedRequest = endpointCompatibleEmbeddingsRequestSchema.parse({
     model: args.config.model,
     input: args.input,
+    dimensions: args.dimensions,
   });
+  const plan = buildEmbeddingInputPlan(parsedRequest.input);
+  const request = { ...parsedRequest, input: plan.input };
 
   const apiBaseUrl = buildOpenAiApiBaseUrl(args.config.baseUrl);
   const apiKey = args.config.apiKey.trim();
@@ -54,8 +159,7 @@ export async function embedTextsWithEndpointCompatibleModel(args: {
   }
 
   const parsedResponse = endpointCompatibleEmbeddingsResponseSchema.parse(await response.json());
+  const embeddings = orderResponseEmbeddings(parsedResponse.data, plan.input.length);
 
-  return [...parsedResponse.data]
-    .toSorted((left, right) => left.index - right.index)
-    .map((item) => item.embedding);
+  return plan.ranges.map(([start, end]) => poolChunkEmbeddings(embeddings.slice(start, end)));
 }

--- a/src/lib/ai/openai-compatible/embeddings-client.ts
+++ b/src/lib/ai/openai-compatible/embeddings-client.ts
@@ -33,7 +33,7 @@ function splitEmbeddingInput(text: string): string[] {
     const chunk = text.slice(start, end).trim();
     if (chunk.length > 0) chunks.push(chunk);
     start = end;
-    while (start < text.length && /\s/.test(text[start] ?? "")) start += 1;
+    while (start < text.length && /\s/.test(text.charAt(start))) start += 1;
   }
   return chunks;
 }

--- a/src/types/schemas/ai-openai-compatible.ts
+++ b/src/types/schemas/ai-openai-compatible.ts
@@ -288,7 +288,8 @@ export const responsesOutputMessageItemSchema = z.union([
 
 export const endpointCompatibleEmbeddingsRequestSchema = z.object({
   model: z.string().min(1),
-  input: z.array(z.string().min(1)).min(1),
+  input: z.array(z.string().trim().min(1)).min(1),
+  dimensions: z.number().int().min(32).max(2560).optional(),
 });
 
 export type EndpointCompatibleEmbeddingsRequest = z.infer<


### PR DESCRIPTION
## Summary
Promotes three documentation corrections from `dev` to `main` so the production docs accurately describe runtime behavior already shipped on `main`. Each correction prevents a developer from acting on misleading guidance.

## Changes

### Documentation
- **Bookmark cache invalidation now points at the real helper**: The cache table in `docs/architecture/caching.md` previously listed only `revalidateTag("bookmarks")` for the Bookmarks domain, implying a single tag covers the dataset. The actual code path uses `invalidateNextJsBookmarksCache()`, which purges the dataset, slug, tag, and search caches together. The table now names that helper and the inline tag list now enumerates the seven bookmark-related tags plus `search-index` instead of just `bookmarks` (`docs/architecture/caching.md`).
- **JSONB tag FTS instructions no longer recommend a broken cast**: `docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md` previously told implementers to build the `projects.tags` tsvector via `to_tsvector('english', coalesce(tags::text, ''))`. That cast emits JSONB syntax (quotes, braces) into the index and silently mis-indexes tags — especially for mixed string/object arrays like bookmarks. The note now mandates `jsonb_array_elements` and a `CASE` on `jsonb_typeof` to extract real tag text, and explicitly flags `tags::text` as unreliable (`docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md`).
- **AI test-coverage map now lists the persistAnalysis paths**: The test-suite inventory in `docs/architecture/ai-services.md` described `__tests__/lib/ai-openai-compatible.test.ts` as covering only SSE parsing and transport behavior, hiding the fact that it also asserts `persistAnalysis` success and error paths. Developers searching the doc for client-side persistence test coverage can now find it (`docs/architecture/ai-services.md`).

## Breaking Changes
None — documentation only.

## Related Issues
Squash-merges of #351, #352, #353 into `dev`; this PR promotes them to `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the embedding client’s request/response handling (chunking, reordering, and pooling), which can affect embedding values and downstream similarity/search behavior. Covered by new unit tests, but it touches core AI data-generation paths and external-provider contracts.
> 
> **Overview**
> **Endpoint-compatible embeddings are now chunk-safe and order-stable.** `embedTextsWithEndpointCompatibleModel` splits oversized input strings into ~32k-char chunks, reorders upstream results strictly by `index`, then mean-pools + L2-normalizes chunk vectors back into one embedding per original input.
> 
> The embeddings request schema now trims input strings and supports optional `dimensions` passthrough, and new tests assert index-order preservation and chunk pooling behavior.
> 
> Docs are updated to reflect the real bookmark cache invalidation helper/tag set, correct JSONB-tag FTS guidance (avoid `tags::text`), and clarify embeddings/test coverage notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6bbe435d8243ac1cdf5f08c3fa8df953a80dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces chunk-safe batch embedding generation: oversized inputs are split at whitespace boundaries, sent in a single expanded request, and pooled back to one normalized vector per original input. Ordering is now strict (sparse-array fill with gap/duplicate errors) instead of sort-only. Three companion documentation corrections align `caching.md`, `ai-services.md`, and the JSONB FTS plan with already-shipped runtime behavior.

- **Embedding client** (`embeddings-client.ts`): adds `splitEmbeddingInput` / `buildEmbeddingInputPlan` for chunking, `orderResponseEmbeddings` for strict index validation, and `poolChunkEmbeddings` for mean-pooling + L2 normalization; also accepts an optional `dimensions` parameter threaded through the request schema.
- **Schema** (`ai-openai-compatible.ts`): input strings are now `.trim()`-ed before the `.min(1)` check, and `dimensions` (int, 32–2560) is added as an optional field.
- **Tests** (`endpoint-compatible-embedding-config.test.ts`): two new cases cover reversed-order response handling and the chunk-split/pool math against known vectors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic changes are isolated to the embeddings client, the new strict ordering replaces a looser sort, and the chunking/pooling path is covered by targeted tests.

All code changes are additive and backward-compatible: non-chunked inputs follow the same single-embedding path as before, strict index validation replaces a less-safe sort, and the documentation corrections fix misleading guidance without touching runtime code.

src/lib/ai/openai-compatible/embeddings-client.ts — the normalization asymmetry between single-chunk and multi-chunk outputs is worth a second look when provider behavior is unknown.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/ai/openai-compatible/embeddings-client.ts | Adds chunking (32 768-char limit), pooling (mean + L2-normalize), and strict index ordering to the embeddings client; single-chunk path returns raw server embeddings while multi-chunk path returns L2-normalized vectors, creating a subtle normalization inconsistency. |
| src/types/schemas/ai-openai-compatible.ts | Adds .trim() to input strings and optional dimensions field (int, 32-2560) to the embeddings request schema; both changes are safe and intentional. |
| __tests__/lib/endpoint-compatible-embedding-config.test.ts | Adds two new test cases: response index ordering (reversed mock) and chunked-input pooling (32769-char input splits into 3 chunks, vectors validated against SQRT1_2); coverage looks correct and complete. |
| docs/architecture/caching.md | Updates Bookmarks invalidation column to name invalidateNextJsBookmarksCache() and enumerates the seven bookmark-related cache tags; documentation correction only. |
| docs/architecture/ai-services.md | Adds a sentence describing chunk-safe embeddings and expands the test inventory entry for ai-openai-compatible.test.ts to include persistAnalysis paths; documentation correction only. |
| docs/plans/2026-02-26-embedding-similarity-upgrade-plan.md | Replaces the broken tags::text cast guidance with jsonb_array_elements / CASE pattern for correct FTS indexing; documentation correction only. |
| docs/file-map.md | Single-line description update for embeddings-client.ts to reflect chunk-safe behavior; trivial documentation sync. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["embedTextsWithEndpointCompatibleModel(input[])"] --> B["Schema parse + trim inputs"]
    B --> C["buildEmbeddingInputPlan"]
    C --> D{Each input > 32768 chars?}
    D -- No --> E["1 chunk = original text"]
    D -- Yes --> F["splitEmbeddingInput: whitespace-aware chunking"]
    F --> G["N chunks per logical input"]
    E --> H["Flatten all chunks to single HTTP POST /v1/embeddings"]
    G --> H
    H --> I["orderResponseEmbeddings: strict index fill (throws on gap or duplicate)"]
    I --> J["For each logical input range: poolChunkEmbeddings"]
    J --> K{Single chunk?}
    K -- Yes --> L["Return raw embedding"]
    K -- No --> M["Mean-average + L2 normalize"]
    L --> N["Return number[][]"]
    M --> N
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fai%2Fopenai-compatible%2Fembeddings-client.ts%3A81-111%0A**Normalization%20asymmetry%20between%20single-chunk%20and%20multi-chunk%20paths**%0A%0A%60poolChunkEmbeddings%60%20returns%20the%20raw%20server%20embedding%20unchanged%20when%20%60embeddings.length%20%3D%3D%3D%201%60%20%28the%20%60return%20first%60%20early%20exit%29%2C%20but%20applies%20mean-averaging%20followed%20by%20L2%20normalization%20when%20two%20or%20more%20chunks%20are%20pooled.%20This%20means%20a%2032%20767-char%20input%20and%20a%2032%20769-char%20input%20produce%20vectors%20with%20potentially%20different%20norms%2C%20which%20silently%20shifts%20cosine-similarity%20scores%20for%20long%20documents%20relative%20to%20shorter%20ones.%20If%20the%20provider%20already%20returns%20L2-normalized%20vectors%20%28common%20for%20modern%20embedding%20models%29%20the%20asymmetry%20is%20harmless%2C%20but%20it%20is%20undocumented%20and%20easy%20to%20break%20when%20switching%20providers.%20Normalizing%20the%20single-chunk%20path%20too%2C%20or%20adding%20a%20doc%20comment%20noting%20the%20assumption%2C%20would%20make%20the%20contract%20explicit.%0A%0A&repo=williamagh%2Fwilliamcallahan.com&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fai%2Fopenai-compatible%2Fembeddings-client.ts%3A81-111%0A**Normalization%20asymmetry%20between%20single-chunk%20and%20multi-chunk%20paths**%0A%0A%60poolChunkEmbeddings%60%20returns%20the%20raw%20server%20embedding%20unchanged%20when%20%60embeddings.length%20%3D%3D%3D%201%60%20%28the%20%60return%20first%60%20early%20exit%29%2C%20but%20applies%20mean-averaging%20followed%20by%20L2%20normalization%20when%20two%20or%20more%20chunks%20are%20pooled.%20This%20means%20a%2032%20767-char%20input%20and%20a%2032%20769-char%20input%20produce%20vectors%20with%20potentially%20different%20norms%2C%20which%20silently%20shifts%20cosine-similarity%20scores%20for%20long%20documents%20relative%20to%20shorter%20ones.%20If%20the%20provider%20already%20returns%20L2-normalized%20vectors%20%28common%20for%20modern%20embedding%20models%29%20the%20asymmetry%20is%20harmless%2C%20but%20it%20is%20undocumented%20and%20easy%20to%20break%20when%20switching%20providers.%20Normalizing%20the%20single-chunk%20path%20too%2C%20or%20adding%20a%20doc%20comment%20noting%20the%20assumption%2C%20would%20make%20the%20contract%20explicit.%0A%0A&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Fwilliamcallahan.com%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fai%2Fopenai-compatible%2Fembeddings-client.ts%3A81-111%0A**Normalization%20asymmetry%20between%20single-chunk%20and%20multi-chunk%20paths**%0A%0A%60poolChunkEmbeddings%60%20returns%20the%20raw%20server%20embedding%20unchanged%20when%20%60embeddings.length%20%3D%3D%3D%201%60%20%28the%20%60return%20first%60%20early%20exit%29%2C%20but%20applies%20mean-averaging%20followed%20by%20L2%20normalization%20when%20two%20or%20more%20chunks%20are%20pooled.%20This%20means%20a%2032%20767-char%20input%20and%20a%2032%20769-char%20input%20produce%20vectors%20with%20potentially%20different%20norms%2C%20which%20silently%20shifts%20cosine-similarity%20scores%20for%20long%20documents%20relative%20to%20shorter%20ones.%20If%20the%20provider%20already%20returns%20L2-normalized%20vectors%20%28common%20for%20modern%20embedding%20models%29%20the%20asymmetry%20is%20harmless%2C%20but%20it%20is%20undocumented%20and%20easy%20to%20break%20when%20switching%20providers.%20Normalizing%20the%20single-chunk%20path%20too%2C%20or%20adding%20a%20doc%20comment%20noting%20the%20assumption%2C%20would%20make%20the%20contract%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib/ai/openai-compatible/embeddings-client.ts:81-111
**Normalization asymmetry between single-chunk and multi-chunk paths**

`poolChunkEmbeddings` returns the raw server embedding unchanged when `embeddings.length === 1` (the `return first` early exit), but applies mean-averaging followed by L2 normalization when two or more chunks are pooled. This means a 32 767-char input and a 32 769-char input produce vectors with potentially different norms, which silently shifts cosine-similarity scores for long documents relative to shorter ones. If the provider already returns L2-normalized vectors (common for modern embedding models) the asymmetry is harmless, but it is undocumented and easy to break when switching providers. Normalizing the single-chunk path too, or adding a doc comment noting the assumption, would make the contract explicit.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(caching): refresh bookmark cache ta..."](https://github.com/williamagh/williamcallahan.com/commit/1d6bbe435d8243ac1cdf5f08c3fa8df953a80dbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32282974)</sub>

<!-- /greptile_comment -->