### PR TITLE
fix(ai-analysis): render generated analysis even when persistence fails

### DIFF
--- a/src/hooks/use-ai-analysis.ts
+++ b/src/hooks/use-ai-analysis.ts
@@ -146,15 +146,23 @@ export function useAiAnalysis<TEntity, TAnalysis>(
 
         if (signal?.aborted) throw new DOMException("Analysis aborted", "AbortError");
 
+        // Persistence is an optimization, not a precondition for display: the
+        // analysis was generated successfully, so always render it. Failures
+        // are already Sentry-captured inside persistAnalysis; environments
+        // where the DB write guard blocks writes (e.g. dev subdomain) would
+        // otherwise show a permanent dead-end error.
         const persistResult = await persistAnalysis(persistenceKey, entityId, parsedAnalysis);
-        if (!persistResult.success) {
-          throw new Error(`Failed to persist analysis: ${persistResult.message}`);
-        }
 
         if (signal?.aborted) throw new DOMException("Analysis aborted", "AbortError");
 
         setState({ status: "success", analysis: parsedAnalysis, error: null });
-        router.refresh();
+        if (persistResult.success) {
+          router.refresh();
+        } else {
+          console.warn(
+            `[useAiAnalysis] Analysis displayed but not persisted: ${persistResult.message}`,
+          );
+        }
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") return;
         const message = error instanceof Error ? error.message : "Failed to generate analysis";


### PR DESCRIPTION
Follow-up to #356 (ISSUE-001 from the dev dogfood report).

The analysis hook treated the persist POST as fatal: a successfully generated analysis was discarded and visitors saw "Failed to persist analysis: Database write failed" with a Retry that re-burned LLM tokens. On the dev subdomain the DB write guard blocks all writes by design, making this a permanent dead end; on production it turned transient DB failures into user-visible errors.

Now the generated analysis always renders; persist failure skips `router.refresh()` and stays observable via the existing Sentry capture plus a console warning.

**Live-verified on dev** (where persistence always fails): `/bookmarks/together-ai-pricing` renders the full analysis with no error banner. `bun run validate` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only success-path change in the analysis hook; no auth or API contract changes beyond skipping refresh on failed persist.
> 
> **Overview**
> **`useAiAnalysis` no longer treats a failed persist POST as a fatal error** after the LLM response is parsed successfully.
> 
> The hook **always moves to success and shows the generated analysis**. **`router.refresh()` runs only when persistence succeeds**, so server-rendered cached analysis stays in sync when the DB write works. When persistence fails, users see the analysis anyway; failures stay visible via **`console.warn`** and existing **Sentry** handling inside `persistAnalysis` (no new error banner or Retry loop that re-calls the model).
> 
> This fixes dev environments where the DB write guard blocks all writes (permanent “Failed to persist analysis” dead end) and avoids turning transient production DB errors into discarded LLM output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2843a78ab012e4be051a3afceea2a355b085729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->