### PR TITLE
fix: AI analysis and Karakeep image persistence — stop enrichment data loss, serve stable S3 images, fix cache invalidation

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -100,13 +100,14 @@ AUDIOBOOKSHELF_LIBRARY_ID=
 AI_TOKEN_SIGNING_SECRET=
 
 # Optional defaults (used when feature-specific vars are not set)
-AI_DEFAULT_OPENAI_BASE_URL=
-AI_DEFAULT_LLM_MODEL=openai/gpt-oss-120b,openai/gpt-oss-20b
+# Researchly LLM gateway data-plane channel; qwen3.6:onprem = own-network inference only
+AI_DEFAULT_OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
+AI_DEFAULT_LLM_MODEL=qwen3.6:onprem
 # Optional embedding model for endpoint-compatible `/v1/embeddings` upstreams
-# AI_DEFAULT_EMBEDDING_MODEL=text-embedding-qwen3-embedding-4b
-# AI_DEFAULT_OPENAI_API_KEY=
+# AI_DEFAULT_EMBEDDING_MODEL=qwen/qwen3-embedding-4b
+# AI_DEFAULT_OPENAI_API_KEY=lgw-your-gateway-client-key
 
 # Feature-specific example (feature = "search" -> AI_SEARCH_*)
 # AI_SEARCH_OPENAI_BASE_URL=
-# AI_SEARCH_LLM_MODEL=openai/gpt-oss-120b,openai/gpt-oss-20b
+# AI_SEARCH_LLM_MODEL=qwen3.6:onprem
 # AI_SEARCH_OPENAI_API_KEY=

--- a/__tests__/lib/bookmarks/checksum-gate.unit.test.ts
+++ b/__tests__/lib/bookmarks/checksum-gate.unit.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { calculateBookmarksChecksum } from "@/lib/bookmarks/utils";
+import type { RawApiBookmark, UnifiedBookmark } from "@/types/schemas/bookmark";
+
+const mockGetBookmarksIndexFromDatabase = vi.fn();
+const mockGetAllBookmarks = vi.fn();
+
+vi.mock("@/lib/db/queries/bookmarks", () => ({
+  getBookmarksIndexFromDatabase: (...args: unknown[]) => mockGetBookmarksIndexFromDatabase(...args),
+  getAllBookmarks: (...args: unknown[]) => mockGetAllBookmarks(...args),
+}));
+
+import { validateChecksumAndGetCached } from "@/lib/bookmarks/refresh-helpers";
+
+const CREATED_AT = "2026-01-01T00:00:00.000Z";
+const MODIFIED_AT = "2026-02-01T00:00:00.000Z";
+
+function buildRaw(id: string, modifiedAt = MODIFIED_AT): RawApiBookmark {
+  return { id, createdAt: CREATED_AT, modifiedAt } as RawApiBookmark;
+}
+
+function buildCached(id: string): UnifiedBookmark {
+  return {
+    id,
+    slug: `example-com-${id}`,
+    url: `https://example.com/${id}`,
+    title: `Bookmark ${id}`,
+    description: "",
+    tags: [],
+    dateBookmarked: CREATED_AT,
+    modifiedAt: MODIFIED_AT,
+    sourceUpdatedAt: MODIFIED_AT,
+  } as UnifiedBookmark;
+}
+
+describe("validateChecksumAndGetCached", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the cached dataset when the raw checksum matches the persisted index checksum", async () => {
+    const raw = [buildRaw("a"), buildRaw("b")];
+    const cached = [buildCached("a"), buildCached("b")];
+    mockGetBookmarksIndexFromDatabase.mockResolvedValue({
+      checksum: calculateBookmarksChecksum(cached),
+      count: cached.length,
+    });
+    mockGetAllBookmarks.mockResolvedValue(cached);
+
+    const result = await validateChecksumAndGetCached(raw, false);
+
+    expect(result.cached).toEqual(cached);
+  });
+
+  it("returns null cache when a bookmark's modifiedAt changed upstream", async () => {
+    const raw = [buildRaw("a"), buildRaw("b", "2026-03-01T00:00:00.000Z")];
+    const cached = [buildCached("a"), buildCached("b")];
+    mockGetBookmarksIndexFromDatabase.mockResolvedValue({
+      checksum: calculateBookmarksChecksum(cached),
+      count: cached.length,
+    });
+    mockGetAllBookmarks.mockResolvedValue(cached);
+
+    const result = await validateChecksumAndGetCached(raw, false);
+
+    expect(result.cached).toBeNull();
+  });
+
+  it("skips the cache entirely when force is requested", async () => {
+    const result = await validateChecksumAndGetCached([buildRaw("a")], true);
+
+    expect(result.cached).toBeNull();
+    expect(mockGetBookmarksIndexFromDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/bookmarks/enrichment-hydration.test.ts
+++ b/__tests__/lib/bookmarks/enrichment-hydration.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { hydrateEnrichment, needsKarakeepImageUpgrade } from "@/lib/bookmarks/enrichment-hydration";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
+
+const TIMESTAMP = "2026-01-01T00:00:00.000Z";
+
+function buildBookmark(overrides: Partial<UnifiedBookmark> = {}): UnifiedBookmark {
+  return {
+    id: "bm-1",
+    slug: "example-com-bm-1",
+    url: "https://example.com/article",
+    title: "Example",
+    description: "",
+    tags: [],
+    dateBookmarked: TIMESTAMP,
+    sourceUpdatedAt: TIMESTAMP,
+    ...overrides,
+  } as UnifiedBookmark;
+}
+
+describe("hydrateEnrichment", () => {
+  it("fills missing enrichment fields from the prior persisted row", () => {
+    const fresh = buildBookmark();
+    const prior = buildBookmark({
+      ogImage: "https://s3-storage.callahan.cloud/images/opengraph/example-com-abcd1234.png",
+      ogTitle: "Persisted title",
+      readingTime: 4,
+    });
+
+    const [hydrated] = hydrateEnrichment([fresh], [prior]);
+
+    expect(hydrated?.ogImage).toBe(prior.ogImage);
+    expect(hydrated?.ogTitle).toBe("Persisted title");
+    expect(hydrated?.readingTime).toBe(4);
+  });
+
+  it("never overwrites enrichment already present on the fresh bookmark", () => {
+    const fresh = buildBookmark({ ogTitle: "Fresh title" });
+    const prior = buildBookmark({ ogTitle: "Stale title" });
+
+    const [hydrated] = hydrateEnrichment([fresh], [prior]);
+
+    expect(hydrated?.ogTitle).toBe("Fresh title");
+  });
+
+  it("leaves bookmarks without a prior row untouched", () => {
+    const fresh = buildBookmark({ id: "new-bookmark" });
+
+    const [hydrated] = hydrateEnrichment([fresh], [buildBookmark()]);
+
+    expect(hydrated?.ogImage).toBeUndefined();
+  });
+});
+
+describe("needsKarakeepImageUpgrade", () => {
+  const content = { type: "link", imageAssetId: "asset-1" } as UnifiedBookmark["content"];
+
+  it("is true when a Karakeep asset exists but ogImage is missing", () => {
+    expect(needsKarakeepImageUpgrade(buildBookmark({ content }))).toBe(true);
+  });
+
+  it("is true when ogImage is still a proxy URL", () => {
+    expect(
+      needsKarakeepImageUpgrade(buildBookmark({ content, ogImage: "/api/assets/asset-1" })),
+    ).toBe(true);
+  });
+
+  it("is false once ogImage points at the CDN", () => {
+    expect(
+      needsKarakeepImageUpgrade(
+        buildBookmark({
+          content,
+          ogImage: "https://s3-storage.callahan.cloud/images/opengraph/example-com-abcd1234.png",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when the bookmark has no Karakeep assets", () => {
+    expect(needsKarakeepImageUpgrade(buildBookmark())).toBe(false);
+  });
+});

--- a/__tests__/lib/caching/cache.test.ts
+++ b/__tests__/lib/caching/cache.test.ts
@@ -1,4 +1,20 @@
-import { CACHE_TTL, getCacheProfile, withCacheFallback, USE_NEXTJS_CACHE } from "@/lib/cache";
+const mockCacheTag = vi.fn();
+const mockCacheLife = vi.fn();
+const mockRevalidateTag = vi.fn();
+
+vi.mock("next/cache", () => ({
+  cacheTag: (...args: unknown[]) => mockCacheTag(...args),
+  cacheLife: (...args: unknown[]) => mockCacheLife(...args),
+  revalidateTag: (...args: unknown[]) => mockRevalidateTag(...args),
+}));
+
+import {
+  CACHE_TTL,
+  cacheContextGuards,
+  getCacheProfile,
+  withCacheFallback,
+  USE_NEXTJS_CACHE,
+} from "@/lib/cache";
 
 describe("lib/cache", () => {
   describe("CACHE_TTL constants", () => {
@@ -79,6 +95,29 @@ describe("lib/cache", () => {
   describe("USE_NEXTJS_CACHE", () => {
     it("should be a boolean", () => {
       expect(typeof USE_NEXTJS_CACHE).toBe("boolean");
+    });
+  });
+
+  describe("cacheContextGuards during production build", () => {
+    it("forwards cacheTag and cacheLife so prerendered entries stay invalidatable by revalidateTag", () => {
+      const previousPhase = process.env.NEXT_PHASE;
+      process.env.NEXT_PHASE = "phase-production-build";
+      mockCacheTag.mockClear();
+      mockCacheLife.mockClear();
+
+      try {
+        cacheContextGuards.cacheTag("AiAnalysis", "ai-analysis-bookmarks-abc");
+        cacheContextGuards.cacheLife("AiAnalysis", { revalidate: 86400 });
+
+        expect(mockCacheTag).toHaveBeenCalledWith("ai-analysis-bookmarks-abc");
+        expect(mockCacheLife).toHaveBeenCalledWith({ revalidate: 86400 });
+      } finally {
+        if (previousPhase === undefined) {
+          delete process.env.NEXT_PHASE;
+        } else {
+          process.env.NEXT_PHASE = previousPhase;
+        }
+      }
     });
   });
 });

--- a/__tests__/lib/db/mutations/bookmarks-conflict-update.test.ts
+++ b/__tests__/lib/db/mutations/bookmarks-conflict-update.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { is, SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  BOOKMARK_ENRICHMENT_FIELDS,
+  mapUnifiedBookmarkToBookmarkInsert,
+} from "@/lib/db/bookmark-record-mapper";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
+
+vi.mock("@/lib/db/connection", () => ({
+  db: {},
+  assertDatabaseWriteAllowed: vi.fn(),
+}));
+
+import { buildBookmarkConflictUpdate } from "@/lib/db/mutations/bookmarks";
+
+function buildInsert(overrides: Partial<UnifiedBookmark> = {}) {
+  const timestamp = "2026-01-01T00:00:00.000Z";
+  return mapUnifiedBookmarkToBookmarkInsert({
+    id: "bm-1",
+    slug: "example-com-bm-1",
+    url: "https://example.com/article",
+    title: "Example",
+    description: "An example bookmark",
+    tags: [],
+    dateBookmarked: timestamp,
+    sourceUpdatedAt: timestamp,
+    ...overrides,
+  } as UnifiedBookmark);
+}
+
+describe("buildBookmarkConflictUpdate", () => {
+  it("wraps every enrichment-owned column in COALESCE so incoming NULL keeps the stored value", () => {
+    const set = buildBookmarkConflictUpdate(buildInsert());
+    const dialect = new PgDialect();
+
+    for (const key of BOOKMARK_ENRICHMENT_FIELDS) {
+      const value = set[key];
+      if (!is(value, SQL)) {
+        throw new Error(`${key} must be a SQL expression`);
+      }
+      const rendered = dialect.sqlToQuery(value).sql;
+      expect(rendered).toContain("coalesce(excluded.");
+      expect(rendered).toContain('"bookmarks".');
+    }
+  });
+
+  it("passes source-owned Karakeep fields through for overwrite", () => {
+    const set = buildBookmarkConflictUpdate(
+      buildInsert({ title: "Updated title", description: "Updated description" }),
+    );
+
+    expect(set.title).toBe("Updated title");
+    expect(set.description).toBe("Updated description");
+    expect(set.url).toBe("https://example.com/article");
+    expect("id" in set).toBe(false);
+  });
+});

--- a/docs/features/bookmarks.md
+++ b/docs/features/bookmarks.md
@@ -63,6 +63,15 @@ Derived columns are computed during normalization (`lib/bookmarks/normalize.ts`)
 - **`og_title`**, **`og_description`**, **`og_image`**: Populated during OG enrichment (`lib/bookmarks/enrich-opengraph.ts`) or backfilled by fetching bookmark URLs and parsing `<meta property="og:*">` tags.
 - **`logo_data`**: `{url, alt}` JSONB mapped from the S3 CDN logo manifest (`json/image-data/logos/manifest.json`) keyed by bookmark domain.
 
+### Enrichment Preservation Contract
+
+Enrichment-owned columns are listed once in `BOOKMARK_ENRICHMENT_FIELDS` (`lib/db/bookmark-record-mapper.ts`); all consumers bind that list:
+
+- **Upsert** (`lib/db/mutations/bookmarks.ts`): on conflict these columns use `COALESCE(excluded.col, bookmarks.col)` so a less-enriched dataset can never null out persisted enrichment.
+- **Hydration** (`lib/bookmarks/enrichment-hydration.ts`): freshly normalized Karakeep payloads are merged with prior persisted rows before enrichment, so unchanged bookmarks skip image work and partial refreshes carry enrichment forward.
+- **Refresh gate** (`lib/bookmarks/refresh-helpers.ts`): the raw-API checksum is computed with the same canonical `calculateBookmarksChecksum`; in data-updater mode the cached short-circuit is bypassed while any bookmark still needs its Karakeep asset upgraded to an S3 CDN URL (`needsKarakeepImageUpgrade`).
+- **Runtime split**: only the data updater (`IS_DATA_UPDATER=true`) downloads Karakeep assets and persists them to S3; the web runtime keeps the relative `/api/assets/<id>` proxy URL (never passed to `persistImageToS3`, which rejects app-relative URLs) until the next updater run upgrades it.
+
 ### Backfill Scripts
 
 All backfill scripts are standalone Node (`#!/usr/bin/env node`) scripts using `postgres` directly. They share a production write guard pattern (`assertDatabaseWriteAllowed`) and support `--dry-run`, `--force`, and `--ids` flags.

--- a/docs/file-map.md
+++ b/docs/file-map.md
@@ -223,6 +223,7 @@ File/Path Functionality Description
 - [x] `blog.ts` `blog` - Blog data helper functions
 - [x] `bookmarks.{client,server}.ts` `json-handling` - Helper functions for bookmarks
 - [x] `bookmarks.ts` `json-handling` - Core bookmarks logic
+- [x] `bookmarks/enrichment-hydration.ts` `bookmarks` - Merges prior persisted enrichment into refreshed datasets; pending Karakeep image-upgrade predicate
 - [x] `cache.ts` `caching` - Node-cache setup and utilities
 - [x] `constants.ts` `overview` - Project-wide constants
 - [x] `education-data-processor.ts` `education` - Utilities for education logos and data

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -144,7 +144,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     return notFound();
   }
 
-  const projectId = project.id ?? project.name;
+  const projectId = project.id;
   const path = `/projects/${slug}`;
 
   // Fetch cached AI analysis from PostgreSQL (runs in parallel with rendering prep)

--- a/src/components/features/projects/project-ai-analysis.client.tsx
+++ b/src/components/features/projects/project-ai-analysis.client.tsx
@@ -171,13 +171,10 @@ export function ProjectAiAnalysis({
   initialAnalysis,
   defaultCollapsed = false,
 }: Readonly<ProjectAiAnalysisProps>) {
-  // Use project.id if available, otherwise fall back to project.name
-  const projectId = project.id ?? project.name;
-
   return (
     <AiAnalysisTerminal
       entity={project}
-      entityId={projectId}
+      entityId={project.id}
       featureName={AI_FEATURE_NAME}
       persistenceKey={PERSISTENCE_KEY}
       loadingMessages={LOADING_MESSAGES}

--- a/src/lib/ai/openai-compatible/feature-config.ts
+++ b/src/lib/ai/openai-compatible/feature-config.ts
@@ -6,8 +6,8 @@ import type {
 } from "@/types/schemas/ai-openai-compatible";
 import { requireEmbeddingSpaceIdForProviderModelId } from "@/lib/ai/embeddings/embedding-space-registry";
 
-const DEFAULT_BASE_URL = "https://popos-sf7.com";
-const DEFAULT_MODEL = "openai/gpt-oss-120b,openai/gpt-oss-20b";
+const DEFAULT_BASE_URL = "https://api.llm-gateway.iocloudhost.net";
+const DEFAULT_MODEL = "qwen3.6:onprem";
 const DEFAULT_MAX_PARALLEL = 1;
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-qwen3-embedding-4b";
 

--- a/src/lib/bookmarks/bookmarks.ts
+++ b/src/lib/bookmarks/bookmarks.ts
@@ -24,6 +24,7 @@ import {
   enrichWithOpenGraph,
   loadDatabaseFallback,
 } from "./refresh-helpers";
+import { hydrateEnrichmentFromDatabase } from "./enrichment-hydration";
 
 /**
  * Refreshes bookmarks data before persistence orchestration.
@@ -61,8 +62,11 @@ export async function refreshBookmarksData(force = false): Promise<UnifiedBookma
     // Normalize and generate slugs
     const normalizedBookmarks = await normalizeAndGenerateSlugs(allRawBookmarks);
 
+    // Carry forward prior enrichment so unchanged bookmarks skip image work
+    const hydratedBookmarks = await hydrateEnrichmentFromDatabase(normalizedBookmarks);
+
     // Enrich with OpenGraph data
-    const enrichedBookmarks = await enrichWithOpenGraph(normalizedBookmarks);
+    const enrichedBookmarks = await enrichWithOpenGraph(hydratedBookmarks);
 
     console.log("[refreshBookmarksData] Refresh cycle completed successfully.");
     return enrichedBookmarks;

--- a/src/lib/bookmarks/enrich-opengraph.ts
+++ b/src/lib/bookmarks/enrich-opengraph.ts
@@ -319,12 +319,17 @@ export async function processBookmarksInBatches(
               absoluteImageUrl = null;
             }
           } else {
-            // In web runtime, we can't fetch from Karakeep directly
-            // Just use the relative URL and let the client handle it
-            absoluteImageUrl = sourceImageUrl;
+            // Web runtime: keep the servable proxy URL and let the scheduled
+            // data updater upgrade it to a persisted S3 CDN URL. Relative
+            // URLs must never reach persistImageToS3 (fetch cannot resolve
+            // them server-side).
+            bookmark.ogImage = sourceImageUrl;
+            bookmark.ogImageExternal = sourceImageUrl;
             console.log(
-              `${LOG_PREFIX} 🔗 Web runtime: Using relative URL for Karakeep asset: ${absoluteImageUrl}`,
+              `${LOG_PREFIX} 🔗 Web runtime: keeping Karakeep proxy URL for later S3 upgrade: ${sourceImageUrl}`,
             );
+            sourceImageUrl = null;
+            absoluteImageUrl = null;
           }
         }
 
@@ -376,9 +381,10 @@ export async function processBookmarksInBatches(
               imageStats.bookmarksWithoutImages++;
             }
           }
-        } else {
-          // No valid image URL after processing
-          bookmark.ogImage = undefined;
+        } else if (!bookmark.ogImage) {
+          // Nothing resolved by the Karakeep branch and no prior image to
+          // keep. (The success paths above null sourceImageUrl/absoluteImageUrl
+          // after setting bookmark.ogImage — never clear their result here.)
           bookmark.ogImageExternal = undefined;
           imageStats.bookmarksWithoutImages++;
         }

--- a/src/lib/bookmarks/enrichment-hydration.ts
+++ b/src/lib/bookmarks/enrichment-hydration.ts
@@ -1,0 +1,66 @@
+/**
+ * Enrichment hydration for the bookmark refresh pipeline.
+ *
+ * Raw Karakeep payloads carry no enrichment (OpenGraph fields, logos,
+ * computed fields). Before re-enrichment, prior persisted values are merged
+ * in so unchanged bookmarks skip image work and partial refreshes can never
+ * regress previously enriched rows. Binds the canonical
+ * BOOKMARK_ENRICHMENT_FIELDS contract; do not restate the field list.
+ *
+ * @module lib/bookmarks/enrichment-hydration
+ */
+
+import { BOOKMARK_ENRICHMENT_FIELDS } from "@/lib/db/bookmark-record-mapper";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
+
+const mergeField = <K extends (typeof BOOKMARK_ENRICHMENT_FIELDS)[number]>(
+  target: UnifiedBookmark,
+  prior: UnifiedBookmark,
+  field: K,
+): void => {
+  target[field] ??= prior[field];
+};
+
+/** Merge prior persisted enrichment into freshly normalized bookmarks (in place). */
+export function hydrateEnrichment(
+  bookmarks: UnifiedBookmark[],
+  existing: readonly UnifiedBookmark[],
+): UnifiedBookmark[] {
+  const priorById = new Map(existing.map((bookmark) => [bookmark.id, bookmark]));
+  for (const bookmark of bookmarks) {
+    const prior = priorById.get(bookmark.id);
+    if (!prior) continue;
+    for (const field of BOOKMARK_ENRICHMENT_FIELDS) {
+      mergeField(bookmark, prior, field);
+    }
+  }
+  return bookmarks;
+}
+
+/** Hydrate enrichment from the persisted PostgreSQL dataset. */
+export async function hydrateEnrichmentFromDatabase(
+  bookmarks: UnifiedBookmark[],
+): Promise<UnifiedBookmark[]> {
+  try {
+    const { getAllBookmarks } = await import("@/lib/db/queries/bookmarks");
+    return hydrateEnrichment(bookmarks, await getAllBookmarks());
+  } catch (error) {
+    console.warn(
+      "[refreshBookmarksData] Prior enrichment unavailable; continuing with raw dataset:",
+      String(error),
+    );
+    return bookmarks;
+  }
+}
+
+/**
+ * A bookmark still needs the data updater to move its Karakeep asset into S3
+ * when it has an asset but its ogImage is missing or still a proxy URL.
+ */
+export function needsKarakeepImageUpgrade(bookmark: UnifiedBookmark): boolean {
+  const hasKarakeepAsset = Boolean(
+    bookmark.content?.imageAssetId || bookmark.content?.screenshotAssetId,
+  );
+  if (!hasKarakeepAsset) return false;
+  return !bookmark.ogImage || bookmark.ogImage.startsWith("/api/assets/");
+}

--- a/src/lib/bookmarks/refresh-helpers.ts
+++ b/src/lib/bookmarks/refresh-helpers.ts
@@ -10,7 +10,8 @@
 import { BOOKMARKS_API_CONFIG } from "@/lib/constants";
 import { normalizeBookmarks } from "./normalize";
 import { processBookmarksInBatches } from "./enrich-opengraph";
-import { createHash } from "node:crypto";
+import { calculateBookmarksChecksum } from "./utils";
+import { needsKarakeepImageUpgrade } from "./enrichment-hydration";
 
 import {
   type UnifiedBookmark,
@@ -152,8 +153,16 @@ export async function validateChecksumAndGetCached(
   allRawBookmarks: RawApiBookmark[],
   force: boolean,
 ): Promise<ChecksumResult> {
-  const rawJsonString = JSON.stringify(allRawBookmarks);
-  const rawChecksum = createHash("sha256").update(rawJsonString).digest("hex");
+  // Must match the canonical checksum persisted by rebuildBookmarkTaxonomyState
+  // (calculateBookmarksChecksum over the unified dataset), so project raw
+  // API fields onto the same identity + modification shape.
+  const rawChecksum = calculateBookmarksChecksum(
+    allRawBookmarks.map((raw) => ({
+      id: raw.id,
+      dateBookmarked: raw.createdAt,
+      modifiedAt: raw.modifiedAt,
+    })),
+  );
 
   if (force) {
     console.log("[refreshBookmarksData] Force refresh requested, skipping checksum check.");
@@ -184,7 +193,20 @@ export async function validateChecksumAndGetCached(
       return { cached: null, checksum: rawChecksum };
     }
 
-    console.log(`[refreshBookmarksData] Raw checksum unchanged (${rawChecksum}) - reuse cached.`);
+    // The data updater is the only runtime able to move Karakeep assets into
+    // S3; reusing the cache there must not strand bookmarks whose images are
+    // still proxy URLs or missing.
+    if (process.env.IS_DATA_UPDATER === "true") {
+      const pendingImageUpgrades = cachedBookmarks.filter(needsKarakeepImageUpgrade).length;
+      if (pendingImageUpgrades > 0) {
+        console.log(
+          `[refreshBookmarksData] ${pendingImageUpgrades} bookmarks awaiting S3 image upgrade; running full enrichment.`,
+        );
+        return { cached: null, checksum: rawChecksum };
+      }
+    }
+
+    console.log(`[refreshBookmarksData] Raw checksum unchanged - reuse cached.`);
     return { cached: cachedBookmarks, checksum: rawChecksum };
   } catch (error) {
     console.warn(

--- a/src/lib/bookmarks/utils.ts
+++ b/src/lib/bookmarks/utils.ts
@@ -172,8 +172,12 @@ export const convertBookmarksToSerializable = (
 /**
  * Calculate checksum for bookmark array based on id and modification time.
  * Order-insensitive: sorts by id to avoid false change detection from reordering.
+ * Accepts any projection carrying identity + modification fields so raw API
+ * payloads and persisted UnifiedBookmarks produce comparable values.
  */
-export const calculateBookmarksChecksum = (bookmarks: UnifiedBookmark[]): string =>
+export const calculateBookmarksChecksum = (
+  bookmarks: ReadonlyArray<Pick<UnifiedBookmark, "id" | "dateBookmarked" | "modifiedAt">>,
+): string =>
   [...bookmarks]
     .toSorted((a, b) => (a.id || "").localeCompare(b.id || ""))
     .map((b) => `${b.id}:${b.modifiedAt || b.dateBookmarked}`)

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -22,17 +22,20 @@ export { CACHE_TTL, USE_NEXTJS_CACHE };
 const PHASE_ENV_KEY = "NEXT_PHASE" as const;
 const BUILD_PHASE_VALUE = "phase-production-build" as const;
 
-export const isCliLikeCacheContext = (): boolean => {
+/** True when running as a standalone CLI script (no Next.js cache runtime). */
+const isCliProcessContext = (): boolean => {
   const argv1 = process.argv[1] || "";
   const inScriptsDir = /(^|[\\/])scripts[\\/]/.test(argv1);
   return (
     inScriptsDir ||
     process.argv.includes("data-updater") ||
     process.argv.includes("reset-and-regenerate") ||
-    process.argv.includes("regenerate-content") ||
-    process.env[PHASE_ENV_KEY] === BUILD_PHASE_VALUE
+    process.argv.includes("regenerate-content")
   );
 };
+
+export const isCliLikeCacheContext = (): boolean =>
+  isCliProcessContext() || process.env[PHASE_ENV_KEY] === BUILD_PHASE_VALUE;
 
 const logCacheError = (
   category: string,
@@ -41,7 +44,7 @@ const logCacheError = (
 ): void => {
   const message = error instanceof Error ? error.message : String(error);
   const isDevelopment = process.env.NODE_ENV === "development";
-  const isCliContext = isCliLikeCacheContext();
+  const isCliContext = isCliProcessContext();
 
   // Always log cache errors, but use appropriate level
   if (isDevelopment && !isCliContext && !process.env.SUPPRESS_CACHE_WARNINGS) {
@@ -73,9 +76,15 @@ const withGuard = <Args extends unknown[]>(
   };
 };
 
+// NOTE: these guards must stay active during `next build` prerendering.
+// cacheTag/cacheLife are valid inside any "use cache" scope at build time and
+// are the only way prerendered entries become addressable by revalidateTag
+// later (skipping them bakes untagged, uninvalidatable entries into the
+// static output). Only true CLI scripts — where no cache runtime exists and
+// the Next APIs throw — are excluded; withGuard logs those throws.
 export const cacheContextGuards = {
   cacheLife: withGuard("cacheLife", (category: string, profile: CacheDurationProfile) => {
-    if (typeof nextCacheLife === "function" && !isCliLikeCacheContext()) {
+    if (typeof nextCacheLife === "function" && !isCliProcessContext()) {
       // Next.js uses function overloads, not a union type, so we need to handle each case
       if (typeof profile === "string") {
         // Use a type assertion that's more specific than any
@@ -88,12 +97,12 @@ export const cacheContextGuards = {
     }
   }),
   cacheTag: withGuard("cacheTag", (_category: string, ...tags: string[]) => {
-    if (typeof nextCacheTag === "function" && !isCliLikeCacheContext()) {
+    if (typeof nextCacheTag === "function" && !isCliProcessContext()) {
       for (const tag of new Set(tags)) nextCacheTag(tag);
     }
   }),
   revalidateTag: withGuard("revalidateTag", (_category: string, ...tags: string[]) => {
-    if (typeof nextRevalidateTag === "function" && !isCliLikeCacheContext()) {
+    if (typeof nextRevalidateTag === "function" && !isCliProcessContext()) {
       for (const tag of new Set(tags)) nextRevalidateTag(tag, "max");
     }
   }),

--- a/src/lib/data-access/github-public-api.ts
+++ b/src/lib/data-access/github-public-api.ts
@@ -72,7 +72,9 @@ function formatActivityView(
   };
 
   const allTimeData = activityRecord.cumulativeAllTimeData || trailingYearData;
-  const priorYearCommits = allTimeData.allPriorYearCommits;
+  // Only the cumulative record carries prior-year commits; the trailing-year
+  // fallback never has them.
+  const priorYearCommits = activityRecord.cumulativeAllTimeData?.allPriorYearCommits;
 
   return {
     source,

--- a/src/lib/db/bookmark-record-mapper.ts
+++ b/src/lib/db/bookmark-record-mapper.ts
@@ -1,6 +1,27 @@
 import type { BookmarkInsert, BookmarkRef } from "@/types/db/bookmarks";
 import { unifiedBookmarkSchema, type UnifiedBookmark } from "@/types/schemas/bookmark";
 
+/**
+ * Canonical list of bookmark fields owned by enrichment/backfill pipelines
+ * (OpenGraph, logos, computed fields, scraped content) rather than the
+ * Karakeep source payload. Consumers must bind this list instead of
+ * restating it: the upsert preserves these columns via COALESCE and the
+ * refresh pipeline hydrates them from prior rows before re-enrichment.
+ */
+export const BOOKMARK_ENRICHMENT_FIELDS = [
+  "ogImage",
+  "ogTitle",
+  "ogDescription",
+  "ogUrl",
+  "ogImageExternal",
+  "ogImageLastFetchedAt",
+  "ogImageEtag",
+  "logoData",
+  "readingTime",
+  "wordCount",
+  "scrapedContentText",
+] as const satisfies ReadonlyArray<keyof UnifiedBookmark & keyof BookmarkInsert>;
+
 const toUndefined = <T>(value: T | null): T | undefined => {
   if (value === null) {
     return undefined;
@@ -8,9 +29,14 @@ const toUndefined = <T>(value: T | null): T | undefined => {
   return value;
 };
 
-/** Convert a nullable string to a valid URL or undefined. Silently drops non-URL values. */
+/**
+ * Convert a nullable string to a servable image URL or undefined.
+ * Accepts absolute URLs and app-relative paths (e.g. /api/assets/<id> proxy
+ * URLs persisted by the web runtime); drops anything else.
+ */
 const toUrlOrUndefined = (value: string | null): string | undefined => {
   if (!value) return undefined;
+  if (value.startsWith("/")) return value;
   return URL.canParse(value) ? value : undefined;
 };
 

--- a/src/lib/db/mutations/bookmarks.ts
+++ b/src/lib/db/mutations/bookmarks.ts
@@ -1,7 +1,9 @@
-import { and, eq, notInArray, sql } from "drizzle-orm";
+import { and, eq, notInArray, sql, type SQL } from "drizzle-orm";
+import type { PgColumn, PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { BOOKMARKS_PER_PAGE } from "@/lib/constants";
 import { calculateBookmarksChecksum } from "@/lib/bookmarks/utils";
 import {
+  BOOKMARK_ENRICHMENT_FIELDS,
   mapUnifiedBookmarksToBookmarkInserts,
   mapUnifiedBookmarkToBookmarkInsert,
 } from "@/lib/db/bookmark-record-mapper";
@@ -21,10 +23,26 @@ const GLOBAL_BOOKMARK_INDEX_STATE_ID = "global";
 const UPSERT_MAX_RETRIES = 3;
 const UPSERT_RETRY_DELAY_MS = 500;
 
-const buildBookmarkConflictUpdate = ({
+/**
+ * Enrichment-owned columns ([BOOKMARK_ENRICHMENT_FIELDS]) are produced by
+ * OpenGraph/logo/computed-field pipelines, not by the Karakeep source
+ * payload. A refresh that carries no enrichment must not erase previously
+ * persisted values, so on conflict these columns keep the stored value
+ * whenever the incoming one is NULL.
+ */
+const preserveEnrichment = (column: PgColumn): SQL =>
+  sql`coalesce(excluded.${sql.identifier(column.name)}, ${column})`;
+
+export const buildBookmarkConflictUpdate = ({
   id: _id,
   ...updatableFields
-}: BookmarkInsert): Omit<BookmarkInsert, "id"> => updatableFields;
+}: BookmarkInsert): PgUpdateSetSource<typeof bookmarks> => {
+  const set: PgUpdateSetSource<typeof bookmarks> = { ...updatableFields };
+  for (const field of BOOKMARK_ENRICHMENT_FIELDS) {
+    set[field] = preserveEnrichment(bookmarks[field]);
+  }
+  return set;
+};
 
 const buildBookmarkIndexStatePayload = (
   count: number,

--- a/src/lib/db/mutations/projects.ts
+++ b/src/lib/db/mutations/projects.ts
@@ -27,7 +27,7 @@ export async function upsertProjects(data: Project[]): Promise<number> {
 
   let upserted = 0;
   for (const item of data) {
-    const id = item.id ?? projectToSlug(item.name);
+    const id = item.id;
     const slug = projectToSlug(item.name);
     await db
       .insert(projects)

--- a/src/lib/db/queries/ai-analysis.ts
+++ b/src/lib/db/queries/ai-analysis.ts
@@ -8,6 +8,7 @@
 
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db/connection";
+import { envLogger } from "@/lib/utils/env-logger";
 import { aiAnalysisLatest, aiAnalysisVersions } from "@/lib/db/schema/ai-analysis";
 import {
   persistedBookmarkAnalysisSchema,
@@ -20,28 +21,45 @@ import type { AnalysisDomain, AnalysisVersion, CachedAnalysis } from "@/types/ai
 // Domain-specific Schema Selection
 // ─────────────────────────────────────────────────────────────────────────────
 
+const schemaForDomain = (domain: AnalysisDomain) => {
+  switch (domain) {
+    case "bookmarks":
+      return persistedBookmarkAnalysisSchema;
+    case "books":
+      return persistedBookAnalysisSchema;
+    case "projects":
+      return persistedProjectAnalysisSchema;
+  }
+};
+
 /**
  * Parse a raw JSONB payload through the domain-specific Zod schema.
  * Returns the validated CachedAnalysis or null on validation failure.
+ * Failures are logged: a stored payload that stops validating would
+ * otherwise be indistinguishable from missing data.
  */
 const parsePayloadForDomain = (
   domain: AnalysisDomain,
+  entityId: string,
   rawPayload: unknown,
 ): CachedAnalysis<unknown> | null => {
-  switch (domain) {
-    case "bookmarks": {
-      const result = persistedBookmarkAnalysisSchema.safeParse(rawPayload);
-      return result.success ? result.data : null;
-    }
-    case "books": {
-      const result = persistedBookAnalysisSchema.safeParse(rawPayload);
-      return result.success ? result.data : null;
-    }
-    case "projects": {
-      const result = persistedProjectAnalysisSchema.safeParse(rawPayload);
-      return result.success ? result.data : null;
-    }
+  const result = schemaForDomain(domain).safeParse(rawPayload);
+  if (result.success) {
+    return result.data;
   }
+
+  envLogger.log(
+    "Stored analysis payload failed schema validation",
+    {
+      domain,
+      entityId,
+      issues: result.error.issues
+        .slice(0, 3)
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`),
+    },
+    { category: "AiAnalysis" },
+  );
+  return null;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -67,7 +85,7 @@ export async function readLatestAnalysis(
     return null;
   }
 
-  return parsePayloadForDomain(domain, firstRow.payload);
+  return parsePayloadForDomain(domain, entityId, firstRow.payload);
 }
 
 /**

--- a/src/lib/image-handling/image-s3-utils.ts
+++ b/src/lib/image-handling/image-s3-utils.ts
@@ -15,7 +15,8 @@ const MIN_IMAGE_BUFFER_SIZE = 100;
 import { readBinaryS3, writeBinaryS3 } from "@/lib/s3/binary";
 import { debug, isDebug } from "@/lib/utils/debug";
 import { getOgImageS3Key, hashImageContent } from "@/lib/utils/opengraph-utils";
-import { listS3Objects } from "@/lib/s3/objects";
+import { checkIfS3ObjectExists } from "@/lib/s3/objects";
+import { BOOKMARKS_API_CONFIG } from "@/lib/constants";
 import { processImageBufferSimple } from "./shared-image-processing";
 import { isS3ReadOnly } from "@/lib/utils/s3-read-only";
 
@@ -42,6 +43,16 @@ export async function persistImageToS3(
       ? `${imageUrl.substring(0, 50)}...[base64 data truncated]`
       : imageUrl;
     console.log(`[${logContext}] Read-only mode: Skipping S3 persistence for ${displayUrl}`);
+    return null;
+  }
+
+  if (imageUrl.startsWith("/")) {
+    // App-relative proxy URLs (e.g. /api/assets/<id>) are not fetchable from
+    // the server; Karakeep assets must go through fetchKarakeepImage +
+    // persistImageBufferToS3 instead.
+    console.error(
+      `[${logContext}] Cannot persist app-relative URL ${imageUrl}; use the Karakeep asset buffer path.`,
+    );
     return null;
   }
 
@@ -176,6 +187,20 @@ export async function persistImageToS3(
 }
 
 /**
+ * A first-party Karakeep asset is either our own proxy URL or a URL on the
+ * configured Karakeep API host — not the hardcoded karakeep.app/hoarder.io
+ * SaaS domains, since this site runs a self-hosted instance.
+ */
+function isFirstPartyKarakeepAsset(imageUrl: string): boolean {
+  if (imageUrl.startsWith("/api/assets/")) return true;
+  try {
+    return new URL(imageUrl).hostname === new URL(BOOKMARKS_API_CONFIG.API_URL).hostname;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Handle stale image URLs by triggering automatic OpenGraph recrawl
  * This is called when image URLs return 404, indicating the OpenGraph metadata is stale
  */
@@ -187,7 +212,7 @@ async function handleStaleImageUrl(
   try {
     const { invalidateOpenGraphCacheForUrl } = await import("@/lib/data-access/opengraph");
 
-    const isKarakeepUrl = /^https?:\/\/(?:[^/]+\.)?(karakeep\.app|hoarder\.io)\/.+/i.test(imageUrl);
+    const isKarakeepUrl = isFirstPartyKarakeepAsset(imageUrl);
 
     // Only trigger recrawl for **first-party Karakeep / Hoarder assets**. Third-party images that
     // disappear (like a site's own og-image.png) should *not* force an immediate refetch cycle – we
@@ -252,72 +277,24 @@ export async function findImageInS3(
   idempotencyKey?: string,
   pageUrl?: string,
 ): Promise<string | null> {
-  // 1. Direct lookup for the ideal filename based on the full known path
+  // The key derivation is deterministic on (pageUrl, idempotencyKey) — the
+  // same inputs the writer uses — so a single existence check is sufficient.
+  // A list-and-substring fallback is impossible here: stored keys embed an
+  // 8-char hash, never the raw idempotency key.
   const idealKey = getOgImageS3Key(imageUrl, s3Directory, pageUrl, idempotencyKey);
-  if (isDebug)
-    debug(
-      `[${logContext}] Attempting direct S3 lookup with key: ${idealKey} for image: ${imageUrl}`,
-    );
   try {
-    const buffer = await readBinaryS3(idealKey);
-    if (buffer) {
+    if (await checkIfS3ObjectExists(idealKey)) {
       if (isDebug) debug(`[${logContext}] Found image by direct key lookup: ${idealKey}`);
       return idealKey;
     }
   } catch (error) {
-    // Catching potential errors from readBinaryS3 if it throws
     const errorMessage = error instanceof Error ? error.message : String(error);
-    if (isDebug)
-      debug(
-        `[${logContext}] Error during direct key lookup for ${idealKey}: ${errorMessage}. Proceeding to fallback search.`,
-      );
-  }
-
-  // 2. Fallback: List objects and search by idempotency key
-  // This is the most reliable fallback if the exact URL/hash has changed but the content ID hasn't.
-  if (isDebug)
-    debug(
-      `[${logContext}] Direct key lookup failed for ${idealKey}. Proceeding to fallback search by IdempotencyKey: ${idempotencyKey}`,
-    );
-  try {
-    if (idempotencyKey) {
-      const allImages = await listS3Objects(s3Directory);
-      if (allImages.length > 0) {
-        const foundById = allImages.find((key) => key.includes(idempotencyKey));
-        if (foundById) {
-          if (isDebug)
-            debug(
-              `[${logContext}] Fallback search: Found image by ID '${idempotencyKey}': ${foundById}`,
-            );
-          return foundById;
-        }
-        if (isDebug)
-          debug(
-            `[${logContext}] Fallback search: IdempotencyKey '${idempotencyKey}' not found in ${allImages.length} listed S3 objects in directory ${s3Directory}.`,
-          );
-      } else {
-        if (isDebug)
-          debug(
-            `[${logContext}] Fallback search: No images found in S3 directory ${s3Directory} to search by IdempotencyKey '${idempotencyKey}'.`,
-          );
-      }
-    } else {
-      if (isDebug)
-        debug(
-          `[${logContext}] Fallback search: No IdempotencyKey provided, skipping search by ID for image: ${imageUrl}.`,
-        );
-    }
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(
-      `[${logContext}] Error during fallback S3 object listing in ${s3Directory}:`,
-      errorMessage,
-    );
+    console.error(`[${logContext}] S3 existence check failed for ${idealKey}: ${errorMessage}`);
   }
 
   if (isDebug)
     debug(
-      `[${logContext}] All S3 lookups failed for image (Original URL: ${imageUrl}, IdempotencyKey: ${idempotencyKey}, PageURL: ${pageUrl}, IdealKey: ${idealKey})`,
+      `[${logContext}] No stored image for (Original URL: ${imageUrl}, IdempotencyKey: ${idempotencyKey}, PageURL: ${pageUrl}, IdealKey: ${idealKey})`,
     );
   return null;
 }

--- a/src/lib/persistence/image-persistence.ts
+++ b/src/lib/persistence/image-persistence.ts
@@ -16,24 +16,27 @@ function getDisplayUrl(imageUrl: string): string {
 
 /** Build full S3 CDN URL from an S3 key. Throws OgError if CDN URL is not configured. */
 function buildS3CdnUrl(s3Key: string): string {
-  const cdnUrl = getS3CdnUrl();
-  if (!cdnUrl) {
+  // getS3CdnUrl throws when NEXT_PUBLIC_S3_CDN_URL is unset; rewrap so
+  // callers receive the documented OgError code.
+  try {
+    return `${getS3CdnUrl()}/${s3Key}`;
+  } catch (error) {
     throw new OgError(
       "NEXT_PUBLIC_S3_CDN_URL not configured - cannot construct S3 URL",
       "s3-config-missing",
+      { originalError: error instanceof Error ? error : new Error(String(error)) },
     );
   }
-  return `${cdnUrl}/${s3Key}`;
 }
 
 /** Build S3 CDN URL, returning null on configuration error (for non-throwing contexts) */
 function buildS3CdnUrlOrNull(s3Key: string, logContext: string): string | null {
-  const cdnUrl = getS3CdnUrl();
-  if (!cdnUrl) {
+  try {
+    return `${getS3CdnUrl()}/${s3Key}`;
+  } catch {
     console.error(`[OpenGraph S3] ${logContext} NEXT_PUBLIC_S3_CDN_URL not configured`);
     return null;
   }
-  return `${cdnUrl}/${s3Key}`;
 }
 
 /** Schedule background image persistence to S3 */

--- a/src/lib/projects/slug-helpers.ts
+++ b/src/lib/projects/slug-helpers.ts
@@ -65,7 +65,7 @@ export function findProjectBySlug(slug: string, projects: Project[]): Project | 
   const projectSlugs = projects.map((project) => ({
     project,
     generated: generateProjectSlug(project.name, project.id),
-    idSlug: titleToSlug(project.id ?? project.name, 30),
+    idSlug: titleToSlug(project.id, 30),
     nameSlug: titleToSlug(project.name, 50),
   }));
 

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,8 +1,12 @@
 import type { RegistryLink } from "./schemas/registry-link";
 
 export interface Project {
-  /** Unique identifier for the project (typically same as name) */
-  id?: string;
+  /**
+   * Stable unique identifier for the project. Persistence identity for AI
+   * analysis and DB rows — never derive it from the display name and never
+   * rename it casually: renames orphan persisted content keyed by the old id.
+   */
+  id: string;
   name: string;
   description: string;
   shortSummary: string; // Short summary for concise display


### PR DESCRIPTION
## What this PR fixes

Two user-facing failure chains, root-caused from production data (DB row audits, S3 object listings, live-site checks):

### Karakeep/Hoarder images failed to persist and stay stable
- **Self-clobbering enrichment loop**: the data updater uploaded every Karakeep asset to S3, then overwrote its own result with `undefined` before persisting — 883/884 bookmarks had `og_image` NULL while 1,353 S3 objects sat unreferenced (`enrich-opengraph.ts`)
- **Destructive upsert**: bookmark conflict updates overwrote all columns, so any less-enriched refresh erased persisted enrichment; now `COALESCE(excluded.col, bookmarks.col)` over a canonical `BOOKMARK_ENRICHMENT_FIELDS` list
- **Dead change detection**: raw-API sha256 checksum was compared against an `id:modifiedAt` list — never equal — forcing full re-enrichment and re-upload of all 883 assets every 2 hours; both sides now use the canonical checksum
- **New: enrichment hydration** (`enrichment-hydration.ts`) carries prior persisted enrichment into refreshes (incremental work) and a data-updater gate self-heals the currently-NULL `og_image` rows on the first post-merge updater run
- **S3 lookup/persist contracts**: deterministic existence check replaces an impossible substring fallback; app-relative URLs rejected from the fetch path; self-hosted Karakeep host recognized for stale-asset recovery; CDN-URL builders honor their documented null/throw contracts

### AI analysis failed to retrieve / regenerated endlessly
- **Build-phase cache tags**: `cacheTag`/`cacheLife` were no-opped during `next build`, leaving prerendered "use cache" entries untagged and uninvalidatable — project pages regenerated their analysis on every visit (tui4j accumulated 8 versions). Verified against Next 16.1.6 sources
- **Stable project identity**: `Project.id` is now required; the `id ?? name` fallback orphaned analyses on rename (orphans cleaned from prod DB)
- **Observable read failures**: stored payloads that fail schema validation now log instead of silently returning null

Also: `github-public-api.ts` strict-mode type fix.

## Verification
- `bun run validate`: 0 errors / 0 warnings; full suite: 147 files, 1372 tests pass (12 new)
- Dev deploy dogfooded (report in session artifacts): bookmark/project/book analysis read paths render from DB with **zero** regeneration requests; 0 broken images; tags + search working; no regressions found
- Post-merge: the production scheduler's next `--bookmarks` run repopulates `og_image` with S3 CDN URLs automatically (`SELECT count(og_image) FROM bookmarks` should climb from 1 toward ~880)