### PR TITLE
fix(site): reject unsafe API writes, preserve project URLs, and prevent stale content

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -103,9 +103,10 @@ AI_TOKEN_SIGNING_SECRET=
 # Researchly LLM gateway data-plane channel; qwen3.6:onprem = own-network inference only
 AI_DEFAULT_OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
 AI_DEFAULT_LLM_MODEL=qwen3.6:onprem
+# Required when using the default gateway above; set to an lgw-* client key.
+AI_DEFAULT_OPENAI_API_KEY=
 # Optional embedding model for endpoint-compatible `/v1/embeddings` upstreams
 # AI_DEFAULT_EMBEDDING_MODEL=qwen/qwen3-embedding-4b
-# AI_DEFAULT_OPENAI_API_KEY=lgw-your-gateway-client-key
 
 # Feature-specific example (feature = "search" -> AI_SEARCH_*)
 # AI_SEARCH_OPENAI_BASE_URL=

--- a/__tests__/__mocks__/lib/data-access/github.ts
+++ b/__tests__/__mocks__/lib/data-access/github.ts
@@ -2,7 +2,7 @@
  * Mock for GitHub data access module
  */
 
-import type { StoredGithubActivityRecord, UserActivityView } from "@/types/github";
+import type { StoredGithubActivity, UserActivityView } from "@/types/github";
 
 // Export S3 key constants that other modules may import
 export const GITHUB_ACTIVITY_S3_KEY_DIR = "github-activity";
@@ -29,7 +29,7 @@ const mockActivity: UserActivityView = {
   },
 };
 
-function toStoredRecord(segment: UserActivityView["trailingYearData"]): StoredGithubActivityRecord {
+function toStoredRecord(segment: UserActivityView["trailingYearData"]): StoredGithubActivity {
   return {
     source: "api",
     data: segment.data,
@@ -61,7 +61,7 @@ export function refreshGitHubActivityDataFromApi() {
       linesAdded: mockActivity.allTimeStats.linesAdded,
       linesRemoved: mockActivity.allTimeStats.linesRemoved,
       dataComplete: true,
-    } satisfies StoredGithubActivityRecord,
+    } satisfies StoredGithubActivity,
   });
 }
 

--- a/__tests__/__mocks__/next/navigation.ts
+++ b/__tests__/__mocks__/next/navigation.ts
@@ -27,4 +27,5 @@ export const useSearchParams = vi.fn(() => mockSearchParams);
 export const usePathname = vi.fn(() => "/");
 export const useParams = vi.fn(() => ({}));
 export const redirect = vi.fn();
+export const permanentRedirect = vi.fn();
 export const notFound = vi.fn();

--- a/__tests__/__mocks__/next/server.ts
+++ b/__tests__/__mocks__/next/server.ts
@@ -158,6 +158,19 @@ export class NextResponse {
   static next(init?: { headers?: Record<string, string> }): NextResponse {
     return new NextResponse(null, { status: 200, headers: init?.headers });
   }
+
+  static redirect(
+    url: string | URL,
+    init: number | { status?: number; headers?: Record<string, string> } = {},
+  ): NextResponse {
+    const responseInit =
+      typeof init === "number"
+        ? { status: init }
+        : { status: init.status ?? 307, headers: init.headers };
+    const response = new NextResponse(null, responseInit);
+    response.headers.set("location", url.toString());
+    return response;
+  }
 }
 
 // Mock connection() - Next.js 16 function to ensure request-time execution

--- a/__tests__/__mocks__/next/server.ts
+++ b/__tests__/__mocks__/next/server.ts
@@ -2,6 +2,8 @@
  * Mock for next/server module
  */
 
+import { vi } from "vitest";
+
 interface CookieOptions {
   name?: string;
   value?: string;
@@ -174,6 +176,4 @@ export class NextResponse {
 }
 
 // Mock connection() - Next.js 16 function to ensure request-time execution
-export async function connection(): Promise<void> {
-  return Promise.resolve();
-}
+export const connection = vi.fn(async (): Promise<void> => undefined);

--- a/__tests__/api/ai/chat-rag-helpers.test.ts
+++ b/__tests__/api/ai/chat-rag-helpers.test.ts
@@ -4,9 +4,12 @@
  */
 
 import { NextRequest } from "next/server";
+import { POST as persistAiAnalysis } from "@/app/api/ai/analysis/[domain]/[id]/route";
 import { buildRagContextForChat, validateRequest } from "@/app/api/ai/chat/[feature]/chat-helpers";
 import { isAbortError } from "@/app/api/ai/chat/[feature]/upstream-error";
+import { persistAnalysis as writeAnalysis } from "@/lib/ai-analysis/writer.server";
 import { buildContextForQuery } from "@/lib/ai/rag";
+import { isOperationAllowed } from "@/lib/rate-limiter";
 
 vi.mock("@/lib/ai/rag", () => ({
   buildContextForQuery: vi.fn().mockImplementation((query: string) =>
@@ -19,8 +22,48 @@ vi.mock("@/lib/ai/rag", () => ({
     }),
   ),
 }));
+vi.mock("@/lib/rate-limiter", () => ({
+  isOperationAllowed: vi.fn().mockReturnValue(true),
+}));
+vi.mock("@/lib/ai-analysis/writer.server", () => ({
+  persistAnalysis: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/utils/env-logger", () => ({
+  envLogger: {
+    log: vi.fn(),
+  },
+}));
 const mockedBuildContextForQuery = vi.mocked(buildContextForQuery);
+const mockedWriteAnalysis = vi.mocked(writeAnalysis);
+const mockedIsOperationAllowed = vi.mocked(isOperationAllowed);
 const conversationId = "77777777-7777-4777-8777-777777777777";
+const bookmarkAnalysis = {
+  summary: "Useful technical resource for practical implementation decisions.",
+  category: "Technology",
+  highlights: ["Explains the implementation tradeoffs clearly."],
+  contextualDetails: {
+    primaryDomain: "Programming",
+    format: "Article",
+    accessMethod: "Free",
+  },
+  relatedResources: ["Related implementation reference"],
+  targetAudience: "Developers",
+};
+
+function buildAnalysisPersistRequest(origin: string): NextRequest {
+  return Object.assign(
+    new NextRequest("https://williamcallahan.com/api/ai/analysis/bookmarks/bookmark-1", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin,
+      },
+    }),
+    {
+      json: () => Promise.resolve({ analysis: bookmarkAnalysis }),
+    },
+  );
+}
 
 describe("AI Chat RAG Helpers", () => {
   beforeEach(() => {
@@ -95,5 +138,41 @@ describe("AI Chat Abort Detection", () => {
 
   it("does not classify generic errors as abort errors", () => {
     expect(isAbortError(new Error("Boom"))).toBe(false);
+  });
+});
+
+describe("AI Analysis Persistence Route", () => {
+  beforeEach(() => {
+    mockedWriteAnalysis.mockClear();
+    mockedIsOperationAllowed.mockClear();
+    mockedIsOperationAllowed.mockReturnValue(true);
+  });
+
+  it("rejects cross-origin persistence before rate limiting or writing", async () => {
+    const request = buildAnalysisPersistRequest("https://attacker.example");
+
+    const response = await persistAiAnalysis(request, {
+      params: Promise.resolve({ domain: "bookmarks", id: "bookmark-1" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(mockedIsOperationAllowed).not.toHaveBeenCalled();
+    expect(mockedWriteAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("persists valid same-origin analysis", async () => {
+    const request = buildAnalysisPersistRequest("https://williamcallahan.com");
+
+    const response = await persistAiAnalysis(request, {
+      params: Promise.resolve({ domain: "bookmarks", id: "bookmark-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockedWriteAnalysis).toHaveBeenCalledWith(
+      "bookmarks",
+      "bookmark-1",
+      expect.objectContaining({ summary: bookmarkAnalysis.summary }),
+      { modelVersion: undefined },
+    );
   });
 });

--- a/__tests__/api/ai/chat-rag-helpers.test.ts
+++ b/__tests__/api/ai/chat-rag-helpers.test.ts
@@ -126,6 +126,9 @@ describe("AI Chat Request Validation", () => {
     const result = await validateRequest(request, "terminal_chat");
 
     expect(result).toBeDefined();
+    if ("parsedBody" in result) {
+      throw new Error("Expected validation to return a Response for non-SSE requests");
+    }
     expect(result.status).toBe(406);
     expect(result.headers.get("X-System-Status")).toBeFalsy();
   });

--- a/__tests__/api/ai/chat-tool-dispatch.test.ts
+++ b/__tests__/api/ai/chat-tool-dispatch.test.ts
@@ -1,4 +1,7 @@
-import { extractToolCallsFromResponseOutput } from "@/app/api/ai/chat/[feature]/tool-dispatch";
+import {
+  dispatchResponseToolCallsByName,
+  extractToolCallsFromResponseOutput,
+} from "@/app/api/ai/chat/[feature]/tool-dispatch";
 
 describe("AI Chat Tool Dispatch (tool-dispatch)", () => {
   it("returns an empty array when output has no function_call items", () => {
@@ -8,7 +11,7 @@ describe("AI Chat Tool Dispatch (tool-dispatch)", () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it("extracts valid tool calls and logs drop counts for invalid/unknown calls", () => {
+  it("extracts schema-valid tool calls and logs drop counts for invalid calls", () => {
     const output: unknown[] = [
       { type: "function_call", call_id: "bad-1", name: "search_bookmarks" },
       {
@@ -27,21 +30,45 @@ describe("AI Chat Tool Dispatch (tool-dispatch)", () => {
 
     const calls = extractToolCallsFromResponseOutput(output);
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.call_id).toBe("ok-1");
-    expect(calls[0]?.name).toBe("search_bookmarks");
-    expect(typeof calls[0]?.arguments).toBe("string");
-    expect(calls[0]?.arguments).toBe(JSON.stringify({ query: "wikipedia", maxResults: 5 }));
+    expect(calls).toHaveLength(2);
+    expect(calls.map((call) => call.call_id)).toEqual(["unknown-1", "ok-1"]);
+    expect(calls[1]?.name).toBe("search_bookmarks");
+    expect(typeof calls[1]?.arguments).toBe("string");
+    expect(calls[1]?.arguments).toBe(JSON.stringify({ query: "wikipedia", maxResults: 5 }));
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("[WARN] [AI Chat] Dropped responses function_call items"),
       expect.objectContaining({
         totalOutputItems: 3,
         functionCallItems: 3,
-        acceptedFunctionCalls: 1,
+        acceptedFunctionCalls: 2,
         droppedInvalidSchema: 1,
-        droppedUnknownTool: 1,
       }),
     );
+  });
+
+  it("returns function_call_output errors for unknown Responses API tools", async () => {
+    const dispatch = await dispatchResponseToolCallsByName([
+      {
+        type: "function_call",
+        call_id: "unknown-1",
+        name: "search_not_registered",
+        arguments: JSON.stringify({ query: "wikipedia" }),
+      },
+    ]);
+
+    expect(dispatch.outputs).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "unknown-1",
+        output: JSON.stringify({
+          query: "",
+          results: [],
+          totalResults: 0,
+          error: 'Unknown tool "search_not_registered"',
+        }),
+      },
+    ]);
+    expect(dispatch.failedCallIds).toEqual(["unknown-1"]);
   });
 });

--- a/__tests__/api/ai/chat-upstream-error.test.ts
+++ b/__tests__/api/ai/chat-upstream-error.test.ts
@@ -73,27 +73,25 @@ describe("isTimeoutError", () => {
 });
 
 describe("formatErrorMessage", () => {
-  const originalEnv = process.env.NODE_ENV;
-
   afterEach(() => {
-    process.env.NODE_ENV = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   it("sanitizes error details in production", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const result = formatErrorMessage(new Error("secret upstream key invalid"));
     expect(result).toBe("Upstream AI service error");
     expect(result).not.toContain("secret");
   });
 
   it("includes error details in development", () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     const result = formatErrorMessage(new Error("Connection refused"));
     expect(result).toBe("Upstream AI service error: Connection refused");
   });
 
   it("handles non-Error values", () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     expect(formatErrorMessage("plain string")).toBe("Upstream AI service error: plain string");
     expect(formatErrorMessage(42)).toBe("Upstream AI service error: 42");
   });

--- a/__tests__/api/ai/chat-upstream-pipeline-tools.test.ts
+++ b/__tests__/api/ai/chat-upstream-pipeline-tools.test.ts
@@ -233,4 +233,20 @@ describe("AI Chat Upstream Pipeline Tools", () => {
       "invalid_prompt: Provider rejected the prompt",
     );
   });
+
+  it.each(["queued", "in_progress", "cancelled", "incomplete"] as const)(
+    "surfaces Responses API non-completed status %s",
+    async (status) => {
+      mockCallOpenAiCompatibleResponses.mockResolvedValueOnce({
+        id: `response_${status}`,
+        status,
+        output_text: "",
+        output: [],
+      });
+
+      await expect(createPipeline({ apiMode: "responses" }).runUpstream()).rejects.toThrow(
+        `status "${status}"`,
+      );
+    },
+  );
 });

--- a/__tests__/api/ai/chat-upstream-pipeline-tools.test.ts
+++ b/__tests__/api/ai/chat-upstream-pipeline-tools.test.ts
@@ -11,6 +11,7 @@ import {
   resetPipelineMocks,
   searchQuery,
 } from "./upstream-pipeline-test-harness";
+import { formatBookmarkResultsAsLinks } from "@/app/api/ai/chat/[feature]/bookmark-tool";
 
 describe("AI Chat Upstream Pipeline Tools", () => {
   beforeEach(() => {
@@ -83,6 +84,20 @@ describe("AI Chat Upstream Pipeline Tools", () => {
     expect(mockCallOpenAiCompatibleChatCompletions).toHaveBeenCalledTimes(2);
     expect(reply).toBe(allowlistedReply);
     expect(reply).not.toContain("Here are the best matches I found:");
+  });
+
+  it("escapes bookmark titles before rendering deterministic markdown links", () => {
+    const reply = formatBookmarkResultsAsLinks([
+      {
+        title: "Helpful](https://evil.example) [Injected",
+        url: "/bookmarks/safe-bookmark",
+      },
+    ]);
+
+    expect(reply).toContain(
+      "[Helpful\\](https://evil.example) \\[Injected](/bookmarks/safe-bookmark)",
+    );
+    expect(reply).not.toContain("[Helpful](https://evil.example)");
   });
 
   it("uses deterministic fallback when model returns empty content instead of required tool calls", async () => {
@@ -203,5 +218,19 @@ describe("AI Chat Upstream Pipeline Tools", () => {
     expect(firstCallRequest?.tools?.[0]?.name).toBe("search_bookmarks");
     expect(mockedSearchBookmarks).toHaveBeenCalledWith(searchQuery);
     expect(reply).toContain(bookmarkLink);
+  });
+
+  it("surfaces Responses API failed status provider details", async () => {
+    mockCallOpenAiCompatibleResponses.mockResolvedValueOnce({
+      id: "response_failed",
+      status: "failed",
+      error: { code: "invalid_prompt", message: "Provider rejected the prompt" },
+      output_text: "",
+      output: [],
+    });
+
+    await expect(createPipeline({ apiMode: "responses" }).runUpstream()).rejects.toThrow(
+      "invalid_prompt: Provider rejected the prompt",
+    );
   });
 });

--- a/__tests__/api/ai/upstream-pipeline-test-harness.ts
+++ b/__tests__/api/ai/upstream-pipeline-test-harness.ts
@@ -23,6 +23,22 @@ export const mockGetUpstreamRequestQueue = vi.fn().mockReturnValue({
 });
 
 vi.mock("@/lib/ai/openai-compatible/openai-compatible-client", () => ({
+  assertOpenAiCompatibleResponsesSucceeded: (response: {
+    id: string;
+    status?: string;
+    error?: { code: string; message: string } | null;
+  }) => {
+    if (response.status !== "failed") return;
+    const detail = response.error
+      ? `${response.error.code}: ${response.error.message}`
+      : "No provider error details returned.";
+    throw Object.assign(
+      new Error(
+        `[AI] Responses API returned status "${response.status}" for ${response.id}: ${detail}`,
+      ),
+      { name: "OpenAiCompatibleResponsesFailureError", status: 502 },
+    );
+  },
   callOpenAiCompatibleChatCompletions: (...args: unknown[]) =>
     mockCallOpenAiCompatibleChatCompletions(...args),
   callOpenAiCompatibleResponses: (...args: unknown[]) => mockCallOpenAiCompatibleResponses(...args),

--- a/__tests__/api/ai/upstream-pipeline-test-harness.ts
+++ b/__tests__/api/ai/upstream-pipeline-test-harness.ts
@@ -1,7 +1,8 @@
 import { buildChatPipeline } from "@/app/api/ai/chat/[feature]/upstream-pipeline";
 import { searchBookmarks } from "@/lib/search/searchers/dynamic-searchers";
-import type { AiChatModelStreamEvent, ValidatedRequestContext } from "@/types/features/ai-chat";
+import type { ValidatedRequestContext } from "@/types/features/ai-chat";
 import type { OpenAiCompatibleChatMessage } from "@/types/schemas/ai-openai-compatible";
+import type { AiChatModelStreamUpdate } from "@/types/schemas/ai-openai-compatible-client";
 
 export const mockCallOpenAiCompatibleChatCompletions = vi.fn().mockResolvedValue({
   choices: [{ message: { content: "ok" } }],
@@ -121,7 +122,7 @@ const bookmarkResult = {
 
 export type ApiMode = "chat_completions" | "responses";
 export type ChatFeature = "terminal_chat" | "bookmark-analysis";
-export type EventPayload = AiChatModelStreamEvent;
+export type EventPayload = AiChatModelStreamUpdate;
 export type PipelineOptions = {
   feature?: ChatFeature;
   temperature?: number;

--- a/__tests__/api/ai/upstream-pipeline-test-harness.ts
+++ b/__tests__/api/ai/upstream-pipeline-test-harness.ts
@@ -29,10 +29,10 @@ vi.mock("@/lib/ai/openai-compatible/openai-compatible-client", () => ({
     status?: string;
     error?: { code: string; message: string } | null;
   }) => {
-    if (response.status !== "failed") return;
+    if (response.status === undefined || response.status === "completed") return;
     const detail = response.error
       ? `${response.error.code}: ${response.error.message}`
-      : "No provider error details returned.";
+      : `No provider error details returned for status "${response.status}".`;
     throw Object.assign(
       new Error(
         `[AI] Responses API returned status "${response.status}" for ${response.id}: ${detail}`,

--- a/__tests__/api/bookmarks-feed.test.ts
+++ b/__tests__/api/bookmarks-feed.test.ts
@@ -4,7 +4,8 @@ import { getBookmarksIndex, getBookmarksPage } from "@/lib/bookmarks/service.ser
 import { getAllPostsMeta } from "@/lib/blog";
 import { getDiscoveryRankedBookmarks } from "@/lib/db/queries/discovery-scores";
 import { loadSlugMapping } from "@/lib/bookmarks/slug-manager";
-import type { BookmarkSlugMapping, UnifiedBookmark } from "@/types";
+import type { BookmarkSlugMapping, UnifiedBookmark } from "@/types/schemas/bookmark";
+import { NextRequest } from "next/server";
 
 vi.mock("@/lib/bookmarks/service.server");
 vi.mock("@/lib/bookmarks/slug-manager");
@@ -114,7 +115,7 @@ describe("Bookmark feed modes", () => {
     mockLoadSlugMapping.mockResolvedValue(createSlugMapping(latestBookmarks));
 
     const response = await getBookmarksRoute(
-      new Request("http://localhost/api/bookmarks?feed=latest&page=1&limit=20"),
+      new NextRequest("http://localhost/api/bookmarks?feed=latest&page=1&limit=20"),
     );
     const payload = await response.json();
 
@@ -145,7 +146,7 @@ describe("Bookmark feed modes", () => {
     );
 
     const response = await getBookmarksRoute(
-      new Request("http://localhost/api/bookmarks?feed=discover&page=1&limit=4"),
+      new NextRequest("http://localhost/api/bookmarks?feed=discover&page=1&limit=4"),
     );
     const payload = await response.json();
 
@@ -164,7 +165,7 @@ describe("Bookmark feed modes", () => {
     mockGetDiscoveryRankedBookmarks.mockRejectedValueOnce(new Error("relation missing"));
 
     const response = await getBookmarksRoute(
-      new Request("http://localhost/api/bookmarks?feed=discover&page=1&limit=20"),
+      new NextRequest("http://localhost/api/bookmarks?feed=discover&page=1&limit=20"),
     );
 
     expect(response.status).toBe(500);

--- a/__tests__/api/bookmarks/pagination-limit.test.ts
+++ b/__tests__/api/bookmarks/pagination-limit.test.ts
@@ -3,8 +3,7 @@ import { getBookmarks, getBookmarksIndex, getBookmarksPage } from "@/lib/bookmar
 // Import BOOKMARKS_PER_PAGE lazily within isolated module to avoid global cache interfering with env-config tests
 // Placeholder variable – will be set in beforeAll
 let BOOKMARKS_PER_PAGE: number;
-import type { UnifiedBookmark } from "@/types";
-import type { BookmarkSlugMapping } from "@/types/bookmark";
+import type { BookmarkSlugMapping, UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock dependencies used inside the route
 vi.mock("@/lib/bookmarks/service.server");
@@ -42,7 +41,11 @@ describe("Bookmark API – large limit behavior", () => {
     mockGetBookmarksIndex.mockImplementation(async (limit) => ({
       count: mockBookmarks.length,
       totalPages: Math.ceil(mockBookmarks.length / (limit || BOOKMARKS_PER_PAGE)),
+      pageSize: limit || BOOKMARKS_PER_PAGE,
+      lastModified: "2025-01-01T00:00:00.000Z",
       lastFetchedAt: Date.now(),
+      lastAttemptedAt: Date.now(),
+      checksum: "mock-checksum",
     }));
     mockGetBookmarksPage.mockResolvedValue(mockBookmarks);
 

--- a/__tests__/api/bookmarks/tag-filtering.test.ts
+++ b/__tests__/api/bookmarks/tag-filtering.test.ts
@@ -204,6 +204,35 @@ describe("Bookmark API Tag Filtering", () => {
       expect(data.data[0].id).toBe("1");
     });
 
+    it("should query canonical tag results when the requested tag is an alias", async () => {
+      const aliasBookmark = mockBookmarks[0];
+      if (!aliasBookmark) throw new Error("Expected alias bookmark fixture");
+      mockGetBookmarksIndex.mockResolvedValueOnce(createIndexData(mockBookmarks.length));
+      mockResolveBookmarkTagSlug.mockResolvedValueOnce({
+        requestedSlug: "llms",
+        canonicalSlug: "ai",
+        canonicalTagName: "AI",
+        isAlias: true,
+      });
+      mockGetBookmarksByTag.mockResolvedValueOnce({
+        bookmarks: [aliasBookmark],
+        totalCount: 1,
+        totalPages: 1,
+      });
+
+      const response = await GET(createRequest({ tag: "llms" }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(mockResolveBookmarkTagSlug).toHaveBeenCalledWith("llms");
+      expect(mockGetBookmarksByTag).toHaveBeenCalledWith("ai", 1, 20);
+      expect(data.meta.filter).toMatchObject({
+        tag: "llms",
+        resolvedTag: "AI",
+        exactCount: 1,
+      });
+    });
+
     it("should perform case-insensitive tag matching", async () => {
       mockGetBookmarksIndex.mockResolvedValueOnce(createIndexData(mockBookmarks.length));
 

--- a/__tests__/api/bookmarks/tag-filtering.test.ts
+++ b/__tests__/api/bookmarks/tag-filtering.test.ts
@@ -13,7 +13,7 @@ import {
 import { loadSlugMapping } from "@/lib/bookmarks/slug-manager";
 import { findRelatedBookmarkIdsForSeeds } from "@/lib/db/queries/embedding-similarity";
 import { tagToSlug } from "@/lib/utils/tag-utils";
-import type { UnifiedBookmark, BookmarkSlugMapping } from "@/types";
+import type { UnifiedBookmark, BookmarkSlugMapping } from "@/types/schemas/bookmark";
 import { NextRequest } from "next/server";
 
 // Mock dependencies
@@ -133,6 +133,7 @@ describe("Bookmark API Tag Filtering", () => {
         bookmarks: filtered,
         totalCount: filtered.length,
         totalPages: 1,
+        fromCache: true,
       };
     });
     mockGetBookmarkById.mockImplementation(async (id) => {
@@ -218,6 +219,7 @@ describe("Bookmark API Tag Filtering", () => {
         bookmarks: [aliasBookmark],
         totalCount: 1,
         totalPages: 1,
+        fromCache: true,
       });
 
       const response = await GET(createRequest({ tag: "llms" }));
@@ -250,6 +252,7 @@ describe("Bookmark API Tag Filtering", () => {
         bookmarks: [],
         totalCount: 0,
         totalPages: 0,
+        fromCache: true,
       });
 
       const response = await GET(createRequest({ tag: "non-existent-tag" }));
@@ -280,6 +283,7 @@ describe("Bookmark API Tag Filtering", () => {
         bookmarks: largeSet.slice(20, 40),
         totalCount: 50,
         totalPages: 3,
+        fromCache: true,
       });
       mockGetBookmarksIndex.mockResolvedValueOnce(createIndexData(largeSet.length, 20));
       // Override default slug mapping for this test's larger dataset

--- a/__tests__/api/search-api.integration.test.ts
+++ b/__tests__/api/search-api.integration.test.ts
@@ -266,6 +266,7 @@ describe("Related Content API route guards", () => {
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV };
     relatedContentMocks.findSimilarByEntity.mockClear();
     relatedContentMocks.sourceEmbeddingExists.mockClear();
@@ -273,6 +274,7 @@ describe("Related Content API route guards", () => {
   });
 
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -291,7 +293,7 @@ describe("Related Content API route guards", () => {
   });
 
   it("hides the related-content debug route in production before database reads", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const response = await getRelatedContentDebug(
       new NextRequest("https://williamcallahan.com/api/related-content/debug?type=bookmark&id=b1"),
     );

--- a/__tests__/api/search-api.integration.test.ts
+++ b/__tests__/api/search-api.integration.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { vi } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, connection } from "next/server";
 import { GET } from "@/app/api/search/all/route";
 import { GET as getRelatedContent } from "@/app/api/related-content/route";
 import { GET as getRelatedContentDebug } from "@/app/api/related-content/debug/route";
@@ -286,6 +286,7 @@ describe("Related Content API route guards", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(data.meta).toHaveProperty("buildPhase", true);
+    expect(connection).toHaveBeenCalledOnce();
     expect(relatedContentMocks.findSimilarByEntity).not.toHaveBeenCalled();
   });
 

--- a/__tests__/api/search-api.integration.test.ts
+++ b/__tests__/api/search-api.integration.test.ts
@@ -4,7 +4,16 @@
  */
 
 import { vi } from "vitest";
+import { NextRequest } from "next/server";
 import { GET } from "@/app/api/search/all/route";
+import { GET as getRelatedContent } from "@/app/api/related-content/route";
+import { GET as getRelatedContentDebug } from "@/app/api/related-content/debug/route";
+
+const relatedContentMocks = vi.hoisted(() => ({
+  findSimilarByEntity: vi.fn().mockResolvedValue([]),
+  sourceEmbeddingExists: vi.fn().mockResolvedValue(true),
+  hydrateRelatedContent: vi.fn().mockResolvedValue([]),
+}));
 
 // Headers is already available globally via polyfills.js
 
@@ -107,6 +116,15 @@ vi.mock("@/lib/search/searchers/tag-search", () => ({
 
 vi.mock("@/lib/search/searchers/ai-analysis-searcher", () => ({
   searchAiAnalysis: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/db/queries/cross-domain-similarity", () => ({
+  findSimilarByEntity: relatedContentMocks.findSimilarByEntity,
+  sourceEmbeddingExists: relatedContentMocks.sourceEmbeddingExists,
+}));
+
+vi.mock("@/lib/db/queries/content-hydration", () => ({
+  hydrateRelatedContent: relatedContentMocks.hydrateRelatedContent,
 }));
 
 /**
@@ -241,5 +259,44 @@ describe("Search API: GET /api/search/all", () => {
         expect(Array.isArray(result.results)).toBe(true);
       }
     });
+  });
+});
+
+describe("Related Content API route guards", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    relatedContentMocks.findSimilarByEntity.mockClear();
+    relatedContentMocks.sourceEmbeddingExists.mockClear();
+    relatedContentMocks.hydrateRelatedContent.mockClear();
+  });
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("returns a no-store build-phase payload without querying related content", async () => {
+    process.env.NEXT_PHASE = "phase-production-build";
+    const response = await getRelatedContent(
+      new NextRequest("https://williamcallahan.com/api/related-content?type=bookmark&id=b1"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(data.meta).toHaveProperty("buildPhase", true);
+    expect(relatedContentMocks.findSimilarByEntity).not.toHaveBeenCalled();
+  });
+
+  it("hides the related-content debug route in production before database reads", async () => {
+    process.env.NODE_ENV = "production";
+    const response = await getRelatedContentDebug(
+      new NextRequest("https://williamcallahan.com/api/related-content/debug?type=bookmark&id=b1"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(relatedContentMocks.sourceEmbeddingExists).not.toHaveBeenCalled();
+    expect(relatedContentMocks.findSimilarByEntity).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/search/bookmarks-search.test.ts
+++ b/__tests__/api/search/bookmarks-search.test.ts
@@ -1,6 +1,6 @@
 import { GET } from "@/app/api/search/bookmarks/route";
-import type { SearchResult } from "@/types/search";
-import type { UnifiedBookmark } from "@/types";
+import type { SearchResult } from "@/types/schemas/search";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
 const { mockSearchBookmarksFtsPage } = vi.hoisted(() => ({
   mockSearchBookmarksFtsPage: vi.fn(),

--- a/__tests__/app/api/cv/pdf/route.test.ts
+++ b/__tests__/app/api/cv/pdf/route.test.ts
@@ -6,68 +6,9 @@
  */
 
 import type { ReactElement } from "react";
+import { NextRequest } from "next/server";
 
-type ResponseHeadersInit = Record<string, string> | undefined;
-
-class HeaderBag {
-  private readonly store = new Map<string, string>();
-
-  constructor(init?: ResponseHeadersInit) {
-    if (init) {
-      for (const [key, value] of Object.entries(init)) {
-        this.store.set(key.toLowerCase(), value);
-      }
-    }
-  }
-
-  get(name: string): string | null {
-    return this.store.get(name.toLowerCase()) ?? null;
-  }
-
-  set(name: string, value: string): void {
-    this.store.set(name.toLowerCase(), value);
-  }
-}
-
-class TestResponse {
-  private readonly body: Buffer;
-  readonly status: number;
-  readonly headers: HeaderBag;
-
-  constructor(
-    body: string | Buffer | Uint8Array | null,
-    init?: { status?: number; headers?: ResponseHeadersInit },
-  ) {
-    if (body instanceof Buffer) {
-      this.body = body;
-    } else if (body instanceof Uint8Array) {
-      this.body = Buffer.from(body);
-    } else if (body == null) {
-      this.body = Buffer.alloc(0);
-    } else {
-      this.body = Buffer.from(body);
-    }
-
-    this.status = init?.status ?? 200;
-    this.headers = new HeaderBag(init?.headers);
-  }
-
-  arrayBuffer(): Promise<ArrayBuffer> {
-    const copy = Buffer.from(this.body);
-    return Promise.resolve(copy.buffer.slice(copy.byteOffset, copy.byteOffset + copy.byteLength));
-  }
-
-  json(): Promise<unknown> {
-    return Promise.resolve(JSON.parse(this.body.toString("utf8")));
-  }
-}
-
-if (typeof globalThis.Response === "undefined") {
-  (globalThis as { Response?: typeof TestResponse }).Response =
-    TestResponse as unknown as typeof globalThis.Response;
-}
-
-const renderToBufferMock = vi.fn<Promise<Buffer>, [ReactElement]>();
+const renderToBufferMock = vi.fn<(element: ReactElement) => Promise<Buffer>>();
 const mockPdfComponent = vi.fn(() => null);
 
 const mockedLogger = {
@@ -110,7 +51,7 @@ describe("GET /api/cv/pdf", () => {
     const pdfPayload = Buffer.from("%PDF-1.4 test payload");
     renderToBufferMock.mockResolvedValueOnce(pdfPayload);
 
-    const request = { url: "https://example.com/api/cv/pdf" } as Request;
+    const request = new NextRequest("https://example.com/api/cv/pdf");
     const { GET } = await import("@/app/api/cv/pdf/route");
     const response = await GET(request);
 
@@ -132,7 +73,7 @@ describe("GET /api/cv/pdf", () => {
     const error = new Error("render failed");
     renderToBufferMock.mockRejectedValueOnce(error);
 
-    const request = { url: "https://example.com/api/cv/pdf" } as Request;
+    const request = new NextRequest("https://example.com/api/cv/pdf");
     const { GET } = await import("@/app/api/cv/pdf/route");
     const response = await GET(request);
 

--- a/__tests__/app/api/og-image/route.test.ts
+++ b/__tests__/app/api/og-image/route.test.ts
@@ -1,9 +1,12 @@
 /**
  * @file Unit tests for the og-image API route handler
  * @description Tests that verify the 0.0.0.0 URL fix works correctly in Docker environments
+ * @vitest-environment node
  */
 
 // Mock environment variables and dependencies before importing the route
+import { NextRequest } from "next/server";
+
 const originalEnv = process.env;
 
 beforeEach(() => {
@@ -19,26 +22,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   process.env = originalEnv;
 });
 
-/**
- * Mock NextRequest that simulates Docker environment
- */
-class MockNextRequest {
-  url: string;
-
-  constructor(url: string) {
-    this.url = url;
-  }
-
-  get nextUrl() {
-    return new URL(this.url);
-  }
-}
-
 describe("OG-Image API Route: 0.0.0.0 URL Fix Tests", () => {
-  let GET: any;
+  let GET: typeof import("@/app/api/og-image/route").GET;
 
   beforeEach(async () => {
     // Import GET after setting up mocks
@@ -52,9 +41,9 @@ describe("OG-Image API Route: 0.0.0.0 URL Fix Tests", () => {
      */
     it("should construct redirect URLs without 0.0.0.0 in production", async () => {
       const dockerRequestUrl = "http://0.0.0.0:3000/api/og-image?url=invalid-url";
-      const request = new MockNextRequest(dockerRequestUrl) as any;
+      const request = new NextRequest(dockerRequestUrl);
 
-      let response: any;
+      let response: Response | undefined;
       let locationHeader: string | null = null;
 
       try {
@@ -90,7 +79,7 @@ describe("OG-Image API Route: 0.0.0.0 URL Fix Tests", () => {
     it("should handle Karakeep asset IDs without 0.0.0.0 URLs", async () => {
       const assetId = "a1b2c3d4e5f6789012345678901234567890";
       const dockerRequestUrl = `http://0.0.0.0:3000/api/og-image?url=${assetId}`;
-      const request = new MockNextRequest(dockerRequestUrl) as any;
+      const request = new NextRequest(dockerRequestUrl);
 
       try {
         const response = await GET(request);
@@ -124,7 +113,7 @@ describe("OG-Image API Route: 0.0.0.0 URL Fix Tests", () => {
       const testGET = routeModule.GET;
 
       const dockerRequestUrl = "http://0.0.0.0:3000/api/og-image?url=invalid";
-      const request = new MockNextRequest(dockerRequestUrl) as any;
+      const request = new NextRequest(dockerRequestUrl);
 
       try {
         const response = await testGET(request);
@@ -142,17 +131,87 @@ describe("OG-Image API Route: 0.0.0.0 URL Fix Tests", () => {
   });
 });
 
+describe("OG-Image bookmark fallback validation", () => {
+  const sourceUrl = "https://source.example/page";
+  const attackerUrl = "https://attacker.example/phish";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("@/lib/s3/client");
+    vi.doUnmock("@/lib/s3/config");
+    vi.doUnmock("@/lib/utils/s3-error-guards");
+    vi.doUnmock("@/lib/db/queries/bookmarks");
+  });
+
+  it("does not redirect to non-image bookmark fallback URLs", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/s3/client", () => ({
+      getS3Client: () => ({
+        send: () => Promise.reject(new Error("missing")),
+      }),
+    }));
+    vi.doMock("@/lib/s3/config", () => ({
+      getS3Config: () => ({ bucket: "test-bucket" }),
+    }));
+    vi.doMock("@/lib/utils/s3-error-guards", () => ({
+      isS3Error: () => true,
+    }));
+    vi.doMock("@/lib/db/queries/bookmarks", () => ({
+      getBookmarkById: () =>
+        Promise.resolve({
+          content: {
+            imageUrl: attackerUrl,
+          },
+        }),
+    }));
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("<html>not an image</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      )
+      .mockRejectedValueOnce(new Error("source unavailable"))
+      .mockResolvedValueOnce(
+        new Response("<html>not an image</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+    const { GET } = await import("@/app/api/og-image/route");
+    const request = new NextRequest(
+      `https://williamcallahan.com/api/og-image?url=${encodeURIComponent(sourceUrl)}&bookmarkId=bookmark-1`,
+    );
+
+    const response = await GET(request);
+    const locationHeader = response.headers.get("Location");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      attackerUrl,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "Mozilla/5.0 (compatible; OpenGraph-Image-Bot/1.0)",
+        }),
+      }),
+    );
+    expect(locationHeader).not.toBe(attackerUrl);
+    expect(locationHeader).toContain("opengraph-placeholder.png");
+  });
+});
+
 describe("Production URL Validation", () => {
   /**
    * @description Integration test that verifies getBaseUrl behavior
    */
   it("should use production fallback when env vars are missing", async () => {
     // Test the getBaseUrl function directly
-    process.env = {
-      ...originalEnv,
-      NODE_ENV: "production",
-      // Intentionally omit API_BASE_URL and NEXT_PUBLIC_SITE_URL
-    };
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "");
+    vi.resetModules();
 
     // Clear module cache (only if available - not supported in Bun)
     // if (typeof vi.resetModules === "function") {
@@ -177,7 +236,7 @@ describe("Production URL Validation", () => {
 describe("Logo API Route Validation", () => {
   it("rejects company fallback without a domain", async () => {
     const { GET } = await import("@/app/api/logo/route");
-    const request = new MockNextRequest("http://localhost/api/logo?company=OpenAI") as any;
+    const request = new NextRequest("http://localhost/api/logo?company=OpenAI");
 
     const response = await GET(request);
     expect(response.status).toBe(400);

--- a/__tests__/app/api/upload/route.test.ts
+++ b/__tests__/app/api/upload/route.test.ts
@@ -124,8 +124,9 @@ describe("Upload API", () => {
       writeBinaryS3Mock.mockResolvedValue(undefined);
       parsePdfFromBufferMock.mockResolvedValue({
         metadata: { title: "Test Book", author: "Test Author" },
-        pages: [{ pageNumber: 1, textContent: "Page 1 content" }],
+        pages: [{ pageNumber: 1, textContent: "Page 1 content", wordCount: 3 }],
         totalWordCount: 100,
+        totalPages: 1,
       });
 
       const formData = new FormData();
@@ -188,9 +189,19 @@ describe("Upload API", () => {
 
       writeBinaryS3Mock.mockResolvedValue(undefined);
       parseEpubFromBufferMock.mockResolvedValue({
-        metadata: { title: "Test ePub", creator: "Test Author" },
-        chapters: [{ id: "ch1", title: "Chapter 1", textContent: "Chapter content" }],
+        metadata: { title: "Test ePub", author: "Test Author" },
+        chapters: [
+          {
+            id: "ch1",
+            order: 1,
+            title: "Chapter 1",
+            textContent: "Chapter content",
+            htmlContent: "<p>Chapter content</p>",
+            wordCount: 2,
+          },
+        ],
         totalWordCount: 150,
+        totalChapters: 1,
       });
 
       const formData = new FormData();

--- a/__tests__/app/pages.smoke.test.ts
+++ b/__tests__/app/pages.smoke.test.ts
@@ -181,4 +181,23 @@ describe("App Router Page Smoke Tests (Static Routes)", () => {
       else process.env.S3_SERVER_URL = originalS3ServerUrl;
     }
   });
+
+  it("redirects id-derived project detail slugs to canonical name slugs", async () => {
+    vi.resetModules();
+    const { permanentRedirect } = await import("next/navigation");
+    const redirectError = new Error("redirected");
+    vi.mocked(permanentRedirect).mockImplementationOnce(() => {
+      throw redirectError;
+    });
+
+    const pageModule = await import("@/app/projects/[slug]/page");
+    const ProjectDetailPage = pageModule.default;
+
+    await expect(
+      ProjectDetailPage({
+        params: Promise.resolve({ slug: "tui-aventure-vc" }),
+      }),
+    ).rejects.toBe(redirectError);
+    expect(permanentRedirect).toHaveBeenCalledWith("/projects/company-research-tui");
+  });
 });

--- a/__tests__/bookmarks/tag-navigation-pagination.test.tsx
+++ b/__tests__/bookmarks/tag-navigation-pagination.test.tsx
@@ -10,7 +10,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { useRouter, usePathname } from "next/navigation";
 import { BookmarksWithPagination } from "@/components/features/bookmarks/bookmarks-with-pagination.client";
 import { usePagination } from "@/hooks/use-pagination";
-import type { UnifiedBookmark } from "@/types";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -26,6 +26,7 @@ vi.mock("@/hooks/use-pagination");
 const mockBookmarks: UnifiedBookmark[] = [
   {
     id: "1",
+    slug: "react-best-practices",
     url: "https://example.com/1",
     title: "React Best Practices",
     description: "Learn React",
@@ -35,6 +36,7 @@ const mockBookmarks: UnifiedBookmark[] = [
   },
   {
     id: "2",
+    slug: "typescript-guide",
     url: "https://example.com/2",
     title: "TypeScript Guide",
     description: "TypeScript fundamentals",
@@ -44,6 +46,7 @@ const mockBookmarks: UnifiedBookmark[] = [
   },
   {
     id: "3",
+    slug: "react-hooks",
     url: "https://example.com/3",
     title: "React Hooks",
     description: "Advanced React patterns",
@@ -89,6 +92,7 @@ describe("Tag Navigation with Pagination", () => {
     it("should pass tag filter to pagination hook when tag prop is provided", () => {
       render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -105,7 +109,13 @@ describe("Tag Navigation with Pagination", () => {
     });
 
     it("should not pass tag filter when no tag prop is provided", () => {
-      render(<BookmarksWithPagination initialBookmarks={mockBookmarks} baseUrl="/bookmarks" />);
+      render(
+        <BookmarksWithPagination
+          bookmarks={mockBookmarks}
+          initialBookmarks={mockBookmarks}
+          baseUrl="/bookmarks"
+        />,
+      );
 
       // Verify the hook was called without tag parameter
       expect(usePagination).toHaveBeenCalledWith(
@@ -118,6 +128,7 @@ describe("Tag Navigation with Pagination", () => {
     it("should maintain tag filter across page navigation", () => {
       const { rerender } = render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -129,6 +140,7 @@ describe("Tag Navigation with Pagination", () => {
       // Simulate navigating to page 2
       rerender(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -149,7 +161,13 @@ describe("Tag Navigation with Pagination", () => {
 
   describe("Tag Selection Navigation", () => {
     it("should navigate to tag URL when a tag is clicked", async () => {
-      render(<BookmarksWithPagination initialBookmarks={mockBookmarks} showFilterBar={true} />);
+      render(
+        <BookmarksWithPagination
+          bookmarks={mockBookmarks}
+          initialBookmarks={mockBookmarks}
+          showFilterBar={true}
+        />,
+      );
 
       // Find and click a tag
       const reactTag = await screen.findByRole("button", { name: /React/i });
@@ -165,6 +183,7 @@ describe("Tag Navigation with Pagination", () => {
 
       render(
         <BookmarksWithPagination
+          bookmarks={mockBookmarks}
           initialBookmarks={mockBookmarks}
           showFilterBar={true}
           initialTag="React"
@@ -196,7 +215,13 @@ describe("Tag Navigation with Pagination", () => {
         mutate: mockMutate,
       });
 
-      render(<BookmarksWithPagination initialBookmarks={mockBookmarks} showFilterBar={true} />);
+      render(
+        <BookmarksWithPagination
+          bookmarks={mockBookmarks}
+          initialBookmarks={mockBookmarks}
+          showFilterBar={true}
+        />,
+      );
 
       // Click a tag
       const typescriptTag = await screen.findByRole("button", { name: /TypeScript/i });
@@ -215,6 +240,7 @@ describe("Tag Navigation with Pagination", () => {
 
       render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -235,6 +261,7 @@ describe("Tag Navigation with Pagination", () => {
     it("should use correct baseUrl for tag pages", () => {
       const { rerender } = render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -254,6 +281,7 @@ describe("Tag Navigation with Pagination", () => {
       // When page changes, hook should be called with new page
       rerender(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -275,6 +303,7 @@ describe("Tag Navigation with Pagination", () => {
     it("should show same content for same tag URL on refresh", () => {
       const { rerender } = render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -291,6 +320,7 @@ describe("Tag Navigation with Pagination", () => {
 
       rerender(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -309,6 +339,7 @@ describe("Tag Navigation with Pagination", () => {
 
       const { rerender } = render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -320,6 +351,7 @@ describe("Tag Navigation with Pagination", () => {
       // Simulate page navigation by re-rendering with new page
       rerender(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="React"
           initialTag="React"
@@ -345,6 +377,7 @@ describe("Tag Navigation with Pagination", () => {
       const bookmarksWithSpecialTags: UnifiedBookmark[] = [
         {
           id: "1",
+          slug: "c-plus-plus-guide",
           url: "https://example.com",
           title: "C++ Guide",
           description: "A guide to C++",
@@ -370,6 +403,7 @@ describe("Tag Navigation with Pagination", () => {
 
       render(
         <BookmarksWithPagination
+          bookmarks={bookmarksWithSpecialTags}
           initialBookmarks={bookmarksWithSpecialTags}
           showFilterBar={true}
         />,
@@ -400,6 +434,7 @@ describe("Tag Navigation with Pagination", () => {
 
       render(
         <BookmarksWithPagination
+          bookmarks={[]}
           initialBookmarks={[]}
           tag="NonExistentTag"
           initialTag="NonExistentTag"

--- a/__tests__/components/bookmarks/pagination-search-mode.test.tsx
+++ b/__tests__/components/bookmarks/pagination-search-mode.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { BookmarksWithPagination } from "@/components/features/bookmarks/bookmarks-with-pagination.client";
 import { vi } from "vitest";
-import type { UnifiedBookmark } from "@/types";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock next/navigation's router
 vi.mock("next/navigation", () => ({

--- a/__tests__/components/features/bookmarks/bookmark-card-direct-s3.test.tsx
+++ b/__tests__/components/features/bookmarks/bookmark-card-direct-s3.test.tsx
@@ -15,6 +15,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   process.env = originalEnv;
 });
 
@@ -216,7 +217,7 @@ describe("BookmarkCard Direct S3 CDN Usage Tests", () => {
      */
     it("should use API proxy in development instead of direct S3 URLs", () => {
       // Set development environment
-      process.env.NODE_ENV = "development";
+      vi.stubEnv("NODE_ENV", "development");
 
       const mockBookmark = {
         id: "test-dev-1",

--- a/__tests__/components/features/bookmarks/bookmark-card-screenshot.test.tsx
+++ b/__tests__/components/features/bookmarks/bookmark-card-screenshot.test.tsx
@@ -144,15 +144,4 @@ describe("BookmarkCardClient screenshotAssetId handling", () => {
       expect(logoImage.getAttribute("src")).toBe("/api/assets/test-screenshot-asset-id");
     }
   });
-
-  it("hides category badge when showCategoryBadge is false", () => {
-    const bookmarkWithCategory = {
-      ...mockBookmark,
-      category: "Platform",
-    };
-
-    render(<BookmarkCardClient {...bookmarkWithCategory} showCategoryBadge={false} />);
-
-    expect(screen.queryByText("Platform")).not.toBeInTheDocument();
-  });
 });

--- a/__tests__/components/ui/pagination-control-url.test.tsx
+++ b/__tests__/components/ui/pagination-control-url.test.tsx
@@ -2,6 +2,7 @@ import type { MockedFunction } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { PaginationControlUrl } from "@/components/ui/pagination-control-url.client";
 import { useSearchParams } from "next/navigation";
+import { ReadonlyURLSearchParams } from "next/dist/client/components/readonly-url-search-params";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -33,10 +34,11 @@ vi.mock("next/link", () => ({
 
 describe("PaginationControlUrl", () => {
   const mockUseSearchParams = useSearchParams as MockedFunction<typeof useSearchParams>;
+  const searchParams = (query = "") => new ReadonlyURLSearchParams(query);
 
   beforeEach(() => {
     // Mock URLSearchParams
-    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+    mockUseSearchParams.mockReturnValue(searchParams());
   });
 
   afterEach(() => {
@@ -91,7 +93,7 @@ describe("PaginationControlUrl", () => {
   });
 
   it("preserves query parameters in pagination links", () => {
-    mockUseSearchParams.mockReturnValue(new URLSearchParams("q=test&tag=javascript"));
+    mockUseSearchParams.mockReturnValue(searchParams("q=test&tag=javascript"));
 
     render(
       <PaginationControlUrl

--- a/__tests__/components/ui/terminal/terminal.test.tsx
+++ b/__tests__/components/ui/terminal/terminal.test.tsx
@@ -28,11 +28,11 @@ import React from "react"; // Ensure React is imported first
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Terminal } from "../../../../src/components/ui/terminal/terminal-implementation.client";
 import { TerminalProvider } from "../../../../src/components/ui/terminal/terminal-context.client";
-import {
-  useRegisteredWindowState as useRegisteredWindowStateImported,
-  type GlobalWindowRegistryContextType,
-  type WindowState,
-} from "../../../../src/lib/context/global-window-registry-context.client"; // Import types for mocking
+import { useRegisteredWindowState as useRegisteredWindowStateImported } from "../../../../src/lib/context/global-window-registry-context.client";
+import type {
+  GlobalWindowRegistryContextType,
+  WindowStateValue,
+} from "../../../../src/types/ui/window";
 
 // --- Mock TerminalHeader ---
 vi.mock("../../../../src/components/ui/terminal/terminal-header", () => ({
@@ -77,7 +77,7 @@ vi.mock("next/navigation", () => ({
 // --- Mock GlobalWindowRegistryContext using mock.module ---
 // Keep state external for potential modification by mocked actions if needed,
 // but primarily control return values via mockImplementationOnce in tests.
-let mockWindowState: WindowState = "normal";
+let mockWindowState: WindowStateValue = "normal";
 const MockIcon = React.forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>((props, ref) => (
   <svg ref={ref} {...props} data-testid="mock-icon" />
 ));
@@ -109,7 +109,7 @@ vi.mock("../../../../src/lib/context/global-window-registry-context.client", () 
         },
         registerWindow: vi.fn(),
         unregisterWindow: vi.fn(),
-        setWindowState: vi.fn((id: string, state: WindowState) => {
+        setWindowState: vi.fn((id: string, state: WindowStateValue) => {
           if (id === "main-terminal") setMockState(state);
         }),
         minimizeWindow: vi.fn((id: string) => {

--- a/__tests__/components/ui/terminal/terminalSelectionView.test.tsx
+++ b/__tests__/components/ui/terminal/terminalSelectionView.test.tsx
@@ -9,10 +9,10 @@
 
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { SelectionView } from "@/components/ui/terminal/selection-view.client";
-import type { SelectionItem } from "@/types/terminal";
+import type { SelectionEntry } from "@/types/terminal";
 
 describe("SelectionView Component", () => {
-  const mockItems: SelectionItem[] = [
+  const mockItems: SelectionEntry[] = [
     {
       id: "option-1",
       label: "Option 1",

--- a/__tests__/hooks/use-pagination.test.ts
+++ b/__tests__/hooks/use-pagination.test.ts
@@ -2,7 +2,8 @@ import type { MockedFunction } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { usePagination } from "@/hooks/use-pagination";
 import useSWRInfinite from "swr/infinite";
-import type { UnifiedBookmark, PaginatedResponse } from "@/types";
+import type { PaginatedResponse } from "@/types/lib";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock SWR
 vi.mock("swr/infinite");
@@ -12,6 +13,7 @@ const mockItems: UnifiedBookmark[] = Array.from({ length: 50 }, (_, i) => ({
   url: `https://example.com/${i}`,
   title: `Item ${i}`,
   description: `Description for item ${i}`,
+  slug: `item-${i}`,
   tags: [`tag${i % 3}`],
   dateBookmarked: "2024-01-01T00:00:00.000Z",
   sourceUpdatedAt: "2024-01-01T00:00:00.000Z",

--- a/__tests__/lib/ai/rag/inventory-context.test.ts
+++ b/__tests__/lib/ai/rag/inventory-context.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { buildInventoryContext } from "@/lib/ai/rag/inventory-context";
-import type { BookmarkIndexItem } from "@/types/schemas/search";
+import type { BookmarkIndexEntry } from "@/types/schemas/search";
 
 vi.mock("@/data/investments", () => ({
   investments: [
@@ -106,7 +106,7 @@ vi.mock("@/lib/blog/mdx", () => ({
 
 vi.mock("@/lib/search/loaders/dynamic-content", async () => {
   const { default: MiniSearch } = await import("minisearch");
-  const emptyBookmarksIndex = new MiniSearch<BookmarkIndexItem>({
+  const emptyBookmarksIndex = new MiniSearch<BookmarkIndexEntry>({
     fields: ["title", "description", "tags", "summary", "author", "publisher", "url", "slug"],
     storeFields: ["id", "title", "tags", "url", "slug"],
   });

--- a/__tests__/lib/ai/rag/static-context.test.ts
+++ b/__tests__/lib/ai/rag/static-context.test.ts
@@ -58,6 +58,16 @@ describe("RAG Static Context", () => {
       }
     });
 
+    it("uses database project slugs for dotted project names", () => {
+      const ctx = getStaticContext();
+      const urls = ctx.currentProjects.map((project) => project.url);
+
+      expect(urls).toContain("/projects/aventure-vc");
+      expect(urls).toContain("/projects/williamcallahan-com");
+      expect(urls).not.toContain("/projects/aventurevc");
+      expect(urls).not.toContain("/projects/williamcallahancom");
+    });
+
     it("socialLinks includes GitHub", () => {
       const ctx = getStaticContext();
 

--- a/__tests__/lib/bookmarks/bookmarks-meta.test.ts
+++ b/__tests__/lib/bookmarks/bookmarks-meta.test.ts
@@ -5,7 +5,7 @@
  * For integration tests of real business logic, mock S3 instead.
  */
 import { vi } from "vitest";
-import type { UnifiedBookmark } from "@/types/bookmark";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 import { S3NotFoundError } from "@/lib/s3/errors";
 
 // Explicit mock - no alias hijacking
@@ -36,13 +36,15 @@ const mockBookmarks: UnifiedBookmark[] = [
     url: "https://example.com",
     title: "Example",
     description: "Test bookmark",
+    slug: "example",
     tags: [createTag("test")],
-    imageUrl: null,
     domain: "example.com",
-    createdAt: "2024-01-01",
-    updatedAt: "2024-01-01",
+    dateBookmarked: "2024-01-01",
+    sourceUpdatedAt: "2024-01-01",
+    dateCreated: "2024-01-01",
+    modifiedAt: "2024-01-01",
     isFavorite: false,
-  } as UnifiedBookmark,
+  },
 ];
 
 /** Helper to strip tag objects -> names for deep equality where expected data uses strings */

--- a/__tests__/lib/bookmarks/bookmarks-validation.test.ts
+++ b/__tests__/lib/bookmarks/bookmarks-validation.test.ts
@@ -8,7 +8,7 @@
 
 import { validateBookmarksDataset } from "../../../src/lib/validators/bookmarks";
 import { bookmarksApiResponseSchema } from "../../../src/types/schemas/bookmark";
-import type { UnifiedBookmark } from "../../../src/types";
+import type { UnifiedBookmark } from "../../../src/types/schemas/bookmark";
 
 // Mock console.error to suppress error logs during tests
 vi.spyOn(console, "error").mockImplementation(() => {});
@@ -24,11 +24,13 @@ describe("Bookmarks Validation", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     // Reset process.env to prevent cross-test bleed
     process.env = { ...originalEnv };
   });
 
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = originalEnv;
     vi.restoreAllMocks();
   });
@@ -38,12 +40,14 @@ describe("Bookmarks Validation", () => {
     url,
     title,
     description: "A valid bookmark",
+    slug: id,
     tags: [],
     dateBookmarked: "2023-01-01T00:00:00Z",
-    createdAt: "2023-01-01T00:00:00Z",
+    sourceUpdatedAt: "2023-01-01T00:00:00Z",
+    dateCreated: "2023-01-01T00:00:00Z",
     modifiedAt: "2023-01-01T00:00:00Z",
     archived: false,
-    favourited: false,
+    isFavorite: false,
     taggingStatus: "complete",
     content: {
       type: "link",
@@ -61,12 +65,14 @@ describe("Bookmarks Validation", () => {
         url: "https://example.com",
         title: "Example",
         description: "An example bookmark",
+        slug: "example",
         tags: [],
         dateBookmarked: "2023-01-01T00:00:00Z",
-        createdAt: "2023-01-01T00:00:00Z",
+        sourceUpdatedAt: "2023-01-01T00:00:00Z",
+        dateCreated: "2023-01-01T00:00:00Z",
         modifiedAt: "2023-01-01T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -81,12 +87,14 @@ describe("Bookmarks Validation", () => {
         url: "https://test.com",
         title: "Test Site",
         description: "A test site",
+        slug: "test-site",
         tags: [],
         dateBookmarked: "2023-01-02T00:00:00Z",
-        createdAt: "2023-01-02T00:00:00Z",
+        sourceUpdatedAt: "2023-01-02T00:00:00Z",
+        dateCreated: "2023-01-02T00:00:00Z",
         modifiedAt: "2023-01-02T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -104,7 +112,7 @@ describe("Bookmarks Validation", () => {
   });
 
   test("should fall back to default minimum when MIN_BOOKMARKS_THRESHOLD is invalid", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MIN_BOOKMARKS_THRESHOLD = "invalid";
 
     const bookmarks = [
@@ -122,7 +130,7 @@ describe("Bookmarks Validation", () => {
   });
 
   test("should fall back to default minimum when MIN_BOOKMARKS_THRESHOLD is non-positive", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MIN_BOOKMARKS_THRESHOLD = "0";
 
     const bookmarks = [
@@ -143,7 +151,7 @@ describe("Bookmarks Validation", () => {
   });
 
   test("should respect a valid MIN_BOOKMARKS_THRESHOLD in production", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MIN_BOOKMARKS_THRESHOLD = "5";
 
     const bookmarks = [
@@ -165,12 +173,14 @@ describe("Bookmarks Validation", () => {
         url: "https://test.com",
         title: "Test Bookmark",
         description: "A test bookmark",
+        slug: "test-bookmark",
         tags: [],
         dateBookmarked: "2023-01-01T00:00:00Z",
-        createdAt: "2023-01-01T00:00:00Z",
+        sourceUpdatedAt: "2023-01-01T00:00:00Z",
+        dateCreated: "2023-01-01T00:00:00Z",
         modifiedAt: "2023-01-01T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -194,12 +204,14 @@ describe("Bookmarks Validation", () => {
         url: "",
         title: "No URL Bookmark 1",
         description: "A bookmark without URL",
+        slug: "no-url-bookmark-1",
         tags: [],
         dateBookmarked: "2023-01-01T00:00:00Z",
-        createdAt: "2023-01-01T00:00:00Z",
+        sourceUpdatedAt: "2023-01-01T00:00:00Z",
+        dateCreated: "2023-01-01T00:00:00Z",
         modifiedAt: "2023-01-01T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -214,12 +226,14 @@ describe("Bookmarks Validation", () => {
         url: "",
         title: "No URL Bookmark 2",
         description: "Another bookmark without URL",
+        slug: "no-url-bookmark-2",
         tags: [],
         dateBookmarked: "2023-01-02T00:00:00Z",
-        createdAt: "2023-01-02T00:00:00Z",
+        sourceUpdatedAt: "2023-01-02T00:00:00Z",
+        dateCreated: "2023-01-02T00:00:00Z",
         modifiedAt: "2023-01-02T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -243,12 +257,14 @@ describe("Bookmarks Validation", () => {
         url: "https://example.com",
         title: "Valid Bookmark",
         description: "A valid bookmark",
+        slug: "valid-bookmark",
         tags: [],
         dateBookmarked: "2023-01-01T00:00:00Z",
-        createdAt: "2023-01-01T00:00:00Z",
+        sourceUpdatedAt: "2023-01-01T00:00:00Z",
+        dateCreated: "2023-01-01T00:00:00Z",
         modifiedAt: "2023-01-01T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",
@@ -263,12 +279,14 @@ describe("Bookmarks Validation", () => {
         url: "",
         title: "No URL Bookmark",
         description: "A bookmark without URL",
+        slug: "no-url-bookmark",
         tags: [],
         dateBookmarked: "2023-01-02T00:00:00Z",
-        createdAt: "2023-01-02T00:00:00Z",
+        sourceUpdatedAt: "2023-01-02T00:00:00Z",
+        dateCreated: "2023-01-02T00:00:00Z",
         modifiedAt: "2023-01-02T00:00:00Z",
         archived: false,
-        favourited: false,
+        isFavorite: false,
         taggingStatus: "complete",
         content: {
           type: "link",

--- a/__tests__/lib/bookmarks/bookmarks.test.ts
+++ b/__tests__/lib/bookmarks/bookmarks.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { vi } from "vitest";
-import type { UnifiedBookmark, BookmarkContent } from "../../../src/types";
+import type { BookmarkContent, UnifiedBookmark } from "../../../src/types/schemas/bookmark";
 // Mock getBaseUrl at the top level with the correct path
 vi.mock("@/lib/utils/get-base-url", () => ({
   getBaseUrl: () => "http://localhost:3000",

--- a/__tests__/lib/bookmarks/checksum-gate.unit.test.ts
+++ b/__tests__/lib/bookmarks/checksum-gate.unit.test.ts
@@ -16,10 +16,28 @@ const CREATED_AT = "2026-01-01T00:00:00.000Z";
 const MODIFIED_AT = "2026-02-01T00:00:00.000Z";
 
 function buildRaw(id: string, modifiedAt = MODIFIED_AT): RawApiBookmark {
-  return { id, createdAt: CREATED_AT, modifiedAt } as RawApiBookmark;
+  return {
+    id,
+    createdAt: CREATED_AT,
+    modifiedAt,
+    title: `Bookmark ${id}`,
+    archived: false,
+    favourited: false,
+    taggingStatus: null,
+    summarizationStatus: null,
+    note: null,
+    summary: null,
+    tags: [],
+    content: {
+      type: "link",
+      url: `https://example.com/${id}`,
+      title: `Bookmark ${id}`,
+      description: null,
+    },
+  };
 }
 
-function buildCached(id: string): UnifiedBookmark {
+function buildCached(id: string, overrides: Partial<UnifiedBookmark> = {}): UnifiedBookmark {
   return {
     id,
     slug: `example-com-${id}`,
@@ -30,7 +48,8 @@ function buildCached(id: string): UnifiedBookmark {
     dateBookmarked: CREATED_AT,
     modifiedAt: MODIFIED_AT,
     sourceUpdatedAt: MODIFIED_AT,
-  } as UnifiedBookmark;
+    ...overrides,
+  };
 }
 
 describe("validateChecksumAndGetCached", () => {
@@ -71,5 +90,41 @@ describe("validateChecksumAndGetCached", () => {
 
     expect(result.cached).toBeNull();
     expect(mockGetBookmarksIndexFromDatabase).not.toHaveBeenCalled();
+  });
+
+  it("bypasses cache in updater mode while Karakeep proxy images need S3 upgrades", async () => {
+    const previousUpdater = process.env.IS_DATA_UPDATER;
+    process.env.IS_DATA_UPDATER = "true";
+    const cached = [
+      buildCached("a", {
+        content: {
+          type: "link",
+          url: "https://example.com/a",
+          title: "Bookmark a",
+          description: null,
+          imageAssetId: "asset-1",
+        },
+        ogImage: "/api/assets/asset-1",
+        ogImageExternal: "/api/assets/asset-1",
+      }),
+    ];
+    mockGetBookmarksIndexFromDatabase.mockResolvedValue({
+      checksum: calculateBookmarksChecksum(cached),
+      count: cached.length,
+    });
+    mockGetAllBookmarks.mockResolvedValue(cached);
+
+    try {
+      const result = await validateChecksumAndGetCached([buildRaw("a")], false);
+
+      expect(result.cached).toBeNull();
+      expect(mockGetAllBookmarks).toHaveBeenCalled();
+    } finally {
+      if (previousUpdater === undefined) {
+        delete process.env.IS_DATA_UPDATER;
+      } else {
+        process.env.IS_DATA_UPDATER = previousUpdater;
+      }
+    }
   });
 });

--- a/__tests__/lib/bookmarks/enrichment-hydration.test.ts
+++ b/__tests__/lib/bookmarks/enrichment-hydration.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { hydrateEnrichment, needsKarakeepImageUpgrade } from "@/lib/bookmarks/enrichment-hydration";
-import type { UnifiedBookmark } from "@/types/schemas/bookmark";
+import { unifiedBookmarkSchema, type UnifiedBookmark } from "@/types/schemas/bookmark";
 
 const TIMESTAMP = "2026-01-01T00:00:00.000Z";
 
 function buildBookmark(overrides: Partial<UnifiedBookmark> = {}): UnifiedBookmark {
-  return {
+  return unifiedBookmarkSchema.parse({
     id: "bm-1",
     slug: "example-com-bm-1",
     url: "https://example.com/article",
@@ -15,7 +15,7 @@ function buildBookmark(overrides: Partial<UnifiedBookmark> = {}): UnifiedBookmar
     dateBookmarked: TIMESTAMP,
     sourceUpdatedAt: TIMESTAMP,
     ...overrides,
-  } as UnifiedBookmark;
+  });
 }
 
 describe("hydrateEnrichment", () => {
@@ -53,7 +53,13 @@ describe("hydrateEnrichment", () => {
 });
 
 describe("needsKarakeepImageUpgrade", () => {
-  const content = { type: "link", imageAssetId: "asset-1" } as UnifiedBookmark["content"];
+  const content = {
+    type: "link",
+    url: "https://example.com/article",
+    title: "Example",
+    description: null,
+    imageAssetId: "asset-1",
+  } satisfies NonNullable<UnifiedBookmark["content"]>;
 
   it("is true when a Karakeep asset exists but ogImage is missing", () => {
     expect(needsKarakeepImageUpgrade(buildBookmark({ content }))).toBe(true);
@@ -62,6 +68,19 @@ describe("needsKarakeepImageUpgrade", () => {
   it("is true when ogImage is still a proxy URL", () => {
     expect(
       needsKarakeepImageUpgrade(buildBookmark({ content, ogImage: "/api/assets/asset-1" })),
+    ).toBe(true);
+  });
+
+  it("is true when ogImage is still the Karakeep content-image fallback", () => {
+    const fallbackUrl = "https://karakeep.example/favicon.ico";
+
+    expect(
+      needsKarakeepImageUpgrade(
+        buildBookmark({
+          content: { ...content, imageUrl: fallbackUrl },
+          ogImage: fallbackUrl,
+        }),
+      ),
     ).toBe(true);
   });
 

--- a/__tests__/lib/bookmarks/has-bookmarks-changed.unit.test.ts
+++ b/__tests__/lib/bookmarks/has-bookmarks-changed.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { UnifiedBookmark } from "@/types";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 import { calculateBookmarksChecksum } from "@/lib/bookmarks/utils";
 
 const mockGetBookmarksIndexFromDatabase = vi.fn();

--- a/__tests__/lib/bookmarks/lock-and-freshness.unit.test.ts
+++ b/__tests__/lib/bookmarks/lock-and-freshness.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { UnifiedBookmark } from "@/types";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 import { calculateBookmarksChecksum } from "@/lib/bookmarks/utils";
 
 const mockGetBookmarksIndexFromDatabase = vi.fn();
@@ -78,7 +78,7 @@ describe("Bookmarks lock + freshness behavior (unit)", () => {
     vi.clearAllMocks();
 
     process.env.MIN_BOOKMARKS_THRESHOLD = "1";
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     process.env.SELECTIVE_OG_REFRESH = "true";
 
     mockGetAllBookmarks.mockResolvedValue([]);
@@ -109,7 +109,7 @@ describe("Bookmarks lock + freshness behavior (unit)", () => {
       checksum: calculateBookmarksChecksum(dataset),
     });
 
-    setRefreshBookmarksCallback(() => dataset);
+    setRefreshBookmarksCallback(() => Promise.resolve(dataset));
     initializeBookmarksDataAccess();
 
     expect(await acquireRefreshLock()).toBe(true);

--- a/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
+++ b/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
@@ -3,7 +3,7 @@ import {
   EmptyBookmarksApiResponseError,
   fetchAllPagesFromApi,
 } from "@/lib/bookmarks/refresh-helpers";
-import { normalizeBookmark } from "@/lib/bookmarks/normalize";
+import { normalizeBookmark, normalizeBookmarks } from "@/lib/bookmarks/normalize";
 import type { RawApiBookmark } from "@/types/schemas/bookmark";
 
 function makeRawBookmark(id: string, htmlContent: string | null): RawApiBookmark {
@@ -76,6 +76,15 @@ describe("Scraped content pipeline", () => {
     rawBookmark.content.url = "";
 
     expect(normalizeBookmark(rawBookmark, 0)).toBeNull();
+  });
+
+  it("aborts collection normalization when any bookmark has an invalid source URL", () => {
+    const invalidBookmark = makeRawBookmark("bookmark-empty-url", null);
+    invalidBookmark.content.url = "";
+
+    expect(() =>
+      normalizeBookmarks([makeRawBookmark("bookmark-valid", null), invalidBookmark]),
+    ).toThrow("Refusing partial refresh");
   });
 
   it("requests includeContent=true on every paginated API fetch", async () => {

--- a/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
+++ b/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
@@ -4,7 +4,7 @@ import {
   fetchAllPagesFromApi,
 } from "@/lib/bookmarks/refresh-helpers";
 import { normalizeBookmark } from "@/lib/bookmarks/normalize";
-import type { RawApiBookmark } from "@/types/bookmark";
+import type { RawApiBookmark } from "@/types/schemas/bookmark";
 
 function makeRawBookmark(id: string, htmlContent: string | null): RawApiBookmark {
   return {

--- a/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
+++ b/__tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchAllPagesFromApi } from "@/lib/bookmarks/refresh-helpers";
+import {
+  EmptyBookmarksApiResponseError,
+  fetchAllPagesFromApi,
+} from "@/lib/bookmarks/refresh-helpers";
 import { normalizeBookmark } from "@/lib/bookmarks/normalize";
 import type { RawApiBookmark } from "@/types/bookmark";
 
@@ -68,6 +71,13 @@ describe("Scraped content pipeline", () => {
     expect(normalized?.content).not.toHaveProperty("htmlContent");
   });
 
+  it("drops raw bookmarks with an empty source URL before persistence", () => {
+    const rawBookmark = makeRawBookmark("bookmark-empty-url", null);
+    rawBookmark.content.url = "";
+
+    expect(normalizeBookmark(rawBookmark, 0)).toBeNull();
+  });
+
   it("requests includeContent=true on every paginated API fetch", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -100,5 +110,18 @@ describe("Scraped content pipeline", () => {
     expect(fetchSpy.mock.calls[1]?.[0]).toBe(
       "https://example.com/api/v1/lists/test-list/bookmarks?cursor=next-cursor&includeContent=true",
     );
+  });
+
+  it("rejects an empty API response instead of returning an empty refresh dataset", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      createJsonResponse({ bookmarks: [], nextCursor: null }),
+    );
+
+    await expect(
+      fetchAllPagesFromApi({
+        apiUrl: "https://example.com/api/v1/lists/test-list/bookmarks",
+        requestHeaders: { Accept: "application/json", Authorization: "Bearer token" },
+      }),
+    ).rejects.toBeInstanceOf(EmptyBookmarksApiResponseError);
   });
 });

--- a/__tests__/lib/bookmarks/slug-mapping.test.ts
+++ b/__tests__/lib/bookmarks/slug-mapping.test.ts
@@ -9,7 +9,7 @@ import {
   getSlugForBookmark,
   getBookmarkIdFromSlug,
 } from "@/lib/bookmarks/slug-manager";
-import type { UnifiedBookmark, BookmarkSlugMapping } from "@/types";
+import type { BookmarkSlugMapping } from "@/types/schemas/bookmark";
 import { getSlugMappingRowsFromDatabase } from "@/lib/db/queries/bookmarks";
 
 vi.mock("@/lib/db/queries/bookmarks", () => ({
@@ -22,42 +22,21 @@ vi.mock("@/lib/utils/logger");
 const mockGetSlugMappingRows = vi.mocked(getSlugMappingRowsFromDatabase);
 
 describe("Bookmark Slug Mapping", () => {
-  const mockBookmarks: UnifiedBookmark[] = [
+  const mockBookmarks: Parameters<typeof generateSlugMapping>[0] = [
     {
       id: "bookmark1",
       url: "https://example.com",
       title: "Example Site",
-      description: "An example website for testing",
-      tags: [],
-      domain: "example.com",
-      dateBookmarked: "2024-01-01",
-      sourceUpdatedAt: "2024-01-01T00:00:00Z",
-      summary: "",
-      note: "",
     },
     {
       id: "bookmark2",
       url: "https://github.com/user/repo",
       title: "GitHub Repo",
-      description: "A GitHub repository",
-      tags: [],
-      domain: "github.com",
-      dateBookmarked: "2024-01-02",
-      sourceUpdatedAt: "2024-01-02T00:00:00Z",
-      summary: "",
-      note: "",
     },
     {
       id: "bookmark3",
       url: "https://example.com",
       title: "Example Site Again",
-      description: "Another example website for testing duplicates",
-      tags: [],
-      domain: "example.com",
-      dateBookmarked: "2024-01-03",
-      sourceUpdatedAt: "2024-01-03T00:00:00Z",
-      summary: "",
-      note: "",
     },
   ];
 
@@ -80,7 +59,7 @@ describe("Bookmark Slug Mapping", () => {
     });
 
     it("should preserve existing slugs when provided", () => {
-      const bookmarksWithSlugs: UnifiedBookmark[] = [
+      const bookmarksWithSlugs: Parameters<typeof generateSlugMapping>[0] = [
         { ...mockBookmarks[0], slug: "stable-example-slug" },
         { ...mockBookmarks[1], slug: "stable-github-slug" },
       ];

--- a/__tests__/lib/bookmarks/tag-routes.test.ts
+++ b/__tests__/lib/bookmarks/tag-routes.test.ts
@@ -4,7 +4,7 @@
  * Verifies getBookmarksByTag behavior through DB query module mocks.
  */
 import { vi } from "vitest";
-import type { UnifiedBookmark } from "@/types";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 import { getBookmarksByTag } from "@/lib/bookmarks/bookmarks-data-access.server";
 import {
   getBookmarksPageByTag,

--- a/__tests__/lib/cache-invalidation-simple.test.ts
+++ b/__tests__/lib/cache-invalidation-simple.test.ts
@@ -59,7 +59,7 @@ describe("Cache Invalidation Functions", () => {
     });
   });
 
-  describe.todo("GitHub Cache (Mocked)", () => {
+  describe("GitHub Cache (Mocked)", () => {
     it("should expose cached activity readers", async () => {
       // Clear module cache and use our mock
       vi.resetModules();

--- a/__tests__/lib/cache-invalidation-simple.test.ts
+++ b/__tests__/lib/cache-invalidation-simple.test.ts
@@ -60,16 +60,16 @@ describe("Cache Invalidation Functions", () => {
   });
 
   describe.todo("GitHub Cache (Mocked)", () => {
-    it("should have invalidation function", async () => {
+    it("should expose cached activity readers", async () => {
       // Clear module cache and use our mock
       vi.resetModules();
       const githubModule = await import("@/lib/data-access/github");
 
-      expect(githubModule.invalidateAllGitHubCaches).toBeDefined();
-      expect(typeof githubModule.invalidateAllGitHubCaches).toBe("function");
-
-      // Test that function can be called without errors
-      expect(() => githubModule.invalidateAllGitHubCaches()).not.toThrow();
+      expect(githubModule.refreshGitHubActivityDataFromApi).toBeDefined();
+      expect(typeof githubModule.refreshGitHubActivityDataFromApi).toBe("function");
+      const githubPublicModule = await import("@/lib/data-access/github-public-api");
+      expect(githubPublicModule.getGithubActivityCached).toBeDefined();
+      expect(typeof githubPublicModule.getGithubActivityCached).toBe("function");
     });
   });
 });

--- a/__tests__/lib/cache-invalidation.test.ts
+++ b/__tests__/lib/cache-invalidation.test.ts
@@ -29,7 +29,7 @@ import {
   getBookmarksPage,
   invalidateBookmarksCache,
 } from "@/lib/bookmarks/bookmarks-data-access.server";
-import { getGithubActivity, invalidateAllGitHubCaches } from "@/lib/data-access/github-public-api";
+import { getGithubActivity } from "@/lib/data-access/github-public-api";
 import { getAllPosts } from "@/lib/blog";
 import { invalidateBlogCache } from "@/lib/blog/mdx";
 import type { GraphQLRepoNode } from "@/types/github";
@@ -149,19 +149,16 @@ describe("Next.js Cache Invalidation", () => {
         const start = Date.now();
         const activity2 = await getGithubActivity();
         const cachedTime = Date.now() - start;
-        expect(activity2.trailingYearData.contributionCalendar.totalContributions).toBe(
-          activity1.trailingYearData.contributionCalendar.totalContributions,
+        expect(activity2.trailingYearData.totalContributions).toBe(
+          activity1.trailingYearData.totalContributions,
         );
-
-        // Invalidate cache
-        invalidateAllGitHubCaches();
 
         // Third fetch (should be fresh)
         const start2 = Date.now();
         const activity3 = await getGithubActivity();
         const freshTime = Date.now() - start2;
-        expect(activity3.trailingYearData.contributionCalendar.totalContributions).toBe(
-          activity1.trailingYearData.contributionCalendar.totalContributions,
+        expect(activity3.trailingYearData.totalContributions).toBe(
+          activity1.trailingYearData.totalContributions,
         );
 
         console.log(`GitHub cache test - Cached: ${cachedTime}ms, Fresh: ${freshTime}ms`);

--- a/__tests__/lib/cache-invalidation.test.ts
+++ b/__tests__/lib/cache-invalidation.test.ts
@@ -32,6 +32,42 @@ import {
 import { getGithubActivity, invalidateAllGitHubCaches } from "@/lib/data-access/github-public-api";
 import { getAllPosts } from "@/lib/blog";
 import { invalidateBlogCache } from "@/lib/blog/mdx";
+import type { GraphQLRepoNode } from "@/types/github";
+import type {
+  GitHubActivityApiResponse,
+  GitHubActivitySegment,
+  PriorYearCommitSummary,
+} from "@/types/schemas/github-storage";
+
+const buildGitHubSegment = (
+  overrides: Partial<GitHubActivitySegment> = {},
+): GitHubActivitySegment => ({
+  source: "api",
+  data: [],
+  totalContributions: 12,
+  linesAdded: 120,
+  linesRemoved: 30,
+  dataComplete: true,
+  ...overrides,
+});
+
+const readGithubActivityView = async (record: GitHubActivityApiResponse) => {
+  vi.resetModules();
+  vi.doMock("@/lib/data-access/github-storage", () => ({
+    readGitHubActivityRecord: () => Promise.resolve(record),
+    getGitHubActivityMetadata: () => Promise.resolve(null),
+    isFlatStoredGithubActivityFormat: () => false,
+  }));
+
+  try {
+    const actual = await vi.importActual<typeof import("@/lib/data-access/github-public-api")>(
+      "@/lib/data-access/github-public-api",
+    );
+    return actual.getGithubActivity();
+  } finally {
+    vi.doUnmock("@/lib/data-access/github-storage");
+  }
+};
 
 describe("Next.js Cache Invalidation", () => {
   const USE_NEXTJS_CACHE = process.env.USE_NEXTJS_CACHE === "true";
@@ -133,6 +169,134 @@ describe("Next.js Cache Invalidation", () => {
         console.log("GitHub test skipped - data not available");
         expect(true).toBe(true); // Pass the test
       }
+    });
+  });
+
+  describe("GitHub Activity View", () => {
+    const priorYearCommits = {
+      totalCommits: 5,
+      totalLinesAdded: 240,
+      totalLinesRemoved: 40,
+      publicCommits: 3,
+      privateCommits: 2,
+      perRepo: {
+        "william/example": {
+          commits: 5,
+          linesAdded: 240,
+          linesRemoved: 40,
+          isPrivate: false,
+        },
+      },
+    } satisfies PriorYearCommitSummary;
+
+    it("ignores prior-year commits attached only to the trailing-year segment", async () => {
+      const activity = await readGithubActivityView({
+        trailingYearData: buildGitHubSegment({ allPriorYearCommits: priorYearCommits }),
+        cumulativeAllTimeData: buildGitHubSegment({ totalContributions: 50 }),
+      });
+
+      expect(activity.priorYearCommits).toBeUndefined();
+    });
+
+    it("projects prior-year commits from cumulative all-time data", async () => {
+      const activity = await readGithubActivityView({
+        trailingYearData: buildGitHubSegment(),
+        cumulativeAllTimeData: buildGitHubSegment({ allPriorYearCommits: priorYearCommits }),
+      });
+
+      expect(activity.priorYearCommits).toEqual(priorYearCommits);
+    });
+
+    it("leaves prior-year commits undefined when cumulative data has no summary", async () => {
+      const activity = await readGithubActivityView({
+        trailingYearData: buildGitHubSegment(),
+        cumulativeAllTimeData: buildGitHubSegment(),
+      });
+
+      expect(activity.priorYearCommits).toBeUndefined();
+    });
+  });
+
+  describe("GitHub Repo Processor", () => {
+    it("uses cached weekly stats when the live contributor API fails", async () => {
+      vi.resetModules();
+      const readRepoWeeklyStatsRecord = vi.fn().mockResolvedValue({
+        repoOwnerLogin: "owner",
+        repoName: "repo",
+        lastFetched: "2026-06-09T00:00:00.000Z",
+        status: "complete",
+        stats: [{ w: Date.parse("2026-06-01T00:00:00.000Z") / 1000, a: 100, d: 40, c: 3 }],
+      });
+      const writeRepoWeeklyStatsRecord = vi.fn();
+      vi.doMock("@/lib/data-access/github-api", () => ({
+        fetchContributorStats: vi.fn().mockRejectedValue(new Error("GitHub unavailable")),
+        GitHubContributorStatsPendingError: class GitHubContributorStatsPendingError extends Error {},
+        GitHubContributorStatsRateLimitError: class GitHubContributorStatsRateLimitError extends Error {},
+      }));
+      vi.doMock("@/lib/data-access/github-storage", () => ({
+        readRepoWeeklyStatsRecord,
+        writeRepoWeeklyStatsRecord,
+      }));
+
+      const { processSingleRepository } = await import("@/lib/data-access/github-repo-processor");
+      const repo: GraphQLRepoNode = {
+        id: "repo-id",
+        name: "repo",
+        owner: { login: "owner" },
+        nameWithOwner: "owner/repo",
+        isFork: false,
+        isPrivate: false,
+      };
+      const result = await processSingleRepository({
+        repo,
+        githubRepoOwner: "owner",
+        trailingYearFromDate: new Date("2025-06-10T00:00:00.000Z"),
+        now: new Date("2026-06-10T00:00:00.000Z"),
+      });
+
+      expect(result.yearLinesAdded).toBe(100);
+      expect(result.yearLinesRemoved).toBe(40);
+      expect(result.allTimeLinesAdded).toBe(100);
+      expect(result.dataComplete).toBe(false);
+      expect(result.hasAllTimeData).toBe(true);
+      expect(writeRepoWeeklyStatsRecord).not.toHaveBeenCalled();
+    });
+
+    it("does not overwrite complete activity with an incomplete refresh", async () => {
+      vi.resetModules();
+      const insert = vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+        })),
+      }));
+      vi.doMock("@/lib/db/connection", () => ({
+        assertDatabaseWriteAllowed: vi.fn(),
+        db: { insert },
+      }));
+      vi.doMock("@/lib/db/queries/github-activity", () => ({
+        readGitHubActivityFromDb: () =>
+          Promise.resolve({
+            trailingYearData: buildGitHubSegment({
+              data: [{ date: "2026-06-09", count: 3, level: 1 }],
+              totalContributions: 100,
+              dataComplete: true,
+            }),
+            cumulativeAllTimeData: buildGitHubSegment({ totalContributions: 200 }),
+          }),
+      }));
+
+      const { writeGitHubActivityToDb } = await import("@/lib/db/mutations/github-activity");
+      const result = await writeGitHubActivityToDb({
+        trailingYearData: buildGitHubSegment({
+          data: [{ date: "2026-06-10", count: 5, level: 2 }],
+          totalContributions: 150,
+          dataComplete: false,
+        }),
+        cumulativeAllTimeData: buildGitHubSegment({ totalContributions: 250 }),
+      });
+
+      expect(result).toBe(true);
+      expect(insert).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/lib/caching/cache.test.ts
+++ b/__tests__/lib/caching/cache.test.ts
@@ -70,18 +70,26 @@ describe("lib/cache", () => {
       expect(fallbackFn).toHaveBeenCalled();
     });
 
-    it("should use direct fallback during production build", async () => {
+    it("keeps cached functions active during production build so cache tags register", async () => {
       const previousPhase = process.env.NEXT_PHASE;
       process.env.NEXT_PHASE = "phase-production-build";
-      const cachedFn = vi.fn().mockResolvedValue("cached result");
+      mockCacheTag.mockClear();
+      mockCacheLife.mockClear();
+      const cachedFn = vi.fn(async () => {
+        cacheContextGuards.cacheTag("BuildCache", "build-tag");
+        cacheContextGuards.cacheLife("BuildCache", { revalidate: 120 });
+        return "cached result";
+      });
       const fallbackFn = vi.fn().mockResolvedValue("fallback result");
 
       try {
         const result = await withCacheFallback(cachedFn, fallbackFn);
 
-        expect(result).toBe("fallback result");
-        expect(cachedFn).not.toHaveBeenCalled();
-        expect(fallbackFn).toHaveBeenCalled();
+        expect(result).toBe("cached result");
+        expect(cachedFn).toHaveBeenCalled();
+        expect(fallbackFn).not.toHaveBeenCalled();
+        expect(mockCacheTag).toHaveBeenCalledWith("build-tag");
+        expect(mockCacheLife).toHaveBeenCalledWith({ revalidate: 120 });
       } finally {
         if (previousPhase === undefined) {
           delete process.env.NEXT_PHASE;

--- a/__tests__/lib/cloudflare-headers.test.ts
+++ b/__tests__/lib/cloudflare-headers.test.ts
@@ -10,10 +10,12 @@ describe("Cloudflare header enforcement", () => {
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV };
   });
 
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -50,7 +52,7 @@ describe("Cloudflare header enforcement", () => {
   });
 
   it("skips enforcement outside production", () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
 
     const headers = new Headers();
     const response = requireCloudflareHeaders(headers, { route: "/api/ai/token" });
@@ -58,7 +60,7 @@ describe("Cloudflare header enforcement", () => {
   });
 
   it("blocks when headers are missing in production", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.API_BASE_URL = "https://williamcallahan.com";
 
     const headers = new Headers();

--- a/__tests__/lib/db/bookmark-record-mapper.test.ts
+++ b/__tests__/lib/db/bookmark-record-mapper.test.ts
@@ -110,4 +110,19 @@ describe("bookmark-record-mapper", () => {
       "[BookmarkMapper] Cannot persist bookmark bookmark-3 with an empty slug.",
     );
   });
+
+  it("throws when persisting a bookmark with an empty URL", () => {
+    const invalidBookmark: UnifiedBookmark = {
+      id: "bookmark-4",
+      slug: "bookmark-4",
+      url: "",
+      title: "Fourth Bookmark",
+      description: "Fourth description",
+      tags: [],
+      dateBookmarked: "2026-02-25T10:00:00.000Z",
+      sourceUpdatedAt: "2026-02-25T10:00:00.000Z",
+    };
+
+    expect(() => mapUnifiedBookmarkToBookmarkInsert(invalidBookmark)).toThrow(/Invalid URL/);
+  });
 });

--- a/__tests__/lib/db/embedding-input-contracts.test.ts
+++ b/__tests__/lib/db/embedding-input-contracts.test.ts
@@ -1,9 +1,5 @@
-import {
-  buildEmbeddingText,
-  EMBEDDING_FIELD_CONTRACTS,
-  type EmbeddingFieldSpec,
-} from "@/lib/db/embedding-input-contracts";
-import { CONTENT_EMBEDDING_DOMAINS } from "@/types/db/embeddings";
+import { buildEmbeddingText, EMBEDDING_FIELD_CONTRACTS } from "@/lib/db/embedding-input-contracts";
+import { CONTENT_EMBEDDING_DOMAINS, type EmbeddingFieldSpec } from "@/types/db/embeddings";
 
 /**
  * Words that are banned as standalone labels because they have multiple
@@ -25,7 +21,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
     for (const domain of primaryDomains) {
       const fields = EMBEDDING_FIELD_CONTRACTS[domain as keyof typeof EMBEDDING_FIELD_CONTRACTS];
       const requiredFields = fields.filter((f: EmbeddingFieldSpec) => f.required);
-      expect(requiredFields.length).toBeGreaterThan(0, `Domain "${domain}" has no required fields`);
+      expect(requiredFields.length).toBeGreaterThan(0);
     }
   });
 
@@ -33,11 +29,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
     for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
       let sawVerbose = false;
       for (const field of fields) {
-        expect(sawVerbose && !field.verboseField).toBe(
-          false,
-          `Domain "${domain}": non-verbose field "${field.label}" appears after ` +
-            `verbose field. Verbose fields must be last for truncation safety.`,
-        );
+        expect(sawVerbose && !field.verboseField).toBe(false);
         if (field.verboseField) sawVerbose = true;
       }
     }
@@ -48,11 +40,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
       for (const field of fields) {
         const labelLower = field.label.toLowerCase();
         for (const banned of BANNED_STANDALONE_LABELS) {
-          expect(labelLower).not.toBe(
-            banned,
-            `Domain "${domain}": label "${field.label}" is a banned standalone ` +
-              `word. Qualify it (e.g. "Topic ${field.label}" or "Company ${field.label}").`,
-          );
+          expect(labelLower).not.toBe(banned);
         }
       }
     }
@@ -62,17 +50,14 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
     for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
       const labels = fields.map((f: EmbeddingFieldSpec) => f.label);
       const unique = new Set(labels);
-      expect(unique.size).toBe(labels.length, `Domain "${domain}" has duplicate labels`);
+      expect(unique.size).toBe(labels.length);
     }
   });
 
   it("every field has a non-empty meaning", () => {
     for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
       for (const field of fields) {
-        expect(field.meaning.trim().length).toBeGreaterThan(
-          0,
-          `Domain "${domain}", field "${field.label}" has empty meaning`,
-        );
+        expect(field.meaning.trim().length).toBeGreaterThan(0);
       }
     }
   });

--- a/__tests__/lib/db/embedding-input-contracts.test.ts
+++ b/__tests__/lib/db/embedding-input-contracts.test.ts
@@ -26,7 +26,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
   });
 
   it("verbose fields are always at the end of the field list", () => {
-    for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
+    for (const fields of Object.values(EMBEDDING_FIELD_CONTRACTS)) {
       let sawVerbose = false;
       for (const field of fields) {
         expect(sawVerbose && !field.verboseField).toBe(false);
@@ -36,7 +36,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
   });
 
   it("no label uses a banned standalone word", () => {
-    for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
+    for (const fields of Object.values(EMBEDDING_FIELD_CONTRACTS)) {
       for (const field of fields) {
         const labelLower = field.label.toLowerCase();
         for (const banned of BANNED_STANDALONE_LABELS) {
@@ -47,7 +47,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
   });
 
   it("labels are unique within each domain", () => {
-    for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
+    for (const fields of Object.values(EMBEDDING_FIELD_CONTRACTS)) {
       const labels = fields.map((f: EmbeddingFieldSpec) => f.label);
       const unique = new Set(labels);
       expect(unique.size).toBe(labels.length);
@@ -55,7 +55,7 @@ describe("EMBEDDING_FIELD_CONTRACTS", () => {
   });
 
   it("every field has a non-empty meaning", () => {
-    for (const [domain, fields] of Object.entries(EMBEDDING_FIELD_CONTRACTS)) {
+    for (const fields of Object.values(EMBEDDING_FIELD_CONTRACTS)) {
       for (const field of fields) {
         expect(field.meaning.trim().length).toBeGreaterThan(0);
       }

--- a/__tests__/lib/db/queries/discovery-grouped-integration.test.ts
+++ b/__tests__/lib/db/queries/discovery-grouped-integration.test.ts
@@ -1,7 +1,7 @@
 import {
   groupByPrimaryTag,
   filterRecentlyAdded,
-  type ScoredBookmarkRow,
+  type ScoredBookmark,
 } from "@/lib/db/queries/discovery-grouped";
 
 function makeRow(
@@ -9,7 +9,7 @@ function makeRow(
   primaryTag: { slug: string; name: string } | null,
   score: number,
   dateBookmarked: string,
-): ScoredBookmarkRow {
+): ScoredBookmark {
   return {
     bookmark: {
       id,
@@ -35,7 +35,7 @@ describe("discovery grouped integration", () => {
   afterEach(() => vi.useRealTimers());
 
   it("produces complete discover feed primitives from canonical tags", () => {
-    const rows: ScoredBookmarkRow[] = [
+    const rows: ScoredBookmark[] = [
       makeRow("1", { slug: "ai", name: "AI" }, 0.95, "2026-02-26T00:00:00Z"),
       makeRow("2", { slug: "ai", name: "AI" }, 0.85, "2026-02-25T00:00:00Z"),
       makeRow("3", { slug: "ai", name: "AI" }, 0.75, "2026-02-20T00:00:00Z"),

--- a/__tests__/lib/db/queries/embedding-similarity.test.ts
+++ b/__tests__/lib/db/queries/embedding-similarity.test.ts
@@ -8,12 +8,25 @@ vi.mock("@/lib/db/connection", () => ({
   },
 }));
 
+import { is, SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { CONTENT_EMBEDDING_DIMENSIONS } from "@/lib/db/schema/content-embeddings";
+import { hybridSearchBooks } from "@/lib/db/queries/hybrid-search-books-blog";
+import { hybridSearchProjects } from "@/lib/db/queries/hybrid-search-investments";
 import {
   computeEmbeddingBlendScore,
   findRelatedBookmarkIdsForSeeds,
   findSimilarByEmbedding,
   rankEmbeddingCandidates,
 } from "@/lib/db/queries/embedding-similarity";
+
+function renderLastExecuteSql(): string {
+  const call = mockExecute.mock.calls.at(-1);
+  if (!call) throw new Error("Expected db.execute to be called");
+  const query = call[0];
+  if (!is(query, SQL)) throw new Error("Expected db.execute to receive a SQL query");
+  return new PgDialect().sqlToQuery(query).sql;
+}
 
 describe("embedding-similarity query helpers", () => {
   beforeEach(() => {
@@ -172,5 +185,46 @@ describe("embedding-similarity query helpers", () => {
     });
 
     expect(result).toEqual(["related-2", "related-1"]);
+  });
+});
+
+describe("hybrid search SQL ranking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("orders keyword candidates before limiting embedding-mode project search", async () => {
+    mockExecute.mockResolvedValueOnce([]);
+    const embedding = Array.from({ length: CONTENT_EMBEDDING_DIMENSIONS }, () => 0);
+
+    await hybridSearchProjects({ query: "aventure", embedding, limit: 5 });
+
+    const rendered = renderLastExecuteSql();
+    expect(rendered).toContain("AS keyword_score");
+    expect(rendered).toContain("ORDER BY keyword_score DESC, id DESC");
+    expect(rendered).toContain("LIMIT $");
+  });
+
+  it("uses trigram-weighted keyword score for book fallback search", async () => {
+    mockExecute.mockResolvedValueOnce([
+      {
+        id: "book-1",
+        title: "TypeScript Quickly",
+        slug: "typescript-quickly",
+        authors: ["Yakov Fain"],
+        description: null,
+        cover_url: null,
+        keyword_score: "0.25",
+      },
+    ]);
+
+    const results = await hybridSearchBooks({ query: "typescrip", limit: 1 });
+
+    const rendered = renderLastExecuteSql();
+    expect(rendered).toContain("similarity(title");
+    expect(rendered).toContain("AS keyword_score");
+    expect(rendered).toContain("OR title %");
+    expect(rendered).toContain("ORDER BY keyword_score DESC, id DESC");
+    expect(results[0]?.score).toBe(0.25);
   });
 });

--- a/__tests__/lib/db/schema/projects.test.ts
+++ b/__tests__/lib/db/schema/projects.test.ts
@@ -1,5 +1,19 @@
 import { getTableColumns, getTableName } from "drizzle-orm";
 import { projects } from "@/lib/db/schema/projects";
+import { projects as staticProjects } from "@/data/projects";
+import {
+  findProjectBySlug,
+  generateProjectSlug,
+  getAllProjectSlugs,
+} from "@/lib/projects/slug-helpers";
+
+function requireProjectById(id: string) {
+  const project = staticProjects.find((candidate) => candidate.id === id);
+  if (!project) {
+    throw new Error(`Missing project fixture: ${id}`);
+  }
+  return project;
+}
 
 describe("projects schema", () => {
   it("has the expected table name", () => {
@@ -38,5 +52,22 @@ describe("projects schema", () => {
   it("has a search_vector column for FTS", () => {
     const columns = getTableColumns(projects);
     expect(columns.searchVector).toBeDefined();
+  });
+});
+
+describe("project slug helpers", () => {
+  it("resolves id-derived project URLs without emitting them as canonical slugs", () => {
+    const companyResearchTui = requireProjectById("tui-aventure-vc");
+    const appleMapsJava = requireProjectById("apple-maps-java");
+    const generatedSlugs = getAllProjectSlugs(staticProjects).map((entry) => entry.slug);
+
+    expect(findProjectBySlug("tui-aventure-vc", staticProjects)).toBe(companyResearchTui);
+    expect(findProjectBySlug("apple-maps-java", staticProjects)).toBe(appleMapsJava);
+    expect(findProjectBySlug("company-research-tui", staticProjects)).toBe(companyResearchTui);
+    expect(findProjectBySlug("apple-maps-java-sdk", staticProjects)).toBe(appleMapsJava);
+    expect(generatedSlugs).toContain(generateProjectSlug(companyResearchTui.name));
+    expect(generatedSlugs).toContain(generateProjectSlug(appleMapsJava.name));
+    expect(generatedSlugs).not.toContain("tui-aventure-vc");
+    expect(generatedSlugs).not.toContain("apple-maps-java");
   });
 });

--- a/__tests__/lib/env-config.test.ts
+++ b/__tests__/lib/env-config.test.ts
@@ -27,6 +27,7 @@ describe("Environment Variable Configuration", () => {
   beforeEach(() => {
     /** Reset modules to pick up new env vars */
     vi.resetModules();
+    vi.unstubAllEnvs();
     /** Clone the original env */
     process.env = { ...originalEnv };
   });
@@ -36,6 +37,7 @@ describe("Environment Variable Configuration", () => {
    * Prevents test pollution by resetting process.env to original values
    */
   afterEach(() => {
+    vi.unstubAllEnvs();
     /** Restore original env */
     process.env = { ...originalEnv };
   });
@@ -222,7 +224,7 @@ describe("Environment Variable Configuration", () => {
 
   describe("PostgreSQL Access Mode", () => {
     it("keeps test sessions read-only by default", async () => {
-      process.env.NODE_ENV = "test";
+      vi.stubEnv("NODE_ENV", "test");
       Reflect.deleteProperty(process.env, "DEPLOYMENT_ENV");
       // Clear site URL so NODE_ENV fallback is exercised
       Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SITE_URL");
@@ -237,7 +239,7 @@ describe("Environment Variable Configuration", () => {
     });
 
     it("allows writes only when deployment environment resolves to production", async () => {
-      process.env.NODE_ENV = "test";
+      vi.stubEnv("NODE_ENV", "test");
       process.env.DEPLOYMENT_ENV = "production";
       // Clear site URL so DEPLOYMENT_ENV fallback is exercised
       Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SITE_URL");
@@ -254,7 +256,7 @@ describe("Environment Variable Configuration", () => {
     });
 
     it("blocks writes when deployment environment is not production", async () => {
-      process.env.NODE_ENV = "development";
+      vi.stubEnv("NODE_ENV", "development");
       process.env.DEPLOYMENT_ENV = "testing";
       // Clear site URL so DEPLOYMENT_ENV fallback is exercised
       Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SITE_URL");
@@ -273,7 +275,7 @@ describe("Environment Variable Configuration", () => {
     });
 
     it("allows writes for canonical production runtime when DEPLOYMENT_ENV is stale", async () => {
-      process.env.NODE_ENV = "production";
+      vi.stubEnv("NODE_ENV", "production");
       process.env.DEPLOYMENT_ENV = "development";
       process.env.NEXT_PUBLIC_SITE_URL = "https://williamcallahan.com";
 
@@ -290,7 +292,7 @@ describe("Environment Variable Configuration", () => {
     });
 
     it("keeps development runtimes read-only even when the public site URL is production", async () => {
-      process.env.NODE_ENV = "development";
+      vi.stubEnv("NODE_ENV", "development");
       process.env.DEPLOYMENT_ENV = "development";
       process.env.NEXT_PUBLIC_SITE_URL = "https://williamcallahan.com";
 

--- a/__tests__/lib/get-base-url.test.ts
+++ b/__tests__/lib/get-base-url.test.ts
@@ -15,6 +15,7 @@ describe("getBaseUrl", () => {
    * Clone environment before each test
    */
   beforeEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV }; // clone
   });
 
@@ -22,6 +23,7 @@ describe("getBaseUrl", () => {
    * Restore original environment after all tests complete
    */
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV }; // restore from snapshot
   });
 
@@ -49,7 +51,7 @@ describe("getBaseUrl", () => {
   it("falls back to NEXT_PUBLIC_SITE_URL if API_BASE_URL not set", async () => {
     process.env.API_BASE_URL = undefined;
     process.env.NEXT_PUBLIC_SITE_URL = "https://public.example.com/"; // with trailing slash
-    process.env.NODE_ENV = "production"; // Set to production to use NEXT_PUBLIC_SITE_URL
+    vi.stubEnv("NODE_ENV", "production"); // Set to production to use NEXT_PUBLIC_SITE_URL
     const { getBaseUrl } = await import("@/lib/utils/get-base-url");
     const result = getBaseUrl();
     expect(result).toBe("https://public.example.com"); // trailing slash removed

--- a/__tests__/lib/github-activity.test.ts
+++ b/__tests__/lib/github-activity.test.ts
@@ -141,8 +141,8 @@ describe("lib/data-access/github.ts functionality", () => {
       mockRefreshGitHubActivityDataFromApi.mockResolvedValue(mockResult);
 
       const mockMetadata = {
-        LastModified: new Date(),
-        ETag: "test-etag",
+        lastModified: new Date(),
+        eTag: "test-etag",
       };
       mockGetS3ObjectMetadata.mockResolvedValue(mockMetadata);
 
@@ -166,15 +166,15 @@ describe("lib/data-access/github.ts functionality", () => {
     it("should handle S3 metadata retrieval", async () => {
       const testKey = GITHUB_ACTIVITY_S3_PATHS.ACTIVITY_DATA_PROD_FALLBACK;
       const mockMetadata = {
-        LastModified: new Date("2024-01-01"),
-        ETag: "test-etag",
+        lastModified: new Date("2024-01-01"),
+        eTag: "test-etag",
       };
 
       mockGetS3ObjectMetadata.mockResolvedValue(mockMetadata);
 
       const metadata = await getS3ObjectMetadata(testKey);
       expect(metadata).toEqual(mockMetadata);
-      expect(metadata?.LastModified).toEqual(new Date("2024-01-01"));
+      expect(metadata?.lastModified).toEqual(new Date("2024-01-01"));
     });
 
     it("should calculate age correctly", () => {

--- a/__tests__/lib/image-handling/invert-logo.test.ts
+++ b/__tests__/lib/image-handling/invert-logo.test.ts
@@ -2,12 +2,10 @@
 const { TextEncoder: UtilTextEncoder, TextDecoder: UtilTextDecoder } = require("node:util");
 
 if (typeof global.TextEncoder === "undefined" && UtilTextEncoder) {
-  // @ts-expect-error assign
   global.TextEncoder = UtilTextEncoder;
 }
 
 if (typeof global.TextDecoder === "undefined" && UtilTextDecoder) {
-  // @ts-expect-error assign
   global.TextDecoder = UtilTextDecoder as unknown as typeof global.TextDecoder;
 }
 
@@ -19,8 +17,8 @@ import { invertLogoBuffer } from "@/lib/image-handling/invert-logo";
  * Returns the encoded PNG buffer and the original pixel data.
  */
 function generateSinglePixelPng(r: number, g: number, b: number): Buffer {
-  const img = new Image(1, 1, { kind: "RGB" });
-  img.setPixelXY(0, 0, [r, g, b]);
+  const img = new Image(1, 1);
+  img.setPixelXY(0, 0, [r, g, b, 255]);
   const buffer = Buffer.from(img.toBuffer({ format: "png" }));
   return buffer;
 }
@@ -32,7 +30,7 @@ describe("invertLogoBuffer", () => {
 
     const { buffer: inverted } = await invertLogoBuffer(redPng);
 
-    const invertedImg = await Image.load(inverted);
+    const invertedImg = await Image.load(new Uint8Array(inverted));
     const [r, g, b] = invertedImg.getPixelXY(0, 0);
 
     expect(r).toBe(0);

--- a/__tests__/lib/image-handling/streaming-refetch.test.ts
+++ b/__tests__/lib/image-handling/streaming-refetch.test.ts
@@ -1,7 +1,33 @@
 import { vi, type Mock } from "vitest";
+import { S3Client } from "@aws-sdk/client-s3";
 import { UnifiedImageService } from "@/lib/services/unified-image-service";
+import { streamToS3 } from "@/lib/services/image-streaming";
 import { fetchWithTimeout } from "@/lib/utils/http-client";
 import { checkIfS3ObjectExists } from "@/lib/s3/objects";
+
+type MockUploadInstance = {
+  abort: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  done: ReturnType<typeof vi.fn<() => Promise<{ Location: string }>>>;
+  on: ReturnType<typeof vi.fn<() => MockUploadInstance>>;
+};
+
+const { uploadInstances } = vi.hoisted(() => ({
+  uploadInstances: [] as MockUploadInstance[],
+}));
+
+vi.mock("@aws-sdk/lib-storage", () => {
+  class MockUpload implements MockUploadInstance {
+    abort = vi.fn(() => Promise.resolve());
+    done = vi.fn(() => new Promise<{ Location: string }>(() => undefined));
+    on = vi.fn(() => this);
+
+    constructor() {
+      uploadInstances.push(this);
+    }
+  }
+
+  return { Upload: MockUpload };
+});
 
 vi.mock("@/lib/utils/http-client", () => ({
   fetchWithTimeout: vi.fn(),
@@ -22,6 +48,7 @@ const mockCheckIfS3ObjectExists = checkIfS3ObjectExists as Mock;
 describe("UnifiedImageService streaming fallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    uploadInstances.length = 0;
     mockCheckIfS3ObjectExists.mockResolvedValue(false);
   });
 
@@ -56,5 +83,36 @@ describe("UnifiedImageService streaming fallback", () => {
     expect(result.buffer.length).toBe(3);
     // Note: Buffer content verification skipped due to ArrayBuffer/Buffer transfer quirks in tests
     // The length assertion confirms re-fetch succeeded with new response data
+  });
+
+  it("aborts multipart upload and returns when streaming times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const s3Client = new S3Client({
+        region: "us-east-1",
+        credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      });
+      const stream = new ReadableStream<Uint8Array>({
+        start() {
+          // Leave the stream pending so the mocked Upload.done() never settles first.
+        },
+      });
+
+      const resultPromise = streamToS3(stream, {
+        bucket: "bucket",
+        key: "images/large.png",
+        contentType: "image/png",
+        s3Client,
+      });
+
+      await vi.advanceTimersByTimeAsync(300000);
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain("Stream timeout");
+      expect(uploadInstances[0]?.abort).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/__tests__/lib/image-processing/imageAnalysis.test.ts
+++ b/__tests__/lib/image-processing/imageAnalysis.test.ts
@@ -51,13 +51,6 @@ describe("Logo Analysis Module", () => {
       const result = await invertLogo(testBuffer);
       expect(result).toBe(testBuffer); // Should return the original buffer
     });
-
-    it("should return original buffer when preserveTransparency is requested", async () => {
-      // TODO(wasm-image): This is a no-op stub until WASM implementation
-      const testBuffer = Buffer.from([0]);
-      const result = await invertLogo(testBuffer);
-      expect(result).toBe(testBuffer); // Should return the original buffer
-    });
   });
 
   describe("doesLogoNeedInversion", () => {

--- a/__tests__/lib/image-processing/imageAnalysis.test.ts
+++ b/__tests__/lib/image-processing/imageAnalysis.test.ts
@@ -4,9 +4,8 @@ import {
   invertLogo,
   doesLogoNeedInversion,
   analyzeImage, // Include legacy export for coverage
-  type LogoBrightnessAnalysis, // Import the type
-  type LogoInversion, // Import the type
 } from "@/lib/image-handling/image-analysis";
+import type { LogoBrightnessAnalysis, LogoInversion } from "@/types/logo";
 
 // TODO(wasm-image): Sharp was removed to fix memory leaks. These tests now expect
 // stubbed values until we implement a WASM-based image analysis pipeline.
@@ -56,7 +55,7 @@ describe("Logo Analysis Module", () => {
     it("should return original buffer when preserveTransparency is requested", async () => {
       // TODO(wasm-image): This is a no-op stub until WASM implementation
       const testBuffer = Buffer.from([0]);
-      const result = await invertLogo(testBuffer, true);
+      const result = await invertLogo(testBuffer);
       expect(result).toBe(testBuffer); // Should return the original buffer
     });
   });

--- a/__tests__/lib/instrumentation-register.test.ts
+++ b/__tests__/lib/instrumentation-register.test.ts
@@ -3,16 +3,18 @@
  * @vitest-environment node
  */
 
-vi.mock("../../src/instrumentation-node", () => ({
-  register: vi.fn(),
-}));
-
-vi.mock("../../src/instrumentation-edge", () => ({
-  register: vi.fn(),
-}));
-
 describe("instrumentation register", () => {
   const ORIGINAL_ENV = { ...process.env };
+
+  const mockRuntimeModules = (): void => {
+    vi.doMock("../../src/instrumentation-node", () => ({
+      register: vi.fn(),
+    }));
+
+    vi.doMock("../../src/instrumentation-edge", () => ({
+      register: vi.fn(),
+    }));
+  };
 
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
@@ -27,6 +29,7 @@ describe("instrumentation register", () => {
   it("invokes node instrumentation register in node runtime", async () => {
     process.env.NODE_ENV = "production";
     process.env.NEXT_RUNTIME = "nodejs";
+    mockRuntimeModules();
 
     const { register } = await import("@/instrumentation");
     await register();
@@ -38,6 +41,7 @@ describe("instrumentation register", () => {
   it("invokes edge instrumentation register in edge runtime", async () => {
     process.env.NODE_ENV = "production";
     process.env.NEXT_RUNTIME = "edge";
+    mockRuntimeModules();
 
     const { register } = await import("@/instrumentation");
     await register();
@@ -49,11 +53,68 @@ describe("instrumentation register", () => {
   it("skips instrumentation in development", async () => {
     process.env.NODE_ENV = "development";
     process.env.NEXT_RUNTIME = "nodejs";
+    mockRuntimeModules();
 
     const { register } = await import("@/instrumentation");
     await register();
 
     const nodeModule = await import("../../src/instrumentation-node");
     expect(nodeModule.register).not.toHaveBeenCalled();
+  });
+});
+
+describe("node instrumentation register", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      NEXT_PHASE: "",
+      SENTRY_DSN: "https://public@example.com/1",
+    };
+    globalThis.INSTRUMENTATION_NODE_INSTALLED = undefined;
+    vi.resetModules();
+    vi.doUnmock("../../src/instrumentation-node");
+    vi.doUnmock("../../src/instrumentation-edge");
+    vi.doUnmock("@/instrumentation-node");
+    vi.doUnmock("@/instrumentation-edge");
+    vi.clearAllMocks();
+    vi.doMock("@sentry/nextjs", () => ({
+      init: vi.fn(),
+      zodErrorsIntegration: vi.fn(() => ({ name: "ZodErrors" })),
+      extraErrorDataIntegration: vi.fn(() => ({ name: "ExtraErrorData" })),
+      dedupeIntegration: vi.fn(() => ({ name: "Dedupe" })),
+    }));
+    vi.doMock("@/lib/sentry/resolve-environment", () => ({
+      resolveSentryEnvironment: () => "test",
+    }));
+    vi.doMock("@/lib/image-handling/image-manifest-loader", () => ({
+      loadImageManifests: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock("@/lib/rate-limiter", () => ({
+      loadRateLimitStore: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock("@/lib/constants", () => ({
+      JINA_FETCH_STORE_NAME: "jina",
+      JINA_FETCH_RATE_LIMIT_STORE_KEY: "jina-key",
+    }));
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    globalThis.INSTRUMENTATION_NODE_INSTALLED = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("leaves unhandled promise rejection capture to Sentry defaults", async () => {
+    const processOn = vi.spyOn(process, "on");
+    const { register } = await import("@/instrumentation-node");
+
+    await register();
+
+    const Sentry = await import("@sentry/nextjs");
+    expect(Sentry.init).toHaveBeenCalledTimes(1);
+    expect(processOn).not.toHaveBeenCalledWith("unhandledRejection", expect.any(Function));
   });
 });

--- a/__tests__/lib/instrumentation-register.test.ts
+++ b/__tests__/lib/instrumentation-register.test.ts
@@ -23,11 +23,12 @@ describe("instrumentation register", () => {
   });
 
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = { ...ORIGINAL_ENV };
   });
 
   it("invokes node instrumentation register in node runtime", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.NEXT_RUNTIME = "nodejs";
     mockRuntimeModules();
 
@@ -39,7 +40,7 @@ describe("instrumentation register", () => {
   });
 
   it("invokes edge instrumentation register in edge runtime", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.NEXT_RUNTIME = "edge";
     mockRuntimeModules();
 
@@ -51,7 +52,7 @@ describe("instrumentation register", () => {
   });
 
   it("skips instrumentation in development", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     process.env.NEXT_RUNTIME = "nodejs";
     mockRuntimeModules();
 

--- a/__tests__/lib/middleware/sitewide-rate-limit.test.ts
+++ b/__tests__/lib/middleware/sitewide-rate-limit.test.ts
@@ -22,6 +22,14 @@ describe("sitewideRateLimitMiddleware", () => {
       });
       expect(classifyProxyRequest(request)).toBe("document");
     });
+
+    it("classifies HEAD requests to pages as document", () => {
+      const request = new NextRequest("https://example.com/projects", {
+        method: "HEAD",
+        headers: { accept: "text/html,application/xhtml+xml" },
+      });
+      expect(classifyProxyRequest(request)).toBe("document");
+    });
   });
 
   it("does not rate limit health endpoints", () => {
@@ -59,6 +67,29 @@ describe("sitewideRateLimitMiddleware", () => {
     expect(blocked?.headers.get("Content-Type")).toContain("text/html");
     const body = await new Response(blocked?.body).text();
     expect(body).toContain("You've reached a rate limit. Please wait a few minutes and try again.");
+  });
+
+  it("blocks burst HEAD traffic for document routes", () => {
+    const storePrefix = `test-page-head-burst-${Date.now()}`;
+    const makeRequest = () =>
+      new NextRequest("https://example.com/projects", {
+        method: "HEAD",
+        headers: {
+          "x-forwarded-for": "203.0.113.21",
+          accept: "text/html,application/xhtml+xml",
+        },
+      });
+
+    const limit = PROFILES.page.burst.maxRequests;
+    for (let i = 0; i < limit; i++) {
+      const result = sitewideRateLimitMiddleware(makeRequest(), { storePrefix });
+      expect(result).toBeNull();
+    }
+
+    const blocked = sitewideRateLimitMiddleware(makeRequest(), { storePrefix });
+    expect(blocked).not.toBeNull();
+    expect(blocked?.status).toBe(429);
+    expect(blocked?.headers.get("Retry-After")).toBe("10");
   });
 
   it("blocks burst traffic for API routes with standardized JSON", async () => {

--- a/__tests__/lib/search/api-guards.test.ts
+++ b/__tests__/lib/search/api-guards.test.ts
@@ -13,11 +13,15 @@ import {
   withNoStoreHeaders,
 } from "@/lib/search/api-guards";
 import { NextRequest } from "next/server";
+import type { RateLimiterConfig } from "@/types/lib";
 
 // Mock the rate limiter
-const mockIsOperationAllowed = vi.fn(() => true);
+const mockIsOperationAllowed = vi.fn(
+  (_storeName: string, _contextId: string, _config: RateLimiterConfig) => true,
+);
 vi.mock("@/lib/rate-limiter", () => ({
-  isOperationAllowed: (...args: unknown[]) => mockIsOperationAllowed(...args),
+  isOperationAllowed: (storeName: string, contextId: string, config: RateLimiterConfig) =>
+    mockIsOperationAllowed(storeName, contextId, config),
 }));
 
 describe("Search API Guards", () => {
@@ -25,10 +29,12 @@ describe("Search API Guards", () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
   });
 
   afterAll(() => {
+    vi.unstubAllEnvs();
     process.env = originalEnv;
   });
 
@@ -126,7 +132,7 @@ describe("Search API Guards", () => {
 
   describe("createSearchErrorResponse", () => {
     it("includes details in non-production environment", async () => {
-      process.env.NODE_ENV = "development";
+      vi.stubEnv("NODE_ENV", "development");
       const response = createSearchErrorResponse("User message", "Internal details");
 
       expect(response.status).toBe(500);
@@ -136,7 +142,7 @@ describe("Search API Guards", () => {
     });
 
     it("excludes details in production environment", async () => {
-      process.env.NODE_ENV = "production";
+      vi.stubEnv("NODE_ENV", "production");
       const response = createSearchErrorResponse("User message", "Internal details");
 
       expect(response.status).toBe(500);
@@ -146,14 +152,14 @@ describe("Search API Guards", () => {
     });
 
     it("uses custom status code", () => {
-      process.env.NODE_ENV = "test";
+      vi.stubEnv("NODE_ENV", "test");
       const response = createSearchErrorResponse("Bad request", "Validation failed", 400);
 
       expect(response.status).toBe(400);
     });
 
     it("includes Cache-Control no-store header", () => {
-      process.env.NODE_ENV = "test";
+      vi.stubEnv("NODE_ENV", "test");
       const response = createSearchErrorResponse("Error", "Details");
 
       expect(response.headers.get("Cache-Control")).toBe("no-store");

--- a/__tests__/lib/search/loaders/dynamic-content.test.ts
+++ b/__tests__/lib/search/loaders/dynamic-content.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { buildBookmarksIndex } from "@/lib/search/loaders/dynamic-content";
-import type { BookmarkIndexInput } from "@/types/search";
+import type { BookmarkIndexInput } from "@/types/schemas/search";
 
 describe("Dynamic Content Loaders", () => {
   describe("buildBookmarksIndex", () => {

--- a/__tests__/lib/search/search-deduplication.test.ts
+++ b/__tests__/lib/search/search-deduplication.test.ts
@@ -11,7 +11,7 @@ import { searchBlogPostsServerSide } from "@/lib/blog/server-search";
 import { investments } from "@/data/investments";
 import { experiences } from "@/data/experience";
 import { education, certifications } from "@/data/education";
-import type { SearchResult } from "@/types/search";
+import type { SearchResult } from "@/types/schemas/search";
 
 vi.mock("@/lib/db/queries/search-index-artifacts", () => ({
   getSerializedSearchIndexArtifact: vi.fn().mockResolvedValue(null),
@@ -49,11 +49,25 @@ afterEach(() => {
 
 // Test data
 const duplicateTestResults: SearchResult[] = [
-  { id: "1", type: "post", title: "Test 1", description: "Description 1", url: "/test1", score: 1 },
-  { id: "1", type: "post", title: "Test 1", description: "Description 1", url: "/test1", score: 1 }, // duplicate
+  {
+    id: "1",
+    type: "blog-post",
+    title: "Test 1",
+    description: "Description 1",
+    url: "/test1",
+    score: 1,
+  },
+  {
+    id: "1",
+    type: "blog-post",
+    title: "Test 1",
+    description: "Description 1",
+    url: "/test1",
+    score: 1,
+  }, // duplicate
   {
     id: "2",
-    type: "post",
+    type: "blog-post",
     title: "Test 2",
     description: "Description 2",
     url: "/test2",
@@ -62,10 +76,17 @@ const duplicateTestResults: SearchResult[] = [
 ];
 
 const edgeCaseResults: SearchResult[] = [
-  { id: "", type: "post", title: "Empty ID", description: "Description", url: "/empty", score: 1 },
+  {
+    id: "",
+    type: "blog-post",
+    title: "Empty ID",
+    description: "Description",
+    url: "/empty",
+    score: 1,
+  },
   {
     id: "null",
-    type: "post",
+    type: "blog-post",
     title: "Null-like ID",
     description: "Description",
     url: "/null",
@@ -74,7 +95,14 @@ const edgeCaseResults: SearchResult[] = [
 ];
 
 const searchResults: SearchResult[] = [
-  { id: "1", type: "post", title: "Post 1", description: "Description 1", url: "/post1", score: 1 },
+  {
+    id: "1",
+    type: "blog-post",
+    title: "Post 1",
+    description: "Description 1",
+    url: "/post1",
+    score: 1,
+  },
   {
     id: "2",
     type: "project",
@@ -85,7 +113,7 @@ const searchResults: SearchResult[] = [
   },
   {
     id: "3",
-    type: "post",
+    type: "blog-post",
     title: "Post 3",
     description: "Description 3",
     url: "/post3",

--- a/__tests__/lib/search/search-index-serialization.test.ts
+++ b/__tests__/lib/search/search-index-serialization.test.ts
@@ -11,7 +11,8 @@
 import MiniSearch from "minisearch";
 import { loadIndexFromJSON } from "@/lib/search/index-builder";
 import { searchContent } from "@/lib/search/search-content";
-import type { IndexFieldConfig, SerializedIndex } from "@/types/search";
+import type { IndexFieldConfig } from "@/types/search";
+import type { SerializedIndex } from "@/types/schemas/search";
 
 describe("Search Index Serialization", () => {
   // Sample data for creating test indexes

--- a/__tests__/lib/search/search-index-serialization.test.ts
+++ b/__tests__/lib/search/search-index-serialization.test.ts
@@ -10,6 +10,7 @@
 
 import MiniSearch from "minisearch";
 import { loadIndexFromJSON } from "@/lib/search/index-builder";
+import { searchContent } from "@/lib/search/search-content";
 import type { IndexFieldConfig, SerializedIndex } from "@/types/search";
 
 describe("Search Index Serialization", () => {
@@ -220,6 +221,39 @@ describe("Search Index Serialization", () => {
       const loadedIndex = loadIndexFromJSON<(typeof sampleDocuments)[0]>(afterS3);
       expect(loadedIndex).toBeDefined();
       expect(loadedIndex.documentCount).toBe(sampleDocuments.length);
+    });
+  });
+
+  describe("MiniSearch search options", () => {
+    it("does not override configured field boosts with an exactMatch pseudo-field", () => {
+      const docs = [
+        { id: "title-hit", title: "needle", description: "plain" },
+        { id: "description-hit", title: "plain", description: "needle needle needle needle" },
+      ];
+      const index = new MiniSearch<(typeof docs)[number]>({
+        fields: ["title", "description"],
+        storeFields: ["id", "title", "description"],
+        idField: "id",
+        searchOptions: { boost: { title: 10 } },
+      });
+      index.addAll(docs);
+      const searchSpy = vi.spyOn(index, "search");
+
+      const results = searchContent(
+        docs,
+        "needle",
+        (doc) => [doc.title, doc.description],
+        undefined,
+        index,
+        (doc) => doc.id,
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith("needle", {
+        prefix: true,
+        fuzzy: 0.2,
+        combineWith: "OR",
+      });
+      expect(results[0]?.item.id).toBe("title-hit");
     });
   });
 

--- a/__tests__/lib/seo/metadata.test.ts
+++ b/__tests__/lib/seo/metadata.test.ts
@@ -7,12 +7,35 @@ import { createArticleMetadata, getStaticPageMetadata } from "@/lib/seo/metadata
 import { SEO_DATE_FIELDS } from "@/lib/constants";
 // Remove unused imports - commented out rather than deleted to maintain line numbers
 // import { metadata as siteMetadata, SITE_NAME, PAGE_METADATA } from '../../../../data/metadata';
-import { isPacificDateString, type ArticleOpenGraph, type ProfileOpenGraph } from "@/types/seo";
-import type { SchemaGraph, WebPageBase, CollectionPageSchema } from "@/types/seo/schema";
+import { isPacificDateString } from "@/types/seo";
+import type { ArticleOpenGraph, ProfileOpenGraph } from "@/types/seo/opengraph";
+import type { SchemaGraph, WebPageBase, CollectionPageEntity } from "@/types/seo/schema";
 // import type { Metadata } from 'next';
 // Vitest provides describe, it, expect, beforeEach, afterEach, beforeAll, afterAll globally
 // Mock process.env for tests
 process.env.NEXT_PUBLIC_SITE_URL = "https://williamcallahan.com";
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`Expected ${label} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertArticleOpenGraph(value: unknown): asserts value is ArticleOpenGraph {
+  const record = requireRecord(value, "OpenGraph metadata");
+  if (record.type !== "article") {
+    throw new Error(`Expected article OpenGraph metadata, got ${String(record.type)}`);
+  }
+  requireRecord(record.article, "OpenGraph article metadata");
+}
+
+function assertProfileOpenGraph(value: unknown): asserts value is ProfileOpenGraph {
+  const record = requireRecord(value, "OpenGraph metadata");
+  if (record.type !== "profile") {
+    throw new Error(`Expected profile OpenGraph metadata, got ${String(record.type)}`);
+  }
+}
 
 describe("SEO Metadata", () => {
   describe("createArticleMetadata", () => {
@@ -27,12 +50,13 @@ describe("SEO Metadata", () => {
 
     it("should generate complete article metadata with proper date formats", () => {
       const metadata = createArticleMetadata(mockArticleParams);
+      assertArticleOpenGraph(metadata.openGraph);
 
       // Verify OpenGraph dates (article type should have these)
-      expect(metadata.openGraph?.article?.publishedTime).toBeDefined();
-      expect(metadata.openGraph?.article?.modifiedTime).toBeDefined();
-      expect(isPacificDateString(metadata.openGraph?.article?.publishedTime)).toBe(true);
-      expect(isPacificDateString(metadata.openGraph?.article?.modifiedTime)).toBe(true);
+      expect(metadata.openGraph.article.publishedTime).toBeDefined();
+      expect(metadata.openGraph.article.modifiedTime).toBeDefined();
+      expect(isPacificDateString(metadata.openGraph.article.publishedTime)).toBe(true);
+      expect(isPacificDateString(metadata.openGraph.article.modifiedTime)).toBe(true);
 
       // Verify HTML meta dates
       const publishedDate = metadata.other?.[SEO_DATE_FIELDS.meta.published];
@@ -45,12 +69,13 @@ describe("SEO Metadata", () => {
 
     it("should maintain consistent dates across all formats", () => {
       const metadata = createArticleMetadata(mockArticleParams);
+      assertArticleOpenGraph(metadata.openGraph);
 
       // Get all date representations
       const dates = {
         og: {
-          published: metadata.openGraph?.article?.publishedTime,
-          modified: metadata.openGraph?.article?.modifiedTime,
+          published: metadata.openGraph.article.publishedTime,
+          modified: metadata.openGraph.article.modifiedTime,
         },
         meta: {
           published: metadata.other?.[SEO_DATE_FIELDS.meta.published],
@@ -78,9 +103,10 @@ describe("SEO Metadata", () => {
         ...mockArticleParams,
         datePublished: "2025-01-01T12:00:00", // January = PST
       });
+      assertArticleOpenGraph(metadata.openGraph);
 
       // Check all date fields end with -08:00
-      expect(metadata.openGraph?.article?.publishedTime).toMatch(/-08:00$/);
+      expect(metadata.openGraph.article.publishedTime).toMatch(/-08:00$/);
       const publishedDate = metadata.other?.[SEO_DATE_FIELDS.meta.published];
       expect(typeof publishedDate === "string" && publishedDate).toMatch(/-08:00$/);
     });
@@ -90,20 +116,22 @@ describe("SEO Metadata", () => {
         ...mockArticleParams,
         datePublished: "2025-07-01T12:00:00", // July = PDT
       });
+      assertArticleOpenGraph(metadata.openGraph);
 
       // Check all date fields end with -07:00
-      expect(metadata.openGraph?.article?.publishedTime).toMatch(/-07:00$/);
+      expect(metadata.openGraph.article.publishedTime).toMatch(/-07:00$/);
       const publishedDate = metadata.other?.[SEO_DATE_FIELDS.meta.published];
       expect(typeof publishedDate === "string" && publishedDate).toMatch(/-07:00$/);
     });
 
     it("should include required article metadata fields", () => {
       const metadata = createArticleMetadata(mockArticleParams);
+      assertArticleOpenGraph(metadata.openGraph);
 
       // Verify OpenGraph article fields exist
-      expect(metadata.openGraph?.type).toBe("article");
-      expect(metadata.openGraph?.article?.section).toBeDefined();
-      expect(typeof metadata.openGraph?.article?.section).toBe("string");
+      expect(metadata.openGraph.type).toBe("article");
+      expect(metadata.openGraph.article.section).toBeDefined();
+      expect(typeof metadata.openGraph.article.section).toBe("string");
 
       // Verify title exists
       expect(metadata.title).toBeDefined();
@@ -114,9 +142,9 @@ describe("SEO Metadata", () => {
       expect(typeof metadata.description).toBe("string");
 
       // Verify tags are present
-      expect(metadata.openGraph?.article?.tags).toBeDefined();
-      expect(Array.isArray(metadata.openGraph?.article?.tags)).toBe(true);
-      if (metadata.openGraph?.article?.tags) {
+      expect(metadata.openGraph.article.tags).toBeDefined();
+      expect(Array.isArray(metadata.openGraph.article.tags)).toBe(true);
+      if (metadata.openGraph.article.tags) {
         for (const tag of metadata.openGraph.article.tags) {
           expect(typeof tag).toBe("string");
           expect(tag).toBeTruthy();
@@ -134,14 +162,20 @@ describe("SEO Metadata", () => {
       };
 
       const metadata = createArticleMetadata(minimalParams);
+      assertArticleOpenGraph(metadata.openGraph);
+      const images = metadata.openGraph.images;
+      if (!Array.isArray(images)) {
+        throw new Error("Expected article OpenGraph images to be an array");
+      }
+      const firstImage = images[0];
 
       // Verify default values
-      expect(metadata.openGraph?.article?.tags).toEqual([]);
-      expect(metadata.openGraph?.images).toBeDefined();
-      expect(metadata.openGraph?.images?.[0]?.alt).toBeDefined();
-      expect(metadata.openGraph?.images?.[0]?.url).toBeDefined();
-      expect(typeof metadata.openGraph?.images?.[0]?.alt).toBe("string");
-      expect(typeof metadata.openGraph?.images?.[0]?.url).toBe("string");
+      expect(metadata.openGraph.article.tags).toEqual([]);
+      expect(images).toBeDefined();
+      expect(firstImage?.alt).toBeDefined();
+      expect(firstImage?.url).toBeDefined();
+      expect(typeof firstImage?.alt).toBe("string");
+      expect(typeof firstImage?.url).toBe("string");
     });
   });
 
@@ -219,7 +253,7 @@ describe("SEO Metadata", () => {
         blogMetadata.script?.[0]?.text || "{}",
       ) as SchemaGraph;
       const collectionPage = parsedBlogJsonLd["@graph"]?.find(
-        (entity): entity is CollectionPageSchema => entity["@type"] === "CollectionPage",
+        (entity): entity is CollectionPageEntity => entity["@type"] === "CollectionPage",
       );
       expect(collectionPage).toBeDefined();
       if (collectionPage) {
@@ -355,7 +389,8 @@ describe("SEO Metadata", () => {
     it("should include OpenGraph metadata with correct type", () => {
       // Test profile type
       const experienceMetadata = getStaticPageMetadata("/experience", "experience");
-      const experienceOg = experienceMetadata.openGraph as ProfileOpenGraph;
+      const experienceOg = experienceMetadata.openGraph;
+      assertProfileOpenGraph(experienceOg);
       expect(experienceOg.type).toBe("profile");
       expect(experienceOg.firstName).toBeDefined();
       expect(experienceOg.lastName).toBeDefined();
@@ -363,7 +398,8 @@ describe("SEO Metadata", () => {
 
       // Test article type for collection pages
       const blogMetadata = getStaticPageMetadata("/blog", "blog");
-      const blogOg = blogMetadata.openGraph as ArticleOpenGraph;
+      const blogOg = blogMetadata.openGraph;
+      assertArticleOpenGraph(blogOg);
       expect(blogOg.type).toBe("article");
       expect(blogOg.article).toBeDefined();
       expect(blogOg.article.publishedTime).toBeDefined();

--- a/__tests__/lib/seo/opengraph.test.ts
+++ b/__tests__/lib/seo/opengraph.test.ts
@@ -186,4 +186,120 @@ describe("OpenGraph Metadata", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("external OpenGraph fetch", () => {
+    it("retries a 403 direct response with the Googlebot user agent", async () => {
+      vi.resetModules();
+      type FetchOptionsForTest = {
+        timeout?: number;
+        headers?: Record<string, string>;
+      };
+      type FetchWithTimeoutForTest = (
+        requestUrl: string,
+        options: FetchOptionsForTest,
+      ) => Promise<Response>;
+      type RetryOperation<T> = () => Promise<T>;
+      type OgMetadataForTest = Record<string, string | null>;
+
+      const forbiddenResponse = new Response("", { status: 403, statusText: "Forbidden" });
+      const recoveredResponse = new Response(
+        '<html><head><meta property="og:title" content="Recovered title" /></head></html>',
+        { status: 200 },
+      );
+      Object.defineProperty(recoveredResponse, "url", {
+        value: "https://blocked.example/article",
+      });
+
+      const fetchWithTimeout = vi
+        .fn<FetchWithTimeoutForTest>()
+        .mockResolvedValueOnce(forbiddenResponse)
+        .mockResolvedValueOnce(recoveredResponse);
+
+      vi.doMock("@/lib/utils/http-client", () => ({
+        fetchWithTimeout,
+        getBrowserHeaders: () => ({
+          Accept: "text/html",
+          "User-Agent": "Browser UA",
+        }),
+      }));
+      vi.doMock("@/lib/services/unified-image-service", () => ({
+        getUnifiedImageService: () => ({
+          hasDomainFailedTooManyTimes: () => false,
+          markDomainAsFailed: vi.fn(),
+        }),
+      }));
+      vi.doMock("@/lib/persistence/jina-cache", () => ({
+        getCachedJinaHtml: () => Promise.resolve(null),
+        persistJinaHtmlInBackground: vi.fn(),
+      }));
+      vi.doMock("@/lib/persistence/image-persistence", () => ({
+        scheduleImagePersistence: vi.fn(),
+        persistImageAndGetS3Url: () => Promise.resolve(null),
+      }));
+      vi.doMock("@/lib/rate-limiter", () => ({
+        incrementAndPersist: () => false,
+        waitForPermit: () => Promise.resolve(),
+      }));
+      vi.doMock("@/lib/utils/opengraph-utils", () => ({
+        getDomainType: () => "blocked.example",
+        sanitizeOgMetadata: (metadata: OgMetadataForTest) => metadata,
+      }));
+      vi.doMock("@/lib/opengraph/parser", () => ({
+        extractOpenGraphTags: () => ({
+          title: "Recovered title",
+          description: null,
+          image: null,
+          twitterImage: null,
+          site: null,
+          type: null,
+          profileImage: null,
+          bannerImage: null,
+          url: "https://blocked.example/article",
+          siteName: null,
+        }),
+      }));
+      vi.doMock("@/lib/utils/retry", () => ({
+        RETRY_CONFIGS: { OPENGRAPH_FETCH: {} },
+        retryWithThrow: async <T>(operation: RetryOperation<T>): Promise<T> => operation(),
+      }));
+      vi.doMock("@/lib/constants", () => ({
+        JINA_FETCH_CONFIG: {},
+        JINA_FETCH_STORE_NAME: "jina",
+        JINA_FETCH_CONTEXT_ID: "jina-context",
+        JINA_FETCH_RATE_LIMIT_STORE_KEY: "jina-key",
+        OPENGRAPH_FETCH_CONFIG: { TIMEOUT: 1000 },
+        OPENGRAPH_FETCH_CONTEXT_ID: "opengraph-context",
+        OPENGRAPH_FETCH_STORE_NAME: "opengraph",
+        DEFAULT_OPENGRAPH_FETCH_LIMIT_CONFIG: {},
+        OPENGRAPH_IMAGES_S3_DIR: "opengraph",
+      }));
+
+      const { fetchExternalOpenGraphWithRetry } = await import("@/lib/opengraph/fetch");
+      const result = await fetchExternalOpenGraphWithRetry("https://blocked.example/article");
+
+      if (!result || "networkFailure" in result) {
+        throw new Error("Expected recovered OpenGraph metadata");
+      }
+      const firstCall = fetchWithTimeout.mock.calls.at(0);
+      const secondCall = fetchWithTimeout.mock.calls.at(1);
+      if (!firstCall || !secondCall) {
+        throw new Error("Expected browser fetch followed by Googlebot fetch");
+      }
+
+      expect(result.title).toBe("Recovered title");
+      expect(firstCall[1].headers?.["User-Agent"]).toBe("Browser UA");
+      expect(secondCall[1].headers?.["User-Agent"]).toContain("Googlebot/2.1");
+
+      vi.doUnmock("@/lib/utils/http-client");
+      vi.doUnmock("@/lib/services/unified-image-service");
+      vi.doUnmock("@/lib/persistence/jina-cache");
+      vi.doUnmock("@/lib/persistence/image-persistence");
+      vi.doUnmock("@/lib/rate-limiter");
+      vi.doUnmock("@/lib/utils/opengraph-utils");
+      vi.doUnmock("@/lib/opengraph/parser");
+      vi.doUnmock("@/lib/utils/retry");
+      vi.doUnmock("@/lib/constants");
+      vi.resetModules();
+    });
+  });
 });

--- a/__tests__/lib/seo/opengraph.test.ts
+++ b/__tests__/lib/seo/opengraph.test.ts
@@ -201,105 +201,107 @@ describe("OpenGraph Metadata", () => {
       type RetryOperation<T> = () => Promise<T>;
       type OgMetadataForTest = Record<string, string | null>;
 
-      const forbiddenResponse = new Response("", { status: 403, statusText: "Forbidden" });
-      const recoveredResponse = new Response(
-        '<html><head><meta property="og:title" content="Recovered title" /></head></html>',
-        { status: 200 },
-      );
-      Object.defineProperty(recoveredResponse, "url", {
-        value: "https://blocked.example/article",
-      });
+      try {
+        const forbiddenResponse = new Response("", { status: 403, statusText: "Forbidden" });
+        const recoveredResponse = new Response(
+          '<html><head><meta property="og:title" content="Recovered title" /></head></html>',
+          { status: 200 },
+        );
+        Object.defineProperty(recoveredResponse, "url", {
+          value: "https://blocked.example/article",
+        });
 
-      const fetchWithTimeout = vi
-        .fn<FetchWithTimeoutForTest>()
-        .mockResolvedValueOnce(forbiddenResponse)
-        .mockResolvedValueOnce(recoveredResponse);
+        const fetchWithTimeout = vi
+          .fn<FetchWithTimeoutForTest>()
+          .mockResolvedValueOnce(forbiddenResponse)
+          .mockResolvedValueOnce(recoveredResponse);
 
-      vi.doMock("@/lib/utils/http-client", () => ({
-        fetchWithTimeout,
-        getBrowserHeaders: () => ({
-          Accept: "text/html",
-          "User-Agent": "Browser UA",
-        }),
-      }));
-      vi.doMock("@/lib/services/unified-image-service", () => ({
-        getUnifiedImageService: () => ({
-          hasDomainFailedTooManyTimes: () => false,
-          markDomainAsFailed: vi.fn(),
-        }),
-      }));
-      vi.doMock("@/lib/persistence/jina-cache", () => ({
-        getCachedJinaHtml: () => Promise.resolve(null),
-        persistJinaHtmlInBackground: vi.fn(),
-      }));
-      vi.doMock("@/lib/persistence/image-persistence", () => ({
-        scheduleImagePersistence: vi.fn(),
-        persistImageAndGetS3Url: () => Promise.resolve(null),
-      }));
-      vi.doMock("@/lib/rate-limiter", () => ({
-        incrementAndPersist: () => false,
-        waitForPermit: () => Promise.resolve(),
-      }));
-      vi.doMock("@/lib/utils/opengraph-utils", () => ({
-        getDomainType: () => "blocked.example",
-        sanitizeOgMetadata: (metadata: OgMetadataForTest) => metadata,
-      }));
-      vi.doMock("@/lib/opengraph/parser", () => ({
-        extractOpenGraphTags: () => ({
-          title: "Recovered title",
-          description: null,
-          image: null,
-          twitterImage: null,
-          site: null,
-          type: null,
-          profileImage: null,
-          bannerImage: null,
-          url: "https://blocked.example/article",
-          siteName: null,
-        }),
-      }));
-      vi.doMock("@/lib/utils/retry", () => ({
-        RETRY_CONFIGS: { OPENGRAPH_FETCH: {} },
-        retryWithThrow: async <T>(operation: RetryOperation<T>): Promise<T> => operation(),
-      }));
-      vi.doMock("@/lib/constants", () => ({
-        JINA_FETCH_CONFIG: {},
-        JINA_FETCH_STORE_NAME: "jina",
-        JINA_FETCH_CONTEXT_ID: "jina-context",
-        JINA_FETCH_RATE_LIMIT_STORE_KEY: "jina-key",
-        OPENGRAPH_FETCH_CONFIG: { TIMEOUT: 1000 },
-        OPENGRAPH_FETCH_CONTEXT_ID: "opengraph-context",
-        OPENGRAPH_FETCH_STORE_NAME: "opengraph",
-        DEFAULT_OPENGRAPH_FETCH_LIMIT_CONFIG: {},
-        OPENGRAPH_IMAGES_S3_DIR: "opengraph",
-      }));
+        vi.doMock("@/lib/utils/http-client", () => ({
+          fetchWithTimeout,
+          getBrowserHeaders: () => ({
+            Accept: "text/html",
+            "User-Agent": "Browser UA",
+          }),
+        }));
+        vi.doMock("@/lib/services/unified-image-service", () => ({
+          getUnifiedImageService: () => ({
+            hasDomainFailedTooManyTimes: () => false,
+            markDomainAsFailed: vi.fn(),
+          }),
+        }));
+        vi.doMock("@/lib/persistence/jina-cache", () => ({
+          getCachedJinaHtml: () => Promise.resolve(null),
+          persistJinaHtmlInBackground: vi.fn(),
+        }));
+        vi.doMock("@/lib/persistence/image-persistence", () => ({
+          scheduleImagePersistence: vi.fn(),
+          persistImageAndGetS3Url: () => Promise.resolve(null),
+        }));
+        vi.doMock("@/lib/rate-limiter", () => ({
+          incrementAndPersist: () => false,
+          waitForPermit: () => Promise.resolve(),
+        }));
+        vi.doMock("@/lib/utils/opengraph-utils", () => ({
+          getDomainType: () => "blocked.example",
+          sanitizeOgMetadata: (metadata: OgMetadataForTest) => metadata,
+        }));
+        vi.doMock("@/lib/opengraph/parser", () => ({
+          extractOpenGraphTags: () => ({
+            title: "Recovered title",
+            description: null,
+            image: null,
+            twitterImage: null,
+            site: null,
+            type: null,
+            profileImage: null,
+            bannerImage: null,
+            url: "https://blocked.example/article",
+            siteName: null,
+          }),
+        }));
+        vi.doMock("@/lib/utils/retry", () => ({
+          RETRY_CONFIGS: { OPENGRAPH_FETCH: {} },
+          retryWithThrow: async <T>(operation: RetryOperation<T>): Promise<T> => operation(),
+        }));
+        vi.doMock("@/lib/constants", () => ({
+          JINA_FETCH_CONFIG: {},
+          JINA_FETCH_STORE_NAME: "jina",
+          JINA_FETCH_CONTEXT_ID: "jina-context",
+          JINA_FETCH_RATE_LIMIT_STORE_KEY: "jina-key",
+          OPENGRAPH_FETCH_CONFIG: { TIMEOUT: 1000 },
+          OPENGRAPH_FETCH_CONTEXT_ID: "opengraph-context",
+          OPENGRAPH_FETCH_STORE_NAME: "opengraph",
+          DEFAULT_OPENGRAPH_FETCH_LIMIT_CONFIG: {},
+          OPENGRAPH_IMAGES_S3_DIR: "opengraph",
+        }));
 
-      const { fetchExternalOpenGraphWithRetry } = await import("@/lib/opengraph/fetch");
-      const result = await fetchExternalOpenGraphWithRetry("https://blocked.example/article");
+        const { fetchExternalOpenGraphWithRetry } = await import("@/lib/opengraph/fetch");
+        const result = await fetchExternalOpenGraphWithRetry("https://blocked.example/article");
 
-      if (!result || "networkFailure" in result) {
-        throw new Error("Expected recovered OpenGraph metadata");
+        if (!result || "networkFailure" in result) {
+          throw new Error("Expected recovered OpenGraph metadata");
+        }
+        const firstCall = fetchWithTimeout.mock.calls.at(0);
+        const secondCall = fetchWithTimeout.mock.calls.at(1);
+        if (!firstCall || !secondCall) {
+          throw new Error("Expected browser fetch followed by Googlebot fetch");
+        }
+
+        expect(result.title).toBe("Recovered title");
+        expect(firstCall[1].headers?.["User-Agent"]).toBe("Browser UA");
+        expect(secondCall[1].headers?.["User-Agent"]).toContain("Googlebot/2.1");
+      } finally {
+        vi.doUnmock("@/lib/utils/http-client");
+        vi.doUnmock("@/lib/services/unified-image-service");
+        vi.doUnmock("@/lib/persistence/jina-cache");
+        vi.doUnmock("@/lib/persistence/image-persistence");
+        vi.doUnmock("@/lib/rate-limiter");
+        vi.doUnmock("@/lib/utils/opengraph-utils");
+        vi.doUnmock("@/lib/opengraph/parser");
+        vi.doUnmock("@/lib/utils/retry");
+        vi.doUnmock("@/lib/constants");
+        vi.resetModules();
       }
-      const firstCall = fetchWithTimeout.mock.calls.at(0);
-      const secondCall = fetchWithTimeout.mock.calls.at(1);
-      if (!firstCall || !secondCall) {
-        throw new Error("Expected browser fetch followed by Googlebot fetch");
-      }
-
-      expect(result.title).toBe("Recovered title");
-      expect(firstCall[1].headers?.["User-Agent"]).toBe("Browser UA");
-      expect(secondCall[1].headers?.["User-Agent"]).toContain("Googlebot/2.1");
-
-      vi.doUnmock("@/lib/utils/http-client");
-      vi.doUnmock("@/lib/services/unified-image-service");
-      vi.doUnmock("@/lib/persistence/jina-cache");
-      vi.doUnmock("@/lib/persistence/image-persistence");
-      vi.doUnmock("@/lib/rate-limiter");
-      vi.doUnmock("@/lib/utils/opengraph-utils");
-      vi.doUnmock("@/lib/opengraph/parser");
-      vi.doUnmock("@/lib/utils/retry");
-      vi.doUnmock("@/lib/constants");
-      vi.resetModules();
     });
   });
 });

--- a/__tests__/lib/server/data-fetch-manager-performance.test.ts
+++ b/__tests__/lib/server/data-fetch-manager-performance.test.ts
@@ -2,6 +2,7 @@ import { DataFetchManager } from "@/lib/server/data-fetch-manager";
 import { getInvestmentDomainsAndIds } from "@/lib/data-access/investments";
 import { getBookmarks } from "@/lib/bookmarks/bookmarks-data-access.server";
 import type { MockedFunction } from "vitest";
+import type { UnifiedBookmark } from "@/types/schemas/bookmark";
 
 // Mock dependencies
 vi.mock("@/lib/data-access/investments");
@@ -18,6 +19,31 @@ vi.mock("@/data/education", () => ({
   recentCourses: [{ name: "Course A", website: "https://course-a.com" }],
 }));
 
+const fixtureDate = "2026-06-10T00:00:00.000Z";
+
+function makeBookmark(overrides: Partial<UnifiedBookmark>): UnifiedBookmark {
+  const url = overrides.url ?? "https://bookmark-a.com";
+  const title = overrides.title ?? "Bookmark A";
+  const description = overrides.description ?? "Description A";
+  return {
+    id: overrides.id ?? "bookmark-1",
+    url,
+    title,
+    description,
+    slug: overrides.slug ?? "bookmark-a",
+    tags: overrides.tags ?? [],
+    dateBookmarked: overrides.dateBookmarked ?? fixtureDate,
+    sourceUpdatedAt: overrides.sourceUpdatedAt ?? fixtureDate,
+    content: overrides.content ?? {
+      type: "link",
+      url,
+      title,
+      description,
+    },
+    ...overrides,
+  };
+}
+
 describe("DataFetchManager Performance Optimizations", () => {
   let mockGetInvestmentDomainsAndIds: MockedFunction<typeof getInvestmentDomainsAndIds>;
   let mockGetBookmarks: MockedFunction<typeof getBookmarks>;
@@ -31,21 +57,17 @@ describe("DataFetchManager Performance Optimizations", () => {
     mockGetBookmarks = getBookmarks as MockedFunction<typeof getBookmarks>;
 
     // Mock return values
-    mockGetInvestmentDomainsAndIds.mockResolvedValue([
-      ["investment-a.com", "inv-1"],
-      ["investment-b.com", "inv-2"],
-    ]);
+    mockGetInvestmentDomainsAndIds.mockResolvedValue(
+      new Map([
+        ["investment-a.com", "inv-1"],
+        ["investment-b.com", "inv-2"],
+      ]),
+    );
 
     mockGetBookmarks.mockResolvedValue([
-      {
-        id: "bookmark-1",
-        url: "https://bookmark-a.com",
-        title: "Bookmark A",
-        description: "Description A",
-        tags: [],
-        createdAt: new Date().toISOString(),
-        content: {},
-      },
+      makeBookmark({
+        domain: "bookmark-a.com",
+      }),
     ]);
 
     // DataFetchManager uses singleton pattern
@@ -60,23 +82,20 @@ describe("DataFetchManager Performance Optimizations", () => {
       mockGetInvestmentDomainsAndIds.mockImplementation(async () => {
         callTimes.investments = Date.now() - startTime;
         await new Promise((resolve) => setTimeout(resolve, 50)); // Simulate delay
-        return [["investment-a.com", "inv-1"]];
+        return new Map([["investment-a.com", "inv-1"]]);
       });
 
       mockGetBookmarks.mockImplementation(async () => {
         callTimes.bookmarks = Date.now() - startTime;
         await new Promise((resolve) => setTimeout(resolve, 50)); // Simulate delay
         return [
-          {
+          makeBookmark({
             id: "bookmark-1",
             url: "https://bookmark-a.com",
             domain: "bookmark-a.com",
             title: "Bookmark A",
             description: "Description A",
-            tags: [],
-            createdAt: new Date().toISOString(),
-            content: {},
-          },
+          }),
         ];
       });
 
@@ -121,26 +140,21 @@ describe("DataFetchManager Performance Optimizations", () => {
     it("should handle invalid URLs gracefully", async () => {
       // Mock bookmarks with invalid URL
       mockGetBookmarks.mockResolvedValue([
-        {
+        makeBookmark({
           id: "bookmark-1",
           url: "not-a-valid-url",
-          domain: undefined,
           title: "Invalid Bookmark",
           description: "Description",
-          tags: [],
-          createdAt: new Date().toISOString(),
-          content: {},
-        },
-        {
+          slug: "invalid-bookmark",
+        }),
+        makeBookmark({
           id: "bookmark-2",
           url: "https://valid-bookmark.com",
           domain: "valid-bookmark.com",
           title: "Valid Bookmark",
           description: "Description",
-          tags: [],
-          createdAt: new Date().toISOString(),
-          content: {},
-        },
+          slug: "valid-bookmark",
+        }),
       ]);
 
       const dataFetchManager = new DataFetchManager();
@@ -153,16 +167,13 @@ describe("DataFetchManager Performance Optimizations", () => {
 
     it("should strip www prefix from domains", async () => {
       mockGetBookmarks.mockResolvedValue([
-        {
+        makeBookmark({
           id: "bookmark-1",
           url: "https://www.example.com",
           domain: "example.com",
           title: "Example",
           description: "Description",
-          tags: [],
-          createdAt: new Date().toISOString(),
-          content: {},
-        },
+        }),
       ]);
 
       const dataFetchManager4 = new DataFetchManager();
@@ -179,22 +190,19 @@ describe("DataFetchManager Performance Optimizations", () => {
       // Add delays to simulate real network/database calls
       mockGetInvestmentDomainsAndIds.mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
-        return [["investment-a.com", "inv-1"]];
+        return new Map([["investment-a.com", "inv-1"]]);
       });
 
       mockGetBookmarks.mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
         return [
-          {
+          makeBookmark({
             id: "bookmark-1",
             url: "https://bookmark-a.com",
             domain: "bookmark-a.com",
             title: "Bookmark A",
             description: "Description A",
-            tags: [],
-            createdAt: new Date().toISOString(),
-            content: {},
-          },
+          }),
         ];
       });
 

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -340,5 +340,9 @@ describe("randomString", () => {
     it("does not allow blanket https: sources for imgSrc", () => {
       expect(CSP_DIRECTIVES.imgSrc).not.toContain("https:");
     });
+
+    it("does not include unsafe-eval in static script sources", () => {
+      expect(CSP_DIRECTIVES.scriptSrc).not.toContain("'unsafe-eval'");
+    });
   });
 });

--- a/__tests__/lib/utils/search-helpers.test.ts
+++ b/__tests__/lib/utils/search-helpers.test.ts
@@ -9,7 +9,7 @@ import {
   prepareDocumentsForIndexing,
   transformSearchResultToTerminalResult,
 } from "@/lib/utils/search-helpers";
-import type { SearchResult } from "@/types/search";
+import type { SearchResult } from "@/types/schemas/search";
 
 describe("Search Helpers", () => {
   let consoleWarnSpy: MockInstance;
@@ -278,7 +278,7 @@ describe("Search Helpers", () => {
     it("should transform SearchResult to TerminalSearchResult", () => {
       const searchResult: SearchResult = {
         id: "post-123",
-        type: "blog",
+        type: "blog-post",
         title: "Test Post",
         description: "A test description",
         url: "/blog/test-post",
@@ -288,7 +288,7 @@ describe("Search Helpers", () => {
       const result = transformSearchResultToTerminalResult(searchResult);
 
       expect(result).toEqual({
-        id: "blog-post-123",
+        id: "blog-post-post-123",
         label: "Test Post",
         description: "A test description",
         path: "/blog/test-post",
@@ -318,7 +318,7 @@ describe("Search Helpers", () => {
     it("should handle missing title with fallback", () => {
       const searchResult = {
         id: "test-id",
-        type: "investment",
+        type: "page",
         title: undefined,
         description: "Some description",
         url: "/investments/test",
@@ -333,7 +333,7 @@ describe("Search Helpers", () => {
     it("should handle missing url with fallback", () => {
       const searchResult = {
         id: "test-id",
-        type: "experience",
+        type: "page",
         title: "Test Title",
         description: "Description",
         url: undefined,
@@ -348,7 +348,7 @@ describe("Search Helpers", () => {
     it("should warn and generate deterministic fallback ID when id is missing", () => {
       const searchResult = {
         id: "",
-        type: "blog",
+        type: "blog-post",
         title: "No ID Post",
         description: "Missing ID",
         url: "/blog/no-id",
@@ -358,7 +358,7 @@ describe("Search Helpers", () => {
       const result = transformSearchResultToTerminalResult(searchResult);
 
       // Deterministic fallback: `${type}:${url}:${title}` lowercased, non-alphanum replaced
-      expect(result.id).toBe("blog:/blog/no-id:no-id-post");
+      expect(result.id).toBe("blog-post:/blog/no-id:no-id-post");
       expect(result.label).toBe("No ID Post");
     });
   });

--- a/__tests__/seo/sitemap.test.ts
+++ b/__tests__/seo/sitemap.test.ts
@@ -158,27 +158,21 @@ describe("Sitemap URL Generation", () => {
 
 describe("Sitemap Collector Error Handling", () => {
   const siteUrl = "https://williamcallahan.com";
-  let originalNodeEnv: string | undefined;
   let originalVitest: string | undefined;
   let originalTest: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalNodeEnv = process.env.NODE_ENV;
     originalVitest = process.env.VITEST;
     originalTest = process.env.TEST;
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     process.env.VITEST = "true";
     process.env.TEST = "true";
     mockLoadSlugMapping.mockResolvedValue(null);
   });
 
   afterEach(() => {
-    if (typeof originalNodeEnv === "string") {
-      process.env.NODE_ENV = originalNodeEnv;
-    } else {
-      delete process.env.NODE_ENV;
-    }
+    vi.unstubAllEnvs();
     if (typeof originalVitest === "string") {
       process.env.VITEST = originalVitest;
     } else {
@@ -193,7 +187,7 @@ describe("Sitemap Collector Error Handling", () => {
 
   it("throws in production when bookmark collection fails", async () => {
     const outage = new Error("S3 outage");
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.VITEST = "false";
     process.env.TEST = "false";
     mockGetBookmarksIndex.mockRejectedValue(outage);
@@ -203,7 +197,7 @@ describe("Sitemap Collector Error Handling", () => {
 
   it("throws in production when tag collection fails", async () => {
     const outage = new Error("S3 outage");
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.VITEST = "false";
     process.env.TEST = "false";
     mockListBookmarkTagSlugs.mockRejectedValue(outage);

--- a/__tests__/smoke/bookmarks-api.smoke.test.ts
+++ b/__tests__/smoke/bookmarks-api.smoke.test.ts
@@ -16,7 +16,7 @@
  * @fileoverview External API connectivity smoke test for bookmarks backend
  */
 
-import type { BookmarksApiResponse, RawApiBookmark } from "@/types/bookmark";
+import type { BookmarksApiResponse, RawApiBookmark } from "@/types/schemas/bookmark";
 
 const BOOKMARK_BEARER_TOKEN = process.env.BOOKMARK_BEARER_TOKEN;
 const BOOKMARKS_LIST_ID = process.env.BOOKMARKS_LIST_ID;

--- a/__tests__/smoke/page-routes.smoke.test.ts
+++ b/__tests__/smoke/page-routes.smoke.test.ts
@@ -36,6 +36,7 @@ const mockBookmarkEntries = [
     slug: "example-bookmark",
     url: "https://example.com",
     title: "Example Bookmark",
+    description: "Example bookmark used by route smoke tests",
     modifiedAt: "2024-01-01T00:00:00.000Z",
     dateCreated: "2024-01-01T00:00:00.000Z",
     dateBookmarked: "2024-01-01T00:00:00.000Z",

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "@/data/*": ["../data/*"],
       "@/config/*": ["../config/*"],
+      "@/public/*": ["../public/*"],
       "@/types/*": ["../src/types/*"],
       "@/lib/*": ["../src/lib/*"],
       "@/components/*": ["../src/components/*"],
@@ -32,6 +33,9 @@
     "ignoreDeprecations": "5.0"
   },
   "include": [
+    "../next-env.d.ts",
+    "../config/**/*.ts",
+    "../src/*.ts",
     "../src/app/**/*.ts",
     "../src/app/**/*.tsx",
     "../src/lib/**/*.ts",

--- a/__tests__/utils/tag-utils.test.ts
+++ b/__tests__/utils/tag-utils.test.ts
@@ -51,19 +51,23 @@ describe("Tag Utility Functions", () => {
 
     it("should handle object arrays", () => {
       const tags = [
-        { name: "tag1", id: "1" },
-        { name: "tag2", id: "2" },
+        { name: "tag1", id: "1", slug: "tag1" },
+        { name: "tag2", id: "2", slug: "tag2" },
       ];
       expect(normalizeTagsToStrings(tags)).toEqual(["tag1", "tag2"]);
     });
 
     it("should handle mixed arrays", () => {
-      const tags = ["stringTag", { name: "objectTag", id: "1" }, "anotherString"];
+      const tags = [
+        "stringTag",
+        { name: "objectTag", id: "1", slug: "object-tag" },
+        "anotherString",
+      ];
       expect(normalizeTagsToStrings(tags)).toEqual(["stringTag", "objectTag", "anotherString"]);
     });
 
     it("should filter out empty values", () => {
-      const tags = ["tag1", "", { name: "", id: "1" }, "tag2"];
+      const tags = ["tag1", "", { name: "", id: "1", slug: "" }, "tag2"];
       expect(normalizeTagsToStrings(tags)).toEqual(["tag1", "tag2"]);
     });
 

--- a/config/csp.ts
+++ b/config/csp.ts
@@ -50,7 +50,6 @@ export const CSP_DIRECTIVES = {
     "https://*.x.com",
     ...CLERK_DOMAINS.scripts,
     "blob:",
-    "'unsafe-eval'",
     RAILWAY_TEST_DEPLOYMENTS,
   ],
   connectSrc: [

--- a/docs/architecture/ai-services.md
+++ b/docs/architecture/ai-services.md
@@ -79,11 +79,11 @@ For a route param `feature`, the server resolves configuration with this precede
    - `AI_DEFAULT_OPENAI_BASE_URL`
    - `AI_DEFAULT_LLM_MODEL`
    - `AI_DEFAULT_EMBEDDING_MODEL` (optional; endpoint-compatible `/v1/embeddings` model id)
-   - `AI_DEFAULT_OPENAI_API_KEY` (optional)
+   - `AI_DEFAULT_OPENAI_API_KEY` (optional for config resolution; required before upstream calls when no feature key is set)
    - `AI_DEFAULT_MAX_PARALLEL` (optional; default: 1)
-3. Built-in safe defaults (no secrets):
-   - `baseUrl = https://popos-sf7.com`
-   - `model = openai/gpt-oss-120b,openai/gpt-oss-20b`
+3. Built-in non-secret defaults:
+   - `baseUrl = https://api.llm-gateway.iocloudhost.net`
+   - `model = qwen3.6:onprem`
    - `maxParallel = 1`
    - no API key
 
@@ -105,7 +105,7 @@ For a route param `feature`, the server resolves configuration with this precede
 
 - Dependency: `openai@6.18.0` from npm.
 - SDK base URL is normalized to include `/v1`, so both OpenAI and OpenAI-compatible providers (including LM Studio) can be configured with or without a trailing `/v1`.
-- If no API key is configured, the server uses a compatibility fallback token for SDK initialization (required by the SDK constructor) and logs a warning.
+- If no API key is configured, the server fails before constructing the SDK client; set `AI_DEFAULT_OPENAI_API_KEY` or a feature-specific key.
 - Streaming adapter:
   - Uses SDK stream helpers (`chat.completions.stream(...)` and `responses.stream(...)`) and finalizes each turn via `finalChatCompletion()` / `finalResponse()`.
   - Forwards real upstream token deltas through `onDelta` callbacks.

--- a/docs/features/projects.md
+++ b/docs/features/projects.md
@@ -39,6 +39,8 @@ See [Projects Architecture Diagram](./projects.mmd).
 - Project detail links now set `prefetch={false}` in project cards.
   - This reduces high-volume prefetch fan-out from the projects grid under load.
   - Route transitions remain fully functional, but background request pressure is lower.
+- Project detail URLs emit name-derived canonical slugs.
+  - Older id-derived project paths resolve server-side and permanently redirect to the canonical slug.
 
 ## Key Files
 

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -27,20 +27,16 @@ const BUILD_PHASE_VALUE = "phase-production-build" as const;
 const isProductionBuildPhase = (): boolean => process.env[PHASE_ENV_KEY] === BUILD_PHASE_VALUE;
 ```
 
-### Route Handlers Require `dynamic = "force-dynamic"`
+### Route Handlers Require `connection()`
 
-Route Handlers can be statically pre-rendered at build time even with `noStore()`. **You MUST export `dynamic = "force-dynamic"`**:
+Route Handlers can be pre-rendered at build time even with `noStore()`. Under Next.js 16 Cache Components, call `connection()` before `noStore()` and build-phase guards:
 
 ```typescript
-//  FORBIDDEN - noStore() alone doesn't prevent static rendering
 import { unstable_noStore as noStore } from "next/cache";
-export async function GET() {
-  noStore(); // Not enough! Route can still be pre-rendered at build
-}
+import { connection } from "next/server";
 
-//  REQUIRED - explicit opt-out of static rendering
-export const dynamic = "force-dynamic";
 export async function GET() {
+  await connection();
   noStore();
 }
 ```

--- a/scripts/seed-projects.node.mjs
+++ b/scripts/seed-projects.node.mjs
@@ -31,13 +31,6 @@ function assertProdWrite(op) {
     throw new Error(`[write-guard] Blocked "${op}": env="${raw}".`);
 }
 
-function toSlug(name) {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
 async function run() {
   const dry = hasFlag("--dry-run");
   if (!dry) assertProdWrite("seed-projects");
@@ -46,11 +39,16 @@ async function run() {
 
   try {
     let projects;
+    let generateProjectSlug;
     try {
-      const mod = await import("../data/projects.ts");
-      projects = mod.projects;
+      const [projectsMod, slugMod] = await Promise.all([
+        import("../data/projects.ts"),
+        import("../src/lib/projects/slug-helpers.ts"),
+      ]);
+      projects = projectsMod.projects;
+      generateProjectSlug = slugMod.generateProjectSlug;
     } catch {
-      console.error(`${P} Cannot import data/projects.ts directly.`);
+      console.error(`${P} Cannot import project data and slug owner directly.`);
       console.error(`${P} This script should be invoked via: bun run seed:projects`);
       process.exit(1);
     }
@@ -58,7 +56,7 @@ async function run() {
     console.log(`${P} Found ${projects.length} projects`);
     if (dry) {
       for (const proj of projects) {
-        console.log(`  ${proj.id ?? toSlug(proj.name)}: ${proj.name}`);
+        console.log(`  ${proj.id ?? generateProjectSlug(proj.name)}: ${proj.name}`);
       }
       console.log(`${P} Dry run complete.`);
       return;
@@ -66,14 +64,15 @@ async function run() {
 
     let upserted = 0;
     for (const proj of projects) {
-      const id = proj.id ?? toSlug(proj.name);
+      const id = proj.id ?? generateProjectSlug(proj.name);
+      const slug = generateProjectSlug(proj.name);
       await sql`
         INSERT INTO projects (
           id, name, slug, description, short_summary, url,
           github_url, image_key, tags, tech_stack,
           note, cv_featured, registry_links
         ) VALUES (
-          ${id}, ${proj.name}, ${toSlug(proj.name)}, ${proj.description},
+          ${id}, ${proj.name}, ${slug}, ${proj.description},
           ${proj.shortSummary}, ${proj.url},
           ${proj.githubUrl ?? null}, ${proj.imageKey},
           ${proj.tags ? JSON.stringify(proj.tags) : null}::jsonb,

--- a/src/app/api/ai/analysis/[domain]/[id]/route.ts
+++ b/src/app/api/ai/analysis/[domain]/[id]/route.ts
@@ -18,6 +18,10 @@ import { projectAiAnalysisResponseSchema } from "@/types/schemas/project-ai-anal
 import { persistAnalysisRequestSchema } from "@/types/schemas/ai-analysis-persisted";
 import { getClientIp } from "@/lib/utils/request-utils";
 import {
+  getRequestOriginHostname,
+  isAllowedAiGateHostname,
+} from "@/lib/ai/openai-compatible/gate-token";
+import {
   NO_STORE_HEADERS,
   buildApiRateLimitResponse,
   createErrorResponse,
@@ -88,6 +92,16 @@ export async function POST(
   const MAX_ID_LENGTH = 100;
   if (!id || id.length === 0 || id.length > MAX_ID_LENGTH) {
     return createErrorResponse("Invalid ID", 400);
+  }
+
+  const originHost = getRequestOriginHostname(request);
+  if (!originHost || !isAllowedAiGateHostname(originHost)) {
+    envLogger.log(
+      "Analysis persist: forbidden origin",
+      { domain, id, originHost: originHost ?? "missing" },
+      { category: "AiAnalysis" },
+    );
+    return createErrorResponse("Forbidden", 403);
   }
 
   // Rate limit by IP

--- a/src/app/api/ai/chat/[feature]/analysis-output-config.ts
+++ b/src/app/api/ai/chat/[feature]/analysis-output-config.ts
@@ -5,16 +5,16 @@ import { bookAiAnalysisResponseSchema } from "@/types/schemas/book-ai-analysis";
 import { bookmarkAiAnalysisResponseSchema } from "@/types/schemas/bookmark-ai-analysis";
 import { projectAiAnalysisResponseSchema } from "@/types/schemas/project-ai-analysis";
 
-export const ANALYSIS_SCHEMA_BY_FEATURE: Record<
+export const ANALYSIS_SCHEMA_BY_FEATURE = {
+  "bookmark-analysis": bookmarkAiAnalysisResponseSchema,
+  "book-analysis": bookAiAnalysisResponseSchema,
+  "project-analysis": projectAiAnalysisResponseSchema,
+} satisfies Record<
   AnalysisFeatureId,
   | typeof bookmarkAiAnalysisResponseSchema
   | typeof bookAiAnalysisResponseSchema
   | typeof projectAiAnalysisResponseSchema
-> = {
-  "bookmark-analysis": bookmarkAiAnalysisResponseSchema,
-  "book-analysis": bookAiAnalysisResponseSchema,
-  "project-analysis": projectAiAnalysisResponseSchema,
-};
+>;
 
 export const ANALYSIS_FIELD_CONFIG: Record<
   AnalysisFeatureId,

--- a/src/app/api/ai/chat/[feature]/bookmark-tool.ts
+++ b/src/app/api/ai/chat/[feature]/bookmark-tool.ts
@@ -15,6 +15,15 @@ export const TOOL_MAX_RESULTS_DEFAULT = 5;
 
 const MARKDOWN_LINK_PATTERN = /\[([^\]\n]+)\]\(([^)\n]+)\)/g;
 
+function escapeMarkdownLinkLabel(text: string): string {
+  return text
+    .replaceAll("\\", "\\\\")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+}
+
 /**
  * Reject protocol-relative and external URLs; accept only internal paths.
  *
@@ -50,7 +59,7 @@ export function formatBookmarkResultsAsLinks(
   const topResults = uniqueResults.slice(0, TOOL_MAX_RESULTS_DEFAULT);
   const lines = ["Here are the best matches I found:"];
   for (const result of topResults) {
-    lines.push(`- [${result.title}](${result.url})`);
+    lines.push(`- [${escapeMarkdownLinkLabel(result.title)}](${result.url})`);
   }
   return lines.join("\n");
 }
@@ -76,7 +85,7 @@ export function sanitizeBookmarkLinksAgainstAllowlist(params: {
       const normalizedUrl = normalizeInternalPath(rawUrl);
       if (normalizedUrl && allowedUrls.has(normalizedUrl)) {
         allowedLinkCount += 1;
-        return `[${title}](${normalizedUrl})`;
+        return `[${escapeMarkdownLinkLabel(title)}](${normalizedUrl})`;
       }
       hadDisallowedLink = true;
       return `${title} (link removed)`;

--- a/src/app/api/ai/chat/[feature]/tool-dispatch.ts
+++ b/src/app/api/ai/chat/[feature]/tool-dispatch.ts
@@ -144,12 +144,13 @@ async function executeToolCallBatch(
         });
         continue;
       }
+      const failed = typeof validated.data.error === "string";
       results.push({
         callId: call.callId,
         toolName: call.toolName,
-        failed: false,
+        failed,
         parsed: validated.data,
-        links: validated.data.results.map((r) => ({ title: r.title, url: r.url })),
+        links: failed ? [] : validated.data.results.map((r) => ({ title: r.title, url: r.url })),
       });
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -244,14 +245,13 @@ export async function dispatchToolCallsByName(
   return { responseMessages, observedResults, failedCallIds };
 }
 
-/** Extract function_call items from Responses API output (any registered tool) */
+/** Extract function_call items from Responses API output */
 export function extractToolCallsFromResponseOutput(
   responseOutput: unknown[],
 ): OpenAiCompatibleResponsesFunctionCall[] {
   const toolCalls: OpenAiCompatibleResponsesFunctionCall[] = [];
   let functionCallItems = 0;
   let droppedInvalidSchema = 0;
-  let droppedUnknownTool = 0;
   for (const item of responseOutput) {
     if (!item || typeof item !== "object" || !("type" in item) || item.type !== "function_call") {
       continue;
@@ -265,23 +265,14 @@ export function extractToolCallsFromResponseOutput(
       });
       continue;
     }
-    if (!getToolByName(parsed.data.name)) {
-      droppedUnknownTool += 1;
-      logger.warn("[AI Chat] Ignoring unrecognized tool in response output", {
-        toolName: parsed.data.name,
-      });
-      continue;
-    }
     toolCalls.push(parsed.data);
   }
-  const droppedTotal = droppedInvalidSchema + droppedUnknownTool;
-  if (droppedTotal > 0) {
+  if (droppedInvalidSchema > 0) {
     logger.warn("[AI Chat] Dropped responses function_call items", {
       totalOutputItems: responseOutput.length,
       functionCallItems,
       acceptedFunctionCalls: toolCalls.length,
       droppedInvalidSchema,
-      droppedUnknownTool,
     });
   }
   return toolCalls;

--- a/src/app/api/ai/chat/[feature]/upstream-runner.ts
+++ b/src/app/api/ai/chat/[feature]/upstream-runner.ts
@@ -117,7 +117,7 @@ function handleAnalysisValidation(params: {
     });
   }
   const validation = validateAnalysisOutput(analysisFeature, text);
-  if (validation.ok) return { action: "done", text: validation.normalizedText };
+  if (!("reason" in validation)) return { action: "done", text: validation.normalizedText };
   const nextAttempt = attemptsSoFar + 1;
   if (nextAttempt < MAX_ANALYSIS_VALIDATION_ATTEMPTS) {
     console.warn(

--- a/src/app/api/ai/chat/[feature]/upstream-turn.ts
+++ b/src/app/api/ai/chat/[feature]/upstream-turn.ts
@@ -11,6 +11,7 @@
 import "server-only";
 
 import {
+  assertOpenAiCompatibleResponsesSucceeded,
   callOpenAiCompatibleChatCompletions,
   callOpenAiCompatibleResponses,
   streamOpenAiCompatibleChatCompletions,
@@ -212,6 +213,8 @@ export async function executeResponsesTurn(
       },
     });
   }
+
+  assertOpenAiCompatibleResponsesSucceeded(response);
 
   const toolCalls = extractToolCallsFromResponseOutput(response.output);
   if (toolCalls.length === 0) {

--- a/src/app/api/og-image/route.ts
+++ b/src/app/api/og-image/route.ts
@@ -23,11 +23,50 @@ import { openGraphUrlSchema } from "@/types/schemas/url";
 import { IMAGE_SECURITY_HEADERS, IMAGE_CDN_CACHE_HEADERS } from "@/lib/validators/url";
 import { buildCdnUrl, getCdnConfigFromEnv } from "@/lib/utils/cdn-utils";
 import { isS3Error } from "@/lib/utils/s3-error-guards";
+import type { VerifiedImageRedirect } from "@/types/opengraph";
 
 const getS3Context = () => {
   const { bucket } = getS3Config();
   return { bucket, s3Client: getS3Client() };
 };
+
+async function getVerifiedImageRedirectUrl(
+  imageUrl: string,
+  source: string,
+): Promise<VerifiedImageRedirect> {
+  const urlValidation = openGraphUrlSchema.safeParse(imageUrl);
+  if (!urlValidation.success) {
+    logger.warn(`[OG-Image] Ignoring unsafe ${source} image URL`, urlValidation.error);
+    return { status: "blocked", reason: "unsafe-url" };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const response = await fetch(urlValidation.data, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; OpenGraph-Image-Bot/1.0)",
+      },
+    });
+    await response.body?.cancel();
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (!contentType?.startsWith("image/")) {
+      throw new Error(`Invalid content type: ${contentType}`);
+    }
+
+    return { status: "verified", url: urlValidation.data };
+  } catch (error) {
+    logger.warn(`[OG-Image] Ignoring unverifiable ${source} image URL`, error);
+    return { status: "blocked", reason: "unverifiable-url" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 /**
  * Main handler for OpenGraph image requests
@@ -273,7 +312,13 @@ export async function GET(request: NextRequest) {
           logger.info(
             `[OG-Image] Using Karakeep imageUrl instead of fetching: ${fallbackImageData.imageUrl}`,
           );
-          return NextResponse.redirect(fallbackImageData.imageUrl, { status: 302 });
+          const verifiedImageUrl = await getVerifiedImageRedirectUrl(
+            fallbackImageData.imageUrl,
+            "Karakeep fallback",
+          );
+          if (verifiedImageUrl.status === "verified") {
+            return NextResponse.redirect(verifiedImageUrl.url, { status: 302 });
+          }
         }
 
         // Try screenshotAssetId as second option
@@ -355,7 +400,13 @@ export async function GET(request: NextRequest) {
         // Try imageUrl first
         if (fallbackImageData.imageUrl) {
           logger.info(`[OG-Image] Using Karakeep imageUrl fallback: ${fallbackImageData.imageUrl}`);
-          return NextResponse.redirect(fallbackImageData.imageUrl, { status: 302 });
+          const verifiedImageUrl = await getVerifiedImageRedirectUrl(
+            fallbackImageData.imageUrl,
+            "Karakeep fallback",
+          );
+          if (verifiedImageUrl.status === "verified") {
+            return NextResponse.redirect(verifiedImageUrl.url, { status: 302 });
+          }
         }
 
         // Try imageAssetId

--- a/src/app/api/related-content/debug/route.ts
+++ b/src/app/api/related-content/debug/route.ts
@@ -27,6 +27,7 @@ const isProductionBuildPhase = (): boolean => process.env[PHASE_ENV_KEY] === BUI
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
+const isProductionRuntime = (): boolean => process.env.NODE_ENV === "production";
 
 /**
  * Parse and validate request parameters for the debug endpoint.
@@ -64,14 +65,18 @@ function parseDebugParams(
 }
 
 export async function GET(request: NextRequest) {
+  preventCaching();
+
+  if (isProductionRuntime()) {
+    return createErrorResponse("Not found", 404);
+  }
+
   if (isProductionBuildPhase()) {
     return NextResponse.json(
       { buildPhase: true, message: "Related-content debug disabled during build phase" },
       { status: 200, headers: NO_STORE_HEADERS },
     );
   }
-
-  preventCaching();
 
   try {
     const params = parseDebugParams(request.nextUrl.searchParams);

--- a/src/app/api/related-content/route.ts
+++ b/src/app/api/related-content/route.ts
@@ -40,6 +40,8 @@ function parseTypesParam(value: string | null): RelatedContentType[] | undefined
 }
 
 export async function GET(request: NextRequest) {
+  preventCaching();
+
   if (isProductionBuildPhase()) {
     return NextResponse.json(
       {
@@ -60,7 +62,7 @@ export async function GET(request: NextRequest) {
       { headers: NO_STORE_HEADERS },
     );
   }
-  preventCaching();
+
   const startTime = getMonotonicTime();
 
   try {

--- a/src/app/api/related-content/route.ts
+++ b/src/app/api/related-content/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { preventCaching, createErrorResponse, NO_STORE_HEADERS } from "@/lib/utils/api-utils";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, connection } from "next/server";
 import { limitByTypeAndTotal } from "@/lib/utils/limit-by-type";
 import { findSimilarByEntity } from "@/lib/db/queries/cross-domain-similarity";
 import { applyBlendedScoring } from "@/lib/content-graph/blended-scoring";
@@ -40,6 +40,8 @@ function parseTypesParam(value: string | null): RelatedContentType[] | undefined
 }
 
 export async function GET(request: NextRequest) {
+  // connection(): ensure request-time execution under cacheComponents to avoid prerendered buildPhase responses
+  await connection();
   preventCaching();
 
   if (isProductionBuildPhase()) {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -151,7 +151,7 @@ export async function POST(request: Request): Promise<Response> {
 
     // Validate file against type configuration
     const validation = validateFileForType(file, fileType);
-    if (!validation.valid) {
+    if ("error" in validation) {
       return NextResponse.json(
         { success: false, error: validation.error },
         { status: 400, headers: CORS_HEADERS },

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -21,7 +21,8 @@ import { getLogoCdnData } from "@/lib/data-access/logos";
 import { normalizeDomain } from "@/lib/utils/domain-utils";
 import { getCompanyPlaceholder } from "@/lib/data-access/placeholder-images";
 import { getLogoFromManifestAsync } from "@/lib/image-handling/image-manifest-loader";
-import type { Experience as ExperienceType, ProcessedExperience } from "@/types/schemas/experience";
+import type { Experience as ExperienceType } from "@/types/schemas/experience";
+import type { ExperienceCardExtendedProps } from "@/types/features/experience";
 import type { Logo } from "@/types/logo";
 import { getStaticImageUrl } from "@/lib/data-access/static-images";
 import { mapWithBoundedConcurrency } from "@/lib/utils/async-lock";
@@ -75,7 +76,7 @@ export default async function ExperiencePage() {
   const experienceData = await mapWithBoundedConcurrency(
     experiences,
     EXPERIENCE_LOGO_BATCH_SIZE,
-    async (exp: ExperienceType): Promise<ProcessedExperience> => {
+    async (exp: ExperienceType): Promise<ExperienceCardExtendedProps> => {
       const hasOverrideDomain = Boolean(exp.logoOnlyDomain);
       const domain = hasOverrideDomain
         ? normalizeDomain(exp.logoOnlyDomain as string)
@@ -126,7 +127,6 @@ export default async function ExperiencePage() {
         return {
           ...exp,
           logoData: fallbackLogo ?? { url: getCompanyPlaceholder(), source: null },
-          error: `Failed to process logo: ${errorMessage}`,
         };
       }
     },

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -121,7 +121,6 @@ export default async function ExperiencePage() {
 
         return { ...exp, logoData: resolvedLogoData };
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "Unknown error";
         console.error("[ExperiencePage] Failed to resolve logo:", err);
         const fallbackLogo = domain ? await getLogoCdnData(domain) : null;
         return {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -10,13 +10,17 @@
  */
 
 import { Suspense } from "react";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import { projects } from "@/data/projects";
 import { ProjectDetail } from "@/components/features/projects/project-detail";
 import { RelatedContent } from "@/components/features/related-content/related-content.server";
 import { RelatedContentFallback } from "@/components/features/related-content/related-content-section";
-import { findProjectBySlug, getAllProjectSlugs } from "@/lib/projects/slug-helpers";
+import {
+  findProjectBySlug,
+  generateProjectSlug,
+  getAllProjectSlugs,
+} from "@/lib/projects/slug-helpers";
 import { getCachedAnalysis } from "@/lib/ai-analysis/reader.server";
 import type { ProjectAiAnalysisResponse } from "@/types/schemas/project-ai-analysis";
 import { getStaticPageMetadata } from "@/lib/seo/metadata";
@@ -87,17 +91,18 @@ function buildProjectOgImageUrl(project: Project): string {
 
 export async function generateMetadata({ params }: ProjectPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const path = `/projects/${slug}`;
   const project = findProjectBySlug(slug, projects);
 
   if (!project) {
     return {
-      ...getStaticPageMetadata(path, "projects"),
+      ...getStaticPageMetadata(`/projects/${slug}`, "projects"),
       title: "Project Not Found",
       description: "The requested project could not be found.",
     };
   }
 
+  const canonicalSlug = generateProjectSlug(project.name);
+  const path = `/projects/${canonicalSlug}`;
   const baseMetadata = getStaticPageMetadata(path, "projects");
   const customTitle = generateDynamicTitle(project.name, "projects");
   const customDescription = project.shortSummary || project.description.slice(0, 155);
@@ -144,8 +149,13 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     return notFound();
   }
 
+  const canonicalSlug = generateProjectSlug(project.name);
+  if (slug.toLowerCase() !== canonicalSlug) {
+    permanentRedirect(`/projects/${canonicalSlug}`);
+  }
+
   const projectId = project.id;
-  const path = `/projects/${slug}`;
+  const path = `/projects/${canonicalSlug}`;
 
   // Fetch cached AI analysis from PostgreSQL (runs in parallel with rendering prep)
   const cachedAnalysis = await getCachedAnalysis<ProjectAiAnalysisResponse>("projects", projectId);

--- a/src/components/features/github/github-activity.client.tsx
+++ b/src/components/features/github/github-activity.client.tsx
@@ -6,12 +6,13 @@
 "use client";
 
 import type { UserActivityView } from "@/types/github";
-import type { ContributionDay, PriorYearCommitSummary } from "@/types/schemas/github-storage";
+import type { PriorYearCommitSummary } from "@/types/schemas/github-storage";
 import { formatDistanceToNow } from "date-fns";
 import { Code, RefreshCw } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ActivityCalendarComponent, {
+  type Activity,
   type ThemeInput as ReactActivityCalendarThemeInput,
 } from "react-activity-calendar";
 import CumulativeGitHubStatsCards from "./cumulative-github-stats-cards";
@@ -24,6 +25,12 @@ const MOBILE_COLUMNS = 20; // Fewer columns for mobile to make blocks more visib
 const BLOCK_MARGIN_PX = 2; // Keep constant; margin between squares
 const MIN_BLOCK_SIZE = 8; // Minimum block size for visibility
 const MAX_BLOCK_SIZE = 16; // Maximum block size to prevent oversized blocks
+
+function normalizeContributionDays(
+  days: UserActivityView["trailingYearData"]["data"] | undefined,
+): Activity[] {
+  return days?.map((day) => ({ date: day.date, count: day.count, level: day.level ?? 0 })) ?? [];
+}
 
 // Define the custom theme for the calendar
 const calendarCustomTheme: ReactActivityCalendarThemeInput = {
@@ -48,7 +55,7 @@ const GitHubActivity = () => {
   const { resolvedTheme } = useTheme(); // Resolved theme (accounts for system preference)
   const [blockSize, setBlockSize] = useState<number>(12); // Dynamically calculated square size
   const [isMobile, setIsMobile] = useState(false); // Track mobile viewport
-  const [activityData, setActivityData] = useState<ContributionDay[]>([]); // Activity data for the calendar
+  const [activityData, setActivityData] = useState<Activity[]>([]); // Activity data for the calendar
   const [isLoading, setIsLoading] = useState(true); // Loading state for initial data fetch
   const [isRefreshing, setIsRefreshing] = useState(false); // Loading state for refresh operation
   const [error, setError] = useState<string | null>(null); // Error message, if any
@@ -199,7 +206,7 @@ const GitHubActivity = () => {
           setError(errorMsg); // Set error from API response
 
           // Try to use partial data if available, even with an error response
-          setActivityData(result?.trailingYearData?.data ?? []);
+          setActivityData(normalizeContributionDays(result?.trailingYearData?.data));
           setTotalContributions(result?.trailingYearData?.totalContributions ?? 0);
           setTrailingYearLinesAdded(result?.trailingYearData?.linesAdded ?? null);
           setTrailingYearLinesRemoved(result?.trailingYearData?.linesRemoved ?? null);
@@ -215,7 +222,7 @@ const GitHubActivity = () => {
         }
 
         // If response is OK and data is present
-        setActivityData(result?.trailingYearData?.data ?? []);
+        setActivityData(normalizeContributionDays(result?.trailingYearData?.data));
         setTotalContributions(result?.trailingYearData?.totalContributions ?? 0);
         setTrailingYearLinesAdded(result?.trailingYearData?.linesAdded ?? null);
         setTrailingYearLinesRemoved(result?.trailingYearData?.linesRemoved ?? null);

--- a/src/components/features/projects/project-card.client.tsx
+++ b/src/components/features/projects/project-card.client.tsx
@@ -32,7 +32,7 @@ export function ProjectCard({ project, preload = false }: ProjectCardProps): JSX
   const cdnImageUrl = resolveProjectCardImageUrl(imageKey, name);
 
   // Generate slug for internal detail page link
-  const projectSlug = generateProjectSlug(name, project.id);
+  const projectSlug = generateProjectSlug(name);
   const detailPageUrl = `/projects/${projectSlug}`;
 
   // External project URL (GitHub, website, etc.)

--- a/src/components/features/upload/upload-window.client.tsx
+++ b/src/components/features/upload/upload-window.client.tsx
@@ -398,7 +398,7 @@ function UploadWindowContentInner({
 
       // Validate the file
       const validation = validateFileForType(file, fileType);
-      if (!validation.valid) {
+      if ("error" in validation) {
         setValidationError(validation.error);
       }
     },
@@ -412,7 +412,7 @@ function UploadWindowContentInner({
       // Re-validate if a file is selected
       if (selectedFile) {
         const validation = validateFileForType(selectedFile, newType);
-        if (!validation.valid) {
+        if ("error" in validation) {
           setValidationError(validation.error);
         } else {
           setValidationError(null);

--- a/src/hooks/use-ai-analysis.ts
+++ b/src/hooks/use-ai-analysis.ts
@@ -156,12 +156,12 @@ export function useAiAnalysis<TEntity, TAnalysis>(
         if (signal?.aborted) throw new DOMException("Analysis aborted", "AbortError");
 
         setState({ status: "success", analysis: parsedAnalysis, error: null });
-        if (persistResult.success) {
-          router.refresh();
-        } else {
+        if ("message" in persistResult) {
           console.warn(
             `[useAiAnalysis] Analysis displayed but not persisted: ${persistResult.message}`,
           );
+        } else {
+          router.refresh();
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") return;

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -43,15 +43,6 @@ export async function register(): Promise<void> {
     /* ignore failed EventEmitter tweak */
   }
 
-  // Global unhandled-rejection guard — also forward to Sentry so these
-  // surface as issues instead of disappearing into stdout logs.
-  process.on("unhandledRejection", (reason: unknown) => {
-    console.error("[Instrumentation] Unhandled Promise Rejection:", reason);
-    if (SentryModule) {
-      SentryModule.captureException(reason instanceof Error ? reason : new Error(String(reason)));
-    }
-  });
-
   /** Sentry (Node) **/
   if (process.env.NODE_ENV === "production" && process.env.SENTRY_DSN) {
     const Sentry = await import("@sentry/nextjs");

--- a/src/lib/ai/openai-compatible/openai-compatible-client.ts
+++ b/src/lib/ai/openai-compatible/openai-compatible-client.ts
@@ -134,6 +134,21 @@ function normalizeResponsesOutputText<T extends { output: unknown[]; output_text
   return { ...response, output_text: outputText };
 }
 
+export function assertOpenAiCompatibleResponsesSucceeded(
+  response: OpenAiCompatibleResponsesResponse,
+): void {
+  if (response.status !== "failed") return;
+  const detail = response.error
+    ? `${response.error.code}: ${response.error.message}`
+    : "No provider error details returned.";
+  throw Object.assign(
+    new Error(
+      `[AI] Responses API returned status "${response.status}" for ${response.id}: ${detail}`,
+    ),
+    { name: "OpenAiCompatibleResponsesFailureError", status: 502 },
+  );
+}
+
 export async function callOpenAiCompatibleChatCompletions(args: {
   baseUrl: string;
   apiKey?: string;
@@ -244,7 +259,9 @@ export async function callOpenAiCompatibleResponses(args: {
     toRequestOptions(args),
   );
   const normalizedResponse = normalizeResponsesOutputText(response);
-  return openAiCompatibleResponsesResponseSchema.parse(normalizedResponse);
+  const parsedResponse = openAiCompatibleResponsesResponseSchema.parse(normalizedResponse);
+  assertOpenAiCompatibleResponsesSucceeded(parsedResponse);
+  return parsedResponse;
 }
 
 export async function streamOpenAiCompatibleResponses(args: {
@@ -318,5 +335,7 @@ export async function streamOpenAiCompatibleResponses(args: {
   if (thinkParser && normalizedResponse.output_text) {
     normalizedResponse.output_text = stripThinkTags(normalizedResponse.output_text);
   }
-  return openAiCompatibleResponsesResponseSchema.parse(normalizedResponse);
+  const parsedResponse = openAiCompatibleResponsesResponseSchema.parse(normalizedResponse);
+  assertOpenAiCompatibleResponsesSucceeded(parsedResponse);
+  return parsedResponse;
 }

--- a/src/lib/ai/openai-compatible/openai-compatible-client.ts
+++ b/src/lib/ai/openai-compatible/openai-compatible-client.ts
@@ -137,10 +137,10 @@ function normalizeResponsesOutputText<T extends { output: unknown[]; output_text
 export function assertOpenAiCompatibleResponsesSucceeded(
   response: OpenAiCompatibleResponsesResponse,
 ): void {
-  if (response.status !== "failed") return;
+  if (response.status === undefined || response.status === "completed") return;
   const detail = response.error
     ? `${response.error.code}: ${response.error.message}`
-    : "No provider error details returned.";
+    : `No provider error details returned for status "${response.status}".`;
   throw Object.assign(
     new Error(
       `[AI] Responses API returned status "${response.status}" for ${response.id}: ${detail}`,

--- a/src/lib/ai/rag/inventory-static.ts
+++ b/src/lib/ai/rag/inventory-static.ts
@@ -133,7 +133,7 @@ export async function buildStaticInventorySections(): Promise<{
           formatLine({
             id: project.id,
             name: project.name,
-            url: `/projects/${generateProjectSlug(project.name, project.id)}`,
+            url: `/projects/${generateProjectSlug(project.name)}`,
             externalUrl: project.url,
             githubUrl: project.githubUrl,
             tags: project.tags,

--- a/src/lib/ai/rag/static-context.ts
+++ b/src/lib/ai/rag/static-context.ts
@@ -44,7 +44,7 @@ function buildStaticContext(): StaticContext {
     .map((p) => ({
       name: p.name,
       description: p.shortSummary ?? p.description,
-      url: `/projects/${generateProjectSlug(p.name, p.id)}`,
+      url: `/projects/${generateProjectSlug(p.name)}`,
       externalUrl: p.url,
     }));
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -257,7 +257,7 @@ async function memoizedPostLookup({
       return { status: "found", post: result.post };
     }
 
-    if (result.reason === "error") {
+    if ("error" in result) {
       console.error(`[${fnName}] Error during lookup for slug "${slug}":`, result.error);
       // Don't memoize error results - allow retry on next request
       memo.delete(slug);

--- a/src/lib/bookmarks/bookmarks.ts
+++ b/src/lib/bookmarks/bookmarks.ts
@@ -19,6 +19,7 @@ import {
   validateApiConfig,
   handleTestEnvironment,
   fetchAllPagesFromApi,
+  EmptyBookmarksApiResponseError,
   validateChecksumAndGetCached,
   normalizeAndGenerateSlugs,
   enrichWithOpenGraph,
@@ -73,6 +74,7 @@ export async function refreshBookmarksData(force = false): Promise<UnifiedBookma
   } catch (error) {
     const fetchError = error instanceof Error ? error : new Error(String(error));
     console.error(`[refreshBookmarksData] PRIMARY_FETCH_FAILURE: ${fetchError.message}`);
+    if (fetchError instanceof EmptyBookmarksApiResponseError) throw fetchError;
 
     // Attempt PostgreSQL fallback
     const fallbackData = await loadDatabaseFallback();

--- a/src/lib/bookmarks/enrichment-hydration.ts
+++ b/src/lib/bookmarks/enrichment-hydration.ts
@@ -62,5 +62,7 @@ export function needsKarakeepImageUpgrade(bookmark: UnifiedBookmark): boolean {
     bookmark.content?.imageAssetId || bookmark.content?.screenshotAssetId,
   );
   if (!hasKarakeepAsset) return false;
-  return !bookmark.ogImage || bookmark.ogImage.startsWith("/api/assets/");
+  const isContentImageFallback =
+    bookmark.content?.imageUrl !== undefined && bookmark.ogImage === bookmark.content.imageUrl;
+  return !bookmark.ogImage || bookmark.ogImage.startsWith("/api/assets/") || isContentImageFallback;
 }

--- a/src/lib/bookmarks/normalize.ts
+++ b/src/lib/bookmarks/normalize.ts
@@ -19,6 +19,18 @@ import { normalizeScrapedContentText } from "./scraped-content";
 
 const READING_SPEED_WPM = 200;
 
+export class BookmarkNormalizationError extends Error {
+  constructor(failures: Array<{ id: string; index: number }>) {
+    const rejected = failures
+      .map((failure) => `${failure.id} at index ${failure.index}`)
+      .join(", ");
+    super(
+      `[BookmarksNormalize] Refusing partial refresh; ${failures.length} bookmark(s) failed normalization: ${rejected}`,
+    );
+    this.name = "BookmarkNormalizationError";
+  }
+}
+
 function computeWordCount(text: string | null | undefined): number | undefined {
   if (typeof text !== "string" || text.trim().length === 0) return undefined;
   const words = text.trim().split(/\s+/);
@@ -164,10 +176,25 @@ export function normalizeBookmark(raw: RawApiBookmark, index: number): UnifiedBo
  * Normalizes an array of raw bookmarks
  *
  * @param rawBookmarks - Array of raw bookmarks from API
- * @returns Array of normalized bookmarks (nulls filtered out)
+ * @returns Array of normalized bookmarks
+ * @throws BookmarkNormalizationError if any bookmark fails normalization
  */
 export function normalizeBookmarks(rawBookmarks: RawApiBookmark[]): UnifiedBookmark[] {
-  return rawBookmarks
-    .map((raw, index) => normalizeBookmark(raw, index))
-    .filter((bookmark): bookmark is UnifiedBookmark => bookmark !== null);
+  const normalizedBookmarks: UnifiedBookmark[] = [];
+  const failures: Array<{ id: string; index: number }> = [];
+
+  rawBookmarks.forEach((raw, index) => {
+    const bookmark = normalizeBookmark(raw, index);
+    if (bookmark) {
+      normalizedBookmarks.push(bookmark);
+    } else {
+      failures.push({ id: raw.id, index });
+    }
+  });
+
+  if (failures.length > 0) {
+    throw new BookmarkNormalizationError(failures);
+  }
+
+  return normalizedBookmarks;
 }

--- a/src/lib/bookmarks/normalize.ts
+++ b/src/lib/bookmarks/normalize.ts
@@ -6,7 +6,12 @@
  * @module lib/bookmarks/normalize
  */
 
-import type { RawApiBookmark, UnifiedBookmark, BookmarkContent } from "@/types/schemas/bookmark";
+import {
+  unifiedBookmarkSchema,
+  type RawApiBookmark,
+  type UnifiedBookmark,
+  type BookmarkContent,
+} from "@/types/schemas/bookmark";
 import { envLogger } from "@/lib/utils/env-logger";
 import { processSummaryText, removeCitations } from "@/lib/utils/formatters";
 import { extractDomainWithoutWww } from "@/lib/utils/url-utils";
@@ -57,7 +62,20 @@ export function normalizeBookmark(raw: RawApiBookmark, index: number): UnifiedBo
     const scrapedContentText = normalizeScrapedContentText(
       typeof rawHtml === "string" ? rawHtml : null,
     );
-    const bookmarkUrl = raw.content?.url || "";
+    const bookmarkUrlResult = unifiedBookmarkSchema.shape.url.safeParse(raw.content.url);
+    if (!bookmarkUrlResult.success) {
+      envLogger.log(
+        "Skipping bookmark with invalid URL",
+        {
+          index,
+          bookmarkId: raw.id,
+          issues: bookmarkUrlResult.error.issues,
+        },
+        { category: "BookmarksNormalize" },
+      );
+      return null;
+    }
+    const bookmarkUrl = bookmarkUrlResult.data;
     const domainCandidate = bookmarkUrl ? extractDomainWithoutWww(bookmarkUrl) : "";
     const domain = domainCandidate && domainCandidate !== bookmarkUrl ? domainCandidate : undefined;
     const wordCount = computeWordCount(scrapedContentText);

--- a/src/lib/bookmarks/refresh-helpers.ts
+++ b/src/lib/bookmarks/refresh-helpers.ts
@@ -31,6 +31,15 @@ const loadBookmarkQueryModule = async (): Promise<typeof import("@/lib/db/querie
   return bookmarkQueryModulePromise;
 };
 
+export class EmptyBookmarksApiResponseError extends Error {
+  constructor(pageCount: number) {
+    super(
+      `[refreshBookmarksData] Bookmarks API returned zero bookmarks across ${pageCount} page(s); refusing stale database fallback.`,
+    );
+    this.name = "EmptyBookmarksApiResponseError";
+  }
+}
+
 /** Validates required environment configuration and returns API context. */
 export function validateApiConfig(): BookmarksApiContext {
   const bookmarksListId = BOOKMARKS_API_CONFIG.LIST_ID;
@@ -142,6 +151,9 @@ export async function fetchAllPagesFromApi(ctx: BookmarksApiContext): Promise<Ra
   console.log(
     `[refreshBookmarksData] Total raw bookmarks fetched across ${pageCount} pages: ${allRawBookmarks.length}`,
   );
+  if (allRawBookmarks.length === 0) {
+    throw new EmptyBookmarksApiResponseError(pageCount);
+  }
   return allRawBookmarks;
 }
 

--- a/src/lib/bookmarks/slug-manager.ts
+++ b/src/lib/bookmarks/slug-manager.ts
@@ -24,6 +24,9 @@ import { getDeterministicTimestamp } from "@/lib/utils/deterministic-timestamp";
 const formatSlugEnvironmentSnapshot = (): string =>
   `NODE_ENV=${process.env.NODE_ENV || "(not set)"}, DEPLOYMENT_ENV=${process.env.DEPLOYMENT_ENV || "(not set)"}`;
 
+type BookmarkSlugSource = Pick<UnifiedBookmark, "id" | "url" | "title"> &
+  Partial<Pick<UnifiedBookmark, "slug">>;
+
 let hasLoggedSlugEnvironmentInfo = false;
 
 const logSlugEnvironmentOnce = (context: string): void => {
@@ -42,7 +45,7 @@ const logSlugEnvironmentOnce = (context: string): void => {
  * @returns Mapping with slugs, reverse lookup, and checksum
  * @throws Error if any bookmark cannot generate a slug
  */
-export function generateSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugMapping {
+export function generateSlugMapping(bookmarks: BookmarkSlugSource[]): BookmarkSlugMapping {
   const slugs: Record<string, { id: string; slug: string; url: string; title: string }> = {};
   const reverseMap: Record<string, string> = {};
 
@@ -126,7 +129,7 @@ export function generateSlugMapping(bookmarks: UnifiedBookmark[]): BookmarkSlugM
  * @param overwrite - Kept for API compatibility; ignored in DB mode
  */
 export async function saveSlugMapping(
-  bookmarks: UnifiedBookmark[],
+  bookmarks: BookmarkSlugSource[],
   overwrite = true,
 ): Promise<void> {
   void overwrite;

--- a/src/lib/bookmarks/slug-manager.ts
+++ b/src/lib/bookmarks/slug-manager.ts
@@ -14,7 +14,11 @@ import {
   getBookmarkBySlugFromDatabase,
   getSlugMappingRowsFromDatabase,
 } from "@/lib/db/queries/bookmarks";
-import type { UnifiedBookmark, BookmarkSlugMapping } from "@/types/schemas/bookmark";
+import type {
+  UnifiedBookmark,
+  BookmarkSlugMapping,
+  BookmarkSlugSource,
+} from "@/types/schemas/bookmark";
 import logger from "@/lib/utils/logger";
 import { envLogger } from "@/lib/utils/env-logger";
 import { createHash } from "node:crypto";
@@ -23,9 +27,6 @@ import { getDeterministicTimestamp } from "@/lib/utils/deterministic-timestamp";
 
 const formatSlugEnvironmentSnapshot = (): string =>
   `NODE_ENV=${process.env.NODE_ENV || "(not set)"}, DEPLOYMENT_ENV=${process.env.DEPLOYMENT_ENV || "(not set)"}`;
-
-type BookmarkSlugSource = Pick<UnifiedBookmark, "id" | "url" | "title"> &
-  Partial<Pick<UnifiedBookmark, "slug">>;
 
 let hasLoggedSlugEnvironmentInfo = false;
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -130,7 +130,7 @@ export async function withCacheFallback<T>(
   cachedFn: () => Promise<T>,
   fallbackFn: () => Promise<T>,
 ): Promise<T> {
-  if (isCliLikeCacheContext()) {
+  if (isCliProcessContext()) {
     return await fallbackFn();
   }
 

--- a/src/lib/data-access/github-repo-processor.ts
+++ b/src/lib/data-access/github-repo-processor.ts
@@ -20,6 +20,16 @@ import {
   type SingleRepoProcessingResult,
 } from "@/types/features/github-processing";
 
+async function loadCachedRepoStats(
+  repoOwner: string,
+  repoName: string,
+): Promise<{ stats: RepoRawWeeklyStat[]; status: RepoWeeklyStatCache["status"] } | null> {
+  const dbCache = await readRepoWeeklyStatsRecord(repoOwner, repoName);
+  if (!dbCache || !Array.isArray(dbCache.stats) || dbCache.stats.length === 0) return null;
+  debug(`[GitHub-Repo] Using DB cache for ${repoOwner}/${repoName}`);
+  return { stats: dbCache.stats.toSorted((a, b) => a.w - b.w), status: dbCache.status };
+}
+
 async function fetchOrLoadRepoStats(
   repoOwner: string,
   repoName: string,
@@ -41,11 +51,8 @@ async function fetchOrLoadRepoStats(
   }
 
   // No API data - use PostgreSQL cache snapshot
-  const dbCache = await readRepoWeeklyStatsRecord(repoOwner, repoName);
-  if (dbCache && Array.isArray(dbCache.stats) && dbCache.stats.length > 0) {
-    debug(`[GitHub-Repo] Using DB cache for ${repoOwner}/${repoName}`);
-    return { stats: dbCache.stats.toSorted((a, b) => a.w - b.w), status: dbCache.status };
-  }
+  const dbCache = await loadCachedRepoStats(repoOwner, repoName);
+  if (dbCache) return dbCache;
 
   return { stats: [], status: "empty_no_user_contribs" };
 }
@@ -138,6 +145,8 @@ export async function processSingleRepository({
       status = "fetch_error";
       dataComplete = false;
     }
+    const dbCache = await loadCachedRepoStats(repoOwner, repoName);
+    if (dbCache) stats = dbCache.stats;
   }
 
   const accumulated = accumulateWeeklyStats(stats, trailingYearFromDate, now);

--- a/src/lib/db/bookmark-record-mapper.ts
+++ b/src/lib/db/bookmark-record-mapper.ts
@@ -31,13 +31,15 @@ const toUndefined = <T>(value: T | null): T | undefined => {
 
 /**
  * Convert a nullable string to a servable image URL or undefined.
- * Accepts absolute URLs and app-relative paths (e.g. /api/assets/<id> proxy
- * URLs persisted by the web runtime); drops anything else.
+ * Accepts absolute URLs and app-relative /api/assets/<id> proxy URLs persisted
+ * by the web runtime; drops anything else.
  */
 const toUrlOrUndefined = (value: string | null): string | undefined => {
   if (!value) return undefined;
-  if (value.startsWith("/")) return value;
-  return URL.canParse(value) ? value : undefined;
+  if (value.startsWith("/api/assets/")) return value;
+  if (!URL.canParse(value)) return undefined;
+  const parsed = new URL(value);
+  return parsed.protocol === "http:" || parsed.protocol === "https:" ? value : undefined;
 };
 
 const SLUG_SANITIZE_PATTERN = /[^a-z0-9]+/gi;
@@ -117,39 +119,40 @@ export function mapUnifiedBookmarkToBookmarkInsert(bookmark: UnifiedBookmark): B
   if (normalizedSlug.length === 0) {
     throw new Error(`[BookmarkMapper] Cannot persist bookmark ${bookmark.id} with an empty slug.`);
   }
+  const parsedBookmark = unifiedBookmarkSchema.parse({ ...bookmark, slug: normalizedSlug });
 
   return {
-    id: bookmark.id,
+    id: parsedBookmark.id,
     slug: normalizedSlug,
-    url: bookmark.url,
-    title: bookmark.title,
-    description: bookmark.description,
-    note: bookmark.note ?? null,
-    summary: bookmark.summary ?? null,
-    scrapedContentText: bookmark.scrapedContentText ?? null,
-    tags: bookmark.tags,
-    content: bookmark.content ?? null,
-    assets: bookmark.assets ?? null,
-    logoData: bookmark.logoData ?? null,
-    ogImage: bookmark.ogImage ?? null,
-    ogTitle: bookmark.ogTitle ?? null,
-    ogDescription: bookmark.ogDescription ?? null,
-    ogUrl: bookmark.ogUrl ?? null,
-    ogImageExternal: bookmark.ogImageExternal ?? null,
-    ogImageLastFetchedAt: bookmark.ogImageLastFetchedAt ?? null,
-    ogImageEtag: bookmark.ogImageEtag ?? null,
-    readingTime: bookmark.readingTime ?? null,
-    wordCount: bookmark.wordCount ?? null,
-    archived: bookmark.archived === true,
-    isPrivate: bookmark.isPrivate === true,
-    isFavorite: bookmark.isFavorite === true,
-    taggingStatus: bookmark.taggingStatus ?? null,
-    domain: bookmark.domain ?? null,
-    dateBookmarked: bookmark.dateBookmarked,
-    datePublished: bookmark.datePublished ?? null,
-    dateCreated: bookmark.dateCreated ?? null,
-    modifiedAt: bookmark.modifiedAt ?? null,
-    sourceUpdatedAt: bookmark.sourceUpdatedAt,
+    url: parsedBookmark.url,
+    title: parsedBookmark.title,
+    description: parsedBookmark.description,
+    note: parsedBookmark.note ?? null,
+    summary: parsedBookmark.summary ?? null,
+    scrapedContentText: parsedBookmark.scrapedContentText ?? null,
+    tags: parsedBookmark.tags,
+    content: parsedBookmark.content ?? null,
+    assets: parsedBookmark.assets ?? null,
+    logoData: parsedBookmark.logoData ?? null,
+    ogImage: parsedBookmark.ogImage ?? null,
+    ogTitle: parsedBookmark.ogTitle ?? null,
+    ogDescription: parsedBookmark.ogDescription ?? null,
+    ogUrl: parsedBookmark.ogUrl ?? null,
+    ogImageExternal: parsedBookmark.ogImageExternal ?? null,
+    ogImageLastFetchedAt: parsedBookmark.ogImageLastFetchedAt ?? null,
+    ogImageEtag: parsedBookmark.ogImageEtag ?? null,
+    readingTime: parsedBookmark.readingTime ?? null,
+    wordCount: parsedBookmark.wordCount ?? null,
+    archived: parsedBookmark.archived === true,
+    isPrivate: parsedBookmark.isPrivate === true,
+    isFavorite: parsedBookmark.isFavorite === true,
+    taggingStatus: parsedBookmark.taggingStatus ?? null,
+    domain: parsedBookmark.domain ?? null,
+    dateBookmarked: parsedBookmark.dateBookmarked,
+    datePublished: parsedBookmark.datePublished ?? null,
+    dateCreated: parsedBookmark.dateCreated ?? null,
+    modifiedAt: parsedBookmark.modifiedAt ?? null,
+    sourceUpdatedAt: parsedBookmark.sourceUpdatedAt,
   };
 }
 

--- a/src/lib/db/mutations/github-activity.ts
+++ b/src/lib/db/mutations/github-activity.ts
@@ -60,7 +60,7 @@ const classifyDataset = (d: GitHubActivityApiResponse | null | undefined) => {
   const isEmpty = !hasData && contributions <= 0;
   const isIncomplete = !hasData || !hasCount || !isDataComplete;
 
-  return { hasData, hasCount, contributions, isEmpty, isIncomplete };
+  return { hasData, hasCount, contributions, isEmpty, isIncomplete, isComplete: !isIncomplete };
 };
 
 /**
@@ -77,6 +77,13 @@ export async function writeGitHubActivityToDb(data: GitHubActivityApiResponse): 
     const existingIsHealthy = !!existing && !existingQ.isEmpty;
 
     if (existingIsHealthy) {
+      if (existingQ.isComplete) {
+        debugLog("Non-degrading write: Preserving complete GitHub activity dataset", "warn", {
+          newCount: Math.max(0, newQ.contributions),
+        });
+        return true;
+      }
+
       const existingContributions = Math.max(0, existingQ.contributions);
       const newContributions = Math.max(0, newQ.contributions);
 

--- a/src/lib/db/mutations/projects.ts
+++ b/src/lib/db/mutations/projects.ts
@@ -9,14 +9,8 @@
 
 import { assertDatabaseWriteAllowed, db } from "@/lib/db/connection";
 import { projects } from "@/lib/db/schema/projects";
+import { generateProjectSlug } from "@/lib/projects/slug-helpers";
 import type { Project } from "@/types/project";
-
-function projectToSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-}
 
 /**
  * Upsert a batch of projects.
@@ -28,7 +22,7 @@ export async function upsertProjects(data: Project[]): Promise<number> {
   let upserted = 0;
   for (const item of data) {
     const id = item.id;
-    const slug = projectToSlug(item.name);
+    const slug = generateProjectSlug(item.name);
     await db
       .insert(projects)
       .values({

--- a/src/lib/db/queries/bookmarks.ts
+++ b/src/lib/db/queries/bookmarks.ts
@@ -74,35 +74,6 @@ async function resolveCanonicalTagSlugInternal(tagSlug: string): Promise<Bookmar
     };
   }
 
-  const tagRows = await db
-    .select({
-      tagSlug: bookmarkTags.tagSlug,
-      tagName: bookmarkTags.tagName,
-      tagStatus: bookmarkTags.tagStatus,
-    })
-    .from(bookmarkTags)
-    .where(eq(bookmarkTags.tagSlug, requestedSlug))
-    .limit(1);
-  const tagRow = tagRows[0];
-
-  if (!tagRow) {
-    return {
-      requestedSlug,
-      canonicalSlug: requestedSlug,
-      canonicalTagName: null,
-      isAlias: false,
-    };
-  }
-
-  if (tagRow.tagStatus !== "alias") {
-    return {
-      requestedSlug,
-      canonicalSlug: requestedSlug,
-      canonicalTagName: tagRow.tagName,
-      isAlias: false,
-    };
-  }
-
   const aliasRows = await db
     .select({
       canonicalSlug: bookmarkTagAliasLinks.targetTagSlug,
@@ -119,20 +90,39 @@ async function resolveCanonicalTagSlugInternal(tagSlug: string): Promise<Bookmar
     .limit(1);
   const aliasRow = aliasRows[0];
 
-  if (!aliasRow) {
+  if (aliasRow) {
+    return {
+      requestedSlug,
+      canonicalSlug: aliasRow.canonicalSlug,
+      canonicalTagName: aliasRow.canonicalTagName,
+      isAlias: aliasRow.canonicalSlug !== requestedSlug,
+    };
+  }
+
+  const tagRows = await db
+    .select({
+      tagSlug: bookmarkTags.tagSlug,
+      tagName: bookmarkTags.tagName,
+    })
+    .from(bookmarkTags)
+    .where(eq(bookmarkTags.tagSlug, requestedSlug))
+    .limit(1);
+  const tagRow = tagRows[0];
+
+  if (!tagRow) {
     return {
       requestedSlug,
       canonicalSlug: requestedSlug,
-      canonicalTagName: tagRow.tagName,
+      canonicalTagName: null,
       isAlias: false,
     };
   }
 
   return {
     requestedSlug,
-    canonicalSlug: aliasRow.canonicalSlug,
-    canonicalTagName: aliasRow.canonicalTagName,
-    isAlias: aliasRow.canonicalSlug !== requestedSlug,
+    canonicalSlug: requestedSlug,
+    canonicalTagName: tagRow.tagName,
+    isAlias: false,
   };
 }
 
@@ -172,6 +162,26 @@ export const lightweightBookmarkColumns = {
   isPrivate: bookmarks.isPrivate,
   isFavorite: bookmarks.isFavorite,
 } as const;
+
+const tagAliasJoinCondition = () =>
+  and(
+    eq(bookmarkTagAliasLinks.sourceTagSlug, bookmarkTagLinks.tagSlug),
+    eq(bookmarkTagAliasLinks.linkType, "alias"),
+  );
+
+const canonicalTagLinkSlug = sql<string>`coalesce(${bookmarkTagAliasLinks.targetTagSlug}, ${bookmarkTagLinks.tagSlug})`;
+
+const tagLinkMatchesCanonicalSlug = (canonicalSlug: string) =>
+  sql`${canonicalTagLinkSlug} = ${canonicalSlug}`;
+
+async function countBookmarksForCanonicalTag(canonicalSlug: string): Promise<number> {
+  const countRows = await db
+    .select({ count: sql<number>`count(distinct ${bookmarkTagLinks.bookmarkId})::int` })
+    .from(bookmarkTagLinks)
+    .leftJoin(bookmarkTagAliasLinks, tagAliasJoinCondition())
+    .where(tagLinkMatchesCanonicalSlug(canonicalSlug));
+  return countRows[0]?.count ?? 0;
+}
 
 export async function resolveCanonicalTagSlug(tagSlug: string): Promise<BookmarkTagResolution> {
   return resolveCanonicalTagSlugInternal(tagSlug);
@@ -275,13 +285,23 @@ export async function getBookmarksPageByTag(
     return [];
   }
 
+  const matchingBookmarkIds = db
+    .selectDistinctOn([bookmarkTagLinks.bookmarkId], {
+      bookmarkId: bookmarkTagLinks.bookmarkId,
+      dateBookmarked: bookmarkTagLinks.dateBookmarked,
+    })
+    .from(bookmarkTagLinks)
+    .leftJoin(bookmarkTagAliasLinks, tagAliasJoinCondition())
+    .where(tagLinkMatchesCanonicalSlug(resolution.canonicalSlug))
+    .orderBy(bookmarkTagLinks.bookmarkId, desc(bookmarkTagLinks.dateBookmarked))
+    .as("matching_bookmark_tag_links");
+
   const offset = (pageNumber - 1) * pageSize;
   const rows = (await db
     .select(lightweightBookmarkColumns)
-    .from(bookmarkTagLinks)
-    .innerJoin(bookmarks, eq(bookmarkTagLinks.bookmarkId, bookmarks.id))
-    .where(eq(bookmarkTagLinks.tagSlug, resolution.canonicalSlug))
-    .orderBy(desc(bookmarkTagLinks.dateBookmarked), desc(bookmarkTagLinks.bookmarkId))
+    .from(matchingBookmarkIds)
+    .innerJoin(bookmarks, eq(matchingBookmarkIds.bookmarkId, bookmarks.id))
+    .orderBy(desc(matchingBookmarkIds.dateBookmarked), desc(matchingBookmarkIds.bookmarkId))
     .limit(pageSize)
     .offset(offset)) as BookmarkLightweightSelect[];
 
@@ -327,23 +347,23 @@ export async function getTagBookmarksIndexFromDatabase(
     return null;
   }
 
-  const rows = await db
+  const stateRows = await db
     .select()
     .from(bookmarkTagIndexState)
     .where(eq(bookmarkTagIndexState.tagSlug, resolution.canonicalSlug))
     .limit(1);
-  const stateRow = rows[0];
-  if (stateRow) {
-    return mapBookmarkIndexStateToBookmarksIndex(stateRow);
-  }
-
-  const countRows = await db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(bookmarkTagLinks)
-    .where(eq(bookmarkTagLinks.tagSlug, resolution.canonicalSlug));
-  const count = countRows[0]?.count ?? 0;
+  const count = await countBookmarksForCanonicalTag(resolution.canonicalSlug);
   if (count === 0) {
     return null;
+  }
+  const stateRow = stateRows[0];
+  if (stateRow) {
+    return {
+      ...mapBookmarkIndexStateToBookmarksIndex(stateRow),
+      count,
+      totalPages: Math.ceil(count / pageSize),
+      pageSize,
+    };
   }
   return buildFallbackIndex(count, pageSize);
 }

--- a/src/lib/db/queries/hybrid-search-books-blog.ts
+++ b/src/lib/db/queries/hybrid-search-books-blog.ts
@@ -49,9 +49,12 @@ export async function hybridSearchBooks(options: {
       WITH keyword_results AS (
         SELECT id,
           ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-          similarity(title, ${trimmed}) AS trgm_score
+          similarity(title, ${trimmed}) AS trgm_score,
+          ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+            + similarity(title, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
         FROM books
         WHERE search_vector @@ ${tsQuery} OR title % ${trimmed}
+        ORDER BY keyword_score DESC, id DESC
         LIMIT ${KEYWORD_CANDIDATE_LIMIT}
       ),
       semantic_results AS (
@@ -93,13 +96,14 @@ export async function hybridSearchBooks(options: {
     authors: string[] | null;
     description: string | null;
     cover_url: string | null;
-    fts_score: number;
+    keyword_score: number;
   }>(sql`
     SELECT id, title, slug, authors, description, cover_url,
-      ts_rank_cd(search_vector, ${tsQuery}) AS fts_score
+      ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+        + similarity(title, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
     FROM books
     WHERE search_vector @@ ${tsQuery} OR title % ${trimmed}
-    ORDER BY fts_score DESC LIMIT ${limit}
+    ORDER BY keyword_score DESC, id DESC LIMIT ${limit}
   `);
 
   return rows.map((r) => ({
@@ -109,7 +113,7 @@ export async function hybridSearchBooks(options: {
     authors: r.authors,
     description: r.description,
     coverUrl: r.cover_url,
-    score: Number(r.fts_score),
+    score: Number(r.keyword_score),
   }));
 }
 
@@ -143,10 +147,13 @@ export async function hybridSearchBlogPosts(options: {
       WITH keyword_results AS (
         SELECT id,
           ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-          similarity(title, ${trimmed}) AS trgm_score
+          similarity(title, ${trimmed}) AS trgm_score,
+          ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+            + similarity(title, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
         FROM blog_posts
         WHERE draft = false
           AND (search_vector @@ ${tsQuery} OR title % ${trimmed})
+        ORDER BY keyword_score DESC, id DESC
         LIMIT ${KEYWORD_CANDIDATE_LIMIT}
       ),
       semantic_results AS (
@@ -191,14 +198,15 @@ export async function hybridSearchBlogPosts(options: {
     author_name: string;
     tags: string[] | null;
     published_at: string;
-    fts_score: number;
+    keyword_score: number;
   }>(sql`
     SELECT id, title, slug, excerpt, author_name, tags, published_at,
-      ts_rank_cd(search_vector, ${tsQuery}) AS fts_score
+      ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+        + similarity(title, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
     FROM blog_posts
     WHERE draft = false
       AND (search_vector @@ ${tsQuery} OR title % ${trimmed})
-    ORDER BY fts_score DESC LIMIT ${limit}
+    ORDER BY keyword_score DESC, id DESC LIMIT ${limit}
   `);
 
   return rows.map((r) => ({
@@ -209,6 +217,6 @@ export async function hybridSearchBlogPosts(options: {
     authorName: r.author_name,
     tags: r.tags,
     publishedAt: r.published_at,
-    score: Number(r.fts_score),
+    score: Number(r.keyword_score),
   }));
 }

--- a/src/lib/db/queries/hybrid-search-investments.ts
+++ b/src/lib/db/queries/hybrid-search-investments.ts
@@ -52,9 +52,12 @@ export async function hybridSearchInvestments(options: {
       WITH keyword_results AS (
         SELECT id,
           ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-          similarity(name, ${trimmed}) AS trgm_score
+          similarity(name, ${trimmed}) AS trgm_score,
+          ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+            + similarity(name, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
         FROM investments
         WHERE search_vector @@ ${tsQuery} OR name % ${trimmed}
+        ORDER BY keyword_score DESC, id DESC
         LIMIT ${KEYWORD_CANDIDATE_LIMIT}
       ),
       semantic_results AS (
@@ -103,13 +106,14 @@ export async function hybridSearchInvestments(options: {
     status: string;
     operating_status: string;
     location: string | null;
-    fts_score: number;
+    keyword_score: number;
   }>(sql`
     SELECT id, name, slug, description, category, stage, status, operating_status, location,
-      ts_rank_cd(search_vector, ${tsQuery}) AS fts_score
+      ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+        + similarity(name, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
     FROM investments
     WHERE search_vector @@ ${tsQuery} OR name % ${trimmed}
-    ORDER BY fts_score DESC LIMIT ${limit}
+    ORDER BY keyword_score DESC, id DESC LIMIT ${limit}
   `);
 
   return rows.map((r) => ({
@@ -122,7 +126,7 @@ export async function hybridSearchInvestments(options: {
     status: r.status,
     operatingStatus: r.operating_status,
     location: r.location,
-    score: Number(r.fts_score),
+    score: Number(r.keyword_score),
   }));
 }
 
@@ -157,9 +161,12 @@ export async function hybridSearchProjects(options: {
       WITH keyword_results AS (
         SELECT id,
           ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-          similarity(name, ${trimmed}) AS trgm_score
+          similarity(name, ${trimmed}) AS trgm_score,
+          ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+            + similarity(name, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
         FROM projects
         WHERE search_vector @@ ${tsQuery} OR name % ${trimmed}
+        ORDER BY keyword_score DESC, id DESC
         LIMIT ${KEYWORD_CANDIDATE_LIMIT}
       ),
       semantic_results AS (
@@ -205,13 +212,14 @@ export async function hybridSearchProjects(options: {
     url: string;
     image_key: string;
     tags: string[] | null;
-    fts_score: number;
+    keyword_score: number;
   }>(sql`
     SELECT id, name, slug, description, short_summary, url, image_key, tags,
-      ts_rank_cd(search_vector, ${tsQuery}) AS fts_score
+      ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+        + similarity(name, ${trimmed}) * ${TRIGRAM_WEIGHT} AS keyword_score
     FROM projects
     WHERE search_vector @@ ${tsQuery} OR name % ${trimmed}
-    ORDER BY fts_score DESC LIMIT ${limit}
+    ORDER BY keyword_score DESC, id DESC LIMIT ${limit}
   `);
 
   return rows.map((r) => ({
@@ -223,6 +231,6 @@ export async function hybridSearchProjects(options: {
     url: r.url,
     imageKey: r.image_key,
     tags: r.tags,
-    score: Number(r.fts_score),
+    score: Number(r.keyword_score),
   }));
 }

--- a/src/lib/db/queries/hybrid-search.ts
+++ b/src/lib/db/queries/hybrid-search.ts
@@ -101,10 +101,13 @@ async function hybridSearchWithEmbedding(
     WITH keyword_results AS (
       SELECT id,
         ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-        similarity(title, ${query}) AS trgm_score
+        similarity(title, ${query}) AS trgm_score,
+        ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+          + similarity(title, ${query}) * ${TRIGRAM_WEIGHT} AS keyword_score
       FROM bookmarks
       WHERE search_vector @@ ${tsQuery}
          OR title % ${query}
+      ORDER BY keyword_score DESC, id DESC
       LIMIT ${KEYWORD_CANDIDATE_LIMIT}
     ),
     semantic_results AS (
@@ -143,19 +146,17 @@ async function keywordOnlySearch(
   limit: number,
 ): Promise<Array<{ bookmark: UnifiedBookmark; score: number }>> {
   const tsQuery = sql`websearch_to_tsquery('english', ${query})`;
+  const keywordScore = sql<number>`ts_rank_cd(${bookmarks.searchVector}, ${tsQuery}) * ${FTS_WEIGHT}
+    + similarity(${bookmarks.title}, ${query}) * ${TRIGRAM_WEIGHT}`;
 
   const rows = await db
     .select({
       bookmark: bookmarks,
-      score: sql<number>`ts_rank_cd(${bookmarks.searchVector}, ${tsQuery})`,
+      score: keywordScore,
     })
     .from(bookmarks)
-    .where(sql`${bookmarks.searchVector} @@ ${tsQuery}`)
-    .orderBy(
-      sql`ts_rank_cd(${bookmarks.searchVector}, ${tsQuery}) DESC`,
-      desc(bookmarks.dateBookmarked),
-      desc(bookmarks.id),
-    )
+    .where(sql`${bookmarks.searchVector} @@ ${tsQuery} OR ${bookmarks.title} % ${query}`)
+    .orderBy(sql`${keywordScore} DESC`, desc(bookmarks.dateBookmarked), desc(bookmarks.id))
     .limit(limit);
 
   return rows.map((row) => ({
@@ -249,10 +250,13 @@ export async function hybridSearchThoughts(options: {
       WITH keyword_results AS (
         SELECT id,
           ts_rank_cd(search_vector, ${tsQuery}) AS fts_score,
-          similarity(title, ${normalizedQuery}) AS trgm_score
+          similarity(title, ${normalizedQuery}) AS trgm_score,
+          ts_rank_cd(search_vector, ${tsQuery}) * ${FTS_WEIGHT}
+            + similarity(title, ${normalizedQuery}) * ${TRIGRAM_WEIGHT} AS keyword_score
         FROM thoughts
         WHERE draft = false
           AND (search_vector @@ ${tsQuery} OR title % ${normalizedQuery})
+        ORDER BY keyword_score DESC, id DESC
         LIMIT ${KEYWORD_CANDIDATE_LIMIT}
       ),
       semantic_results AS (
@@ -295,6 +299,8 @@ export async function hybridSearchThoughts(options: {
   }
 
   const tsQuery = sql`websearch_to_tsquery('english', ${normalizedQuery})`;
+  const keywordScore = sql<number>`ts_rank_cd(${thoughts.searchVector}, ${tsQuery}) * ${FTS_WEIGHT}
+    + similarity(${thoughts.title}, ${normalizedQuery}) * ${TRIGRAM_WEIGHT}`;
   const rows = await db
     .select({
       id: thoughts.id,
@@ -305,15 +311,13 @@ export async function hybridSearchThoughts(options: {
       tags: thoughts.tags,
       createdAt: thoughts.createdAt,
       updatedAt: thoughts.updatedAt,
-      score: sql<number>`ts_rank_cd(${thoughts.searchVector}, ${tsQuery})`,
+      score: keywordScore,
     })
     .from(thoughts)
-    .where(sql`${thoughts.draft} = false AND ${thoughts.searchVector} @@ ${tsQuery}`)
-    .orderBy(
-      sql`ts_rank_cd(${thoughts.searchVector}, ${tsQuery}) DESC`,
-      desc(thoughts.createdAt),
-      desc(thoughts.id),
+    .where(
+      sql`${thoughts.draft} = false AND (${thoughts.searchVector} @@ ${tsQuery} OR ${thoughts.title} % ${normalizedQuery})`,
     )
+    .orderBy(sql`${keywordScore} DESC`, desc(thoughts.createdAt), desc(thoughts.id))
     .limit(limit);
 
   return rows.map((row) => ({

--- a/src/lib/health/status-monitor.server.ts
+++ b/src/lib/health/status-monitor.server.ts
@@ -9,12 +9,13 @@
 
 import si from "systeminformation";
 import { getMonotonicTime } from "@/lib/utils";
+import type { HealthMetrics } from "@/types/health";
 
 /**
  * Fetches a consolidated object of system metrics.
  * @returns {Promise<object>} A promise that resolves to an object containing system metrics.
  */
-export async function getSystemMetrics() {
+export async function getSystemMetrics(): Promise<HealthMetrics["system"]> {
   const [mem, cpu, net] = await Promise.all([si.mem(), si.currentLoad(), si.networkStats()]);
 
   return {

--- a/src/lib/image-handling/image-s3-utils.ts
+++ b/src/lib/image-handling/image-s3-utils.ts
@@ -14,7 +14,7 @@ const MIN_IMAGE_BUFFER_SIZE = 100;
 
 import { readBinaryS3, writeBinaryS3 } from "@/lib/s3/binary";
 import { debug, isDebug } from "@/lib/utils/debug";
-import { getOgImageS3Key, hashImageContent } from "@/lib/utils/opengraph-utils";
+import { getOgImageS3Key } from "@/lib/utils/opengraph-utils";
 import { checkIfS3ObjectExists } from "@/lib/s3/objects";
 import { BOOKMARKS_API_CONFIG } from "@/lib/constants";
 import { processImageBufferSimple } from "./shared-image-processing";
@@ -131,14 +131,7 @@ export async function persistImageToS3(
         `[${logContext}] Image processed for ${imageUrl}. New size: ${processedBuffer.length} bytes, ContentType: ${contentType}`,
       );
 
-    // Generate S3 key based on idempotency key if available, otherwise fallback to content hash
-    const s3Key = getOgImageS3Key(
-      imageUrl,
-      s3Directory,
-      pageUrl,
-      idempotencyKey,
-      hashImageContent(processedBuffer),
-    );
+    const s3Key = getOgImageS3Key(imageUrl, s3Directory, pageUrl, idempotencyKey);
     if (isDebug)
       debug(`[${logContext}] Generated S3 key: ${s3Key} for image from URL: ${imageUrl}`);
 
@@ -195,8 +188,12 @@ function isFirstPartyKarakeepAsset(imageUrl: string): boolean {
   if (imageUrl.startsWith("/api/assets/")) return true;
   try {
     return new URL(imageUrl).hostname === new URL(BOOKMARKS_API_CONFIG.API_URL).hostname;
-  } catch {
-    return false;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[Image S3] Failed to classify Karakeep asset URL. imageUrl=${imageUrl}, apiUrl=${BOOKMARKS_API_CONFIG.API_URL}: ${message}`,
+    );
+    throw new Error(`Invalid Karakeep asset URL configuration: ${message}`, { cause: error });
   }
 }
 

--- a/src/lib/opengraph/fetch.ts
+++ b/src/lib/opengraph/fetch.ts
@@ -12,6 +12,8 @@
 const HTTP_FORBIDDEN = 403;
 const HTTP_NOT_FOUND = 404;
 const HTTP_GONE = 410;
+const GOOGLEBOT_USER_AGENT =
+  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
 
 import { debug, debugWarn } from "@/lib/utils/debug";
 import { envLogger } from "@/lib/utils/env-logger";
@@ -357,19 +359,22 @@ async function fetchExternalOpenGraph(
 
       // Use shared fetch utility with timeout and browser headers
       const headers = getBrowserHeaders();
-      const response = await fetchWithTimeout(url, {
+      let response = await fetchWithTimeout(url, {
         timeout: OPENGRAPH_FETCH_CONFIG.TIMEOUT,
-        headers: {
-          ...headers,
-          // Try Googlebot UA if we've had issues before
-          ...(imageService.hasDomainFailedTooManyTimes(domain)
-            ? {
-                "User-Agent":
-                  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-              }
-            : {}),
-        },
+        headers,
       });
+
+      if (response.status === HTTP_FORBIDDEN) {
+        envLogger.log(
+          `Retrying OpenGraph fetch with Googlebot user agent after 403`,
+          { url },
+          { category: "OpenGraph" },
+        );
+        response = await fetchWithTimeout(url, {
+          timeout: OPENGRAPH_FETCH_CONFIG.TIMEOUT,
+          headers: { ...headers, "User-Agent": GOOGLEBOT_USER_AGENT },
+        });
+      }
 
       if (response.status === HTTP_NOT_FOUND || response.status === HTTP_GONE) {
         return { permanentFailure: true, status: response.status };

--- a/src/lib/persistence/image-persistence.ts
+++ b/src/lib/persistence/image-persistence.ts
@@ -142,14 +142,19 @@ export async function persistImageAndGetS3UrlWithStatus(
   idempotencyKey?: string,
   pageUrl?: string,
 ): Promise<PersistImageResult> {
+  if (imageUrl.startsWith("/")) {
+    console.error(
+      `[OpenGraph S3] Cannot persist app-relative image URL ${imageUrl}; Karakeep assets must use the buffer persistence path.`,
+    );
+    return { s3Url: null, wasNewlyPersisted: false };
+  }
+
   // Check if we're in read-only mode (build phase, tests, etc.)
   if (isS3ReadOnly()) {
-    // Skip validation for internal /api/assets/ URLs - these are our own proxy endpoints
-    // and should always be valid. Also skip data URLs.
-    const isInternalAsset = imageUrl.startsWith("/api/assets/");
+    // Skip validation for data URLs.
     const isDataUrl = imageUrl.startsWith("data:");
 
-    if (!isInternalAsset && !isDataUrl) {
+    if (!isDataUrl) {
       try {
         // Try HEAD first, then gracefully fall back to a 1-byte GET if HEAD is blocked.
         const headResult = await fetch(imageUrl, {
@@ -183,18 +188,13 @@ export async function persistImageAndGetS3UrlWithStatus(
         );
         return { s3Url: null, wasNewlyPersisted: false };
       }
-    } else if (isInternalAsset || isDataUrl) {
-      console.log(
-        `[OpenGraph S3] Skipping validation for ${isDataUrl ? "data URL" : "internal asset URL"}: ${isDataUrl ? "data:..." : imageUrl}`,
-      );
+    } else {
+      console.log("[OpenGraph S3] Skipping validation for data URL: data:...");
     }
 
-    // For internal assets or data URLs, don't schedule persistence since they're already hosted inline or by us
-    // Just return the URL which will work from any host
-    if (isInternalAsset || isDataUrl) {
-      console.log(
-        `[OpenGraph S3] Using ${isDataUrl ? "data" : "relative"} URL for ${isDataUrl ? "inline" : "internal Karakeep"} asset`,
-      );
+    // For data URLs, don't schedule persistence since they're already inline.
+    if (isDataUrl) {
+      console.log("[OpenGraph S3] Using data URL for inline asset");
       return { s3Url: imageUrl, wasNewlyPersisted: false };
     }
 

--- a/src/lib/projects/slug-helpers.ts
+++ b/src/lib/projects/slug-helpers.ts
@@ -23,6 +23,13 @@ export function generateProjectSlug(name: string): string {
     .replace(/^-|-$/g, "");
 }
 
+function matchesProjectSlug(project: Project, normalizedSlug: string): boolean {
+  return (
+    generateProjectSlug(project.name) === normalizedSlug ||
+    generateProjectSlug(project.id) === normalizedSlug
+  );
+}
+
 /**
  * Find a project by its slug from a list of projects.
  *
@@ -35,9 +42,9 @@ export function findProjectBySlug(slug: string, projects: Project[]): Project | 
     return null;
   }
 
-  const normalizedSlug = slug.toLowerCase();
+  const normalizedSlug = slug.trim().toLowerCase();
 
-  return projects.find((project) => generateProjectSlug(project.name) === normalizedSlug) ?? null;
+  return projects.find((project) => matchesProjectSlug(project, normalizedSlug)) ?? null;
 }
 
 /**

--- a/src/lib/projects/slug-helpers.ts
+++ b/src/lib/projects/slug-helpers.ts
@@ -3,51 +3,28 @@
  * @module lib/projects/slug-helpers
  * @description
  * Utilities for generating URL-safe slugs from project data.
- * Format: name-slug or name-slug-id-slug (when name and ID differ)
+ * Format: project name slug.
  *
- * Projects have simpler slug requirements than books since they
- * are static data with predictable IDs.
+ * Project URLs use the same name-derived slug stored in PostgreSQL.
  */
 
-import { titleToSlug } from "@/lib/utils/domain-utils";
 import type { Project } from "@/types/project";
 
 /**
  * Generate a URL-safe slug from project data.
  *
- * Strategy:
- * - If name and ID are the same (or ID is absent), use just the name slug
- * - If they differ, combine name and ID for uniqueness
- *
  * @example
- * // Same name and ID: "aventure-vc"
- * generateProjectSlug("aVenture.vc", "aVenture.vc")
- *
- * // Different name and ID: "company-research-tui-tui-aventure-vc"
- * generateProjectSlug("Company Research TUI", "tui-aventure-vc")
+ * generateProjectSlug("aVenture.vc") // "aventure-vc"
  */
-export function generateProjectSlug(name: string, id?: string): string {
-  const nameSlug = titleToSlug(name, 50);
-
-  // If no ID or ID equals name, just use name slug
-  if (!id || id === name) {
-    return nameSlug;
-  }
-
-  const idSlug = titleToSlug(id, 30);
-
-  // If slugified versions are the same, no need to duplicate
-  if (nameSlug === idSlug) {
-    return nameSlug;
-  }
-
-  // Combine for uniqueness
-  return `${nameSlug}-${idSlug}`;
+export function generateProjectSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 /**
  * Find a project by its slug from a list of projects.
- * Priority: exact generated slug > ID slug > name slug
  *
  * @param slug - The URL slug to search for
  * @param projects - Array of projects to search
@@ -60,28 +37,7 @@ export function findProjectBySlug(slug: string, projects: Project[]): Project | 
 
   const normalizedSlug = slug.toLowerCase();
 
-  // Pre-compute all slugs once for efficiency
-  // Note: idSlug uses 30-char limit to match generateProjectSlug's ID truncation
-  const projectSlugs = projects.map((project) => ({
-    project,
-    generated: generateProjectSlug(project.name, project.id),
-    idSlug: titleToSlug(project.id, 30),
-    nameSlug: titleToSlug(project.name, 50),
-  }));
-
-  // Priority 1: exact generated slug match
-  const exactMatch = projectSlugs.find((p) => p.generated === normalizedSlug);
-  if (exactMatch) return exactMatch.project;
-
-  // Priority 2: ID slug match
-  const idMatch = projectSlugs.find((p) => p.idSlug === normalizedSlug);
-  if (idMatch) return idMatch.project;
-
-  // Priority 3: name slug match
-  const nameMatch = projectSlugs.find((p) => p.nameSlug === normalizedSlug);
-  if (nameMatch) return nameMatch.project;
-
-  return null;
+  return projects.find((project) => generateProjectSlug(project.name) === normalizedSlug) ?? null;
 }
 
 /**
@@ -92,6 +48,6 @@ export function findProjectBySlug(slug: string, projects: Project[]): Project | 
  */
 export function getAllProjectSlugs(projects: Project[]): Array<{ slug: string }> {
   return projects.map((project) => ({
-    slug: generateProjectSlug(project.name, project.id),
+    slug: generateProjectSlug(project.name),
   }));
 }

--- a/src/lib/search/search-content.ts
+++ b/src/lib/search/search-content.ts
@@ -14,6 +14,8 @@ import { resolveDefaultEndpointCompatibleEmbeddingConfig } from "@/lib/ai/openai
 import { sanitizeSearchQuery } from "@/lib/validators/search";
 import { envLogger } from "@/lib/utils/env-logger";
 
+const EXACT_MATCH_SCORE_MULTIPLIER = 2;
+
 /**
  * Generic search function that filters items based on a query.
  * Uses MiniSearch for fuzzy matching when available, falls back to substring search.
@@ -64,10 +66,6 @@ export function searchContent<T>(
       const searchResults = miniSearchIndex.search(sanitizedQuery, {
         prefix: true, // Allow prefix matching for autocomplete-like behavior
         fuzzy: 0.2, // Allow typos (20% edit distance)
-        boost: {
-          // Boost exact matches
-          exactMatch: 2,
-        },
         combineWith: "OR", // Any term can match; MiniSearch scoring ranks multi-term hits higher
       });
 
@@ -79,7 +77,11 @@ export function searchContent<T>(
         .filter((item) => resultIds.has(extractId(item)))
         .map((item) => ({
           item,
-          score: scoreById.get(extractId(item)) ?? 0,
+          score:
+            (scoreById.get(extractId(item)) ?? 0) *
+            (getExactMatchField?.(item).toLowerCase() === sanitizedQuery
+              ? EXACT_MATCH_SCORE_MULTIPLIER
+              : 1),
         }))
         .toSorted((a, b) => b.score - a.score);
     } catch (error) {

--- a/src/lib/services/image-streaming.ts
+++ b/src/lib/services/image-streaming.ts
@@ -12,6 +12,8 @@ import { Readable, Transform } from "node:stream";
 import type { StreamToS3Options, StreamingResult } from "@/types/s3-cdn";
 import { guessImageContentType } from "../utils/content-type";
 
+const STREAM_TIMEOUT_MS = 300000; // 5 minutes
+
 /**
  * Stream monitor transform - tracks bytes without modifying stream
  */
@@ -71,22 +73,23 @@ export async function streamToS3(
   let upload: Upload | null = null;
   let timeoutError: Error | null = null;
 
-  try {
-    // Set timeout to prevent hanging streams
-    const STREAM_TIMEOUT_MS = 300000; // 5 minutes
-    timeoutId = setTimeout(() => {
-      timeoutError = new Error(`[ImageStreaming] Stream timeout after ${STREAM_TIMEOUT_MS}ms`);
-      console.error(timeoutError.message);
-      if (upload) {
-        void upload.abort().catch((error) => {
-          console.warn("[ImageStreaming] Failed to abort S3 upload after timeout:", error);
-        });
+  const abortStreamingResources = async (): Promise<void> => {
+    if (upload) {
+      try {
+        await upload.abort();
+      } catch (abortError) {
+        console.warn("[ImageStreaming] Failed to abort S3 upload after timeout:", abortError);
       }
-      if (nodeStream) {
-        nodeStream.destroy(timeoutError);
-      }
-    }, STREAM_TIMEOUT_MS);
+    }
+    if (nodeStream && !nodeStream.destroyed) {
+      nodeStream.destroy();
+    }
+    if (!monitor.destroyed) {
+      monitor.destroy();
+    }
+  };
 
+  try {
     // Convert Web ReadableStream to Node.js stream if needed
     if (responseStream instanceof Readable) {
       nodeStream = responseStream;
@@ -127,7 +130,22 @@ export async function streamToS3(
       }
     });
 
-    const result = await upload.done();
+    const uploadDone = upload.done();
+    uploadDone.catch((error: unknown) => {
+      if (timeoutError) {
+        console.warn("[ImageStreaming] Upload rejected after timeout cleanup:", error);
+      }
+    });
+
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        timeoutError = new Error(`[ImageStreaming] Stream timeout after ${STREAM_TIMEOUT_MS}ms`);
+        console.error(timeoutError.message);
+        reject(timeoutError);
+      }, STREAM_TIMEOUT_MS);
+    });
+
+    const result = await Promise.race([uploadDone, timeoutPromise]);
 
     if (!result?.Location) {
       throw new Error("S3 upload finished without returning a location.");
@@ -141,6 +159,9 @@ export async function streamToS3(
   } catch (error: unknown) {
     const reportedError =
       timeoutError ?? (error instanceof Error ? error : new Error(String(error)));
+    if (timeoutError) {
+      await abortStreamingResources();
+    }
     console.error(`[ImageStreaming] Failed to stream to S3:`, reportedError);
     return {
       success: false,

--- a/src/lib/utils/request-utils.ts
+++ b/src/lib/utils/request-utils.ts
@@ -163,13 +163,14 @@ export function classifyProxyRequest(
   const accept = normalizeHeaderValue(request.headers.get("accept"))?.toLowerCase() ?? "";
   const secFetchDest = normalizeHeaderValue(request.headers.get("sec-fetch-dest"))?.toLowerCase();
   const secFetchMode = normalizeHeaderValue(request.headers.get("sec-fetch-mode"))?.toLowerCase();
+  const isPageMethod = method === "GET" || method === "HEAD";
 
   if (pathname.startsWith("/api/")) return "api";
   if (pathname.startsWith("/_next/image")) return "image";
   if (hasPrefetchHeader(request.headers)) return "prefetch";
   if (isRscRequest(pathname, url.searchParams, request.headers)) return "rsc";
   if (
-    method === "GET" &&
+    isPageMethod &&
     (accept.includes("text/html") ||
       secFetchDest === "document" ||
       secFetchMode === "navigate" ||

--- a/src/lib/utils/search-helpers.ts
+++ b/src/lib/utils/search-helpers.ts
@@ -136,9 +136,15 @@ export function transformSearchResultToTerminalResult(result: SearchResult): Sel
  * ];
  * const deduped = dedupeDocuments(posts, (post) => post.slug);
  */
-export function dedupeDocuments<T extends { id?: string | number }>(
+function getDefaultDocumentId(document: object): string {
+  if (!("id" in document)) return "";
+  const { id } = document;
+  return typeof id === "string" || typeof id === "number" ? String(id) : "";
+}
+
+export function dedupeDocuments<T extends object>(
   documents: T[],
-  getIdField: (doc: T) => string = (doc) => String(doc.id ?? ""),
+  getIdField: (doc: T) => string = getDefaultDocumentId,
 ): T[] {
   const seen = new Set<string>();
   const deduped: T[] = [];
@@ -184,7 +190,7 @@ export function dedupeDocuments<T extends { id?: string | number }>(
  * @param getIdField - Function to extract the ID field
  * @returns Deduplicated array of documents
  */
-export function prepareDocumentsForIndexing<T extends { id?: string | number }>(
+export function prepareDocumentsForIndexing<T extends object>(
   documents: T[],
   sourceName: string,
   getIdField?: (doc: T) => string,

--- a/src/lib/utils/search-helpers.ts
+++ b/src/lib/utils/search-helpers.ts
@@ -138,7 +138,7 @@ export function transformSearchResultToTerminalResult(result: SearchResult): Sel
  */
 function getDefaultDocumentId(document: object): string {
   if (!("id" in document)) return "";
-  const { id } = document;
+  const id = document.id;
   return typeof id === "string" || typeof id === "number" ? String(id) : "";
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -115,7 +115,10 @@ async function buildCspHeader(): Promise<string> {
   // scripts rendered at runtime). To prevent unexpected CSP violations, we **only** merge style
   // hashes. Script hashes are deliberately omitted so that the `'unsafe-inline'` fallback remains
   // effective for all inline scripts generated at request-time by Next.js.
-  const scriptSrc = [...CSP_DIRECTIVES.scriptSrc];
+  const scriptSrc =
+    process.env.NODE_ENV === "production"
+      ? [...CSP_DIRECTIVES.scriptSrc]
+      : [...CSP_DIRECTIVES.scriptSrc, "'unsafe-eval'"];
   const styleSrc = [...CSP_DIRECTIVES.styleSrc, ...cspHashes.styleSrc];
 
   const cspDirectives: typeof CSP_DIRECTIVES = {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -57,9 +57,9 @@ export interface DomainBookmarkContext {
  * @note - The slug can contain the tag and pagination info
  */
 export type BookmarkTagPageContext = {
-  params: {
+  params: Promise<{
     slug: string[];
-  };
+  }>;
 };
 
 /**

--- a/src/types/opengraph.ts
+++ b/src/types/opengraph.ts
@@ -15,6 +15,10 @@ export interface OgFetchResult {
   error?: string;
 }
 
+export type VerifiedImageRedirect =
+  | { status: "verified"; url: string }
+  | { status: "blocked"; reason: string };
+
 /**
  * Enhanced OpenGraph result with caching metadata.
  * This interface is the primary type for OpenGraph data

--- a/src/types/schemas/ai-openai-compatible.ts
+++ b/src/types/schemas/ai-openai-compatible.ts
@@ -324,10 +324,24 @@ export type EndpointCompatibleEmbeddingConfig = z.infer<
   typeof endpointCompatibleEmbeddingConfigSchema
 >;
 
+const openAiCompatibleResponsesStatusSchema = z.enum([
+  "completed",
+  "failed",
+  "in_progress",
+  "cancelled",
+  "queued",
+  "incomplete",
+]);
+const openAiCompatibleResponsesErrorSchema = z
+  .object({ code: z.string().min(1), message: z.string().min(1) })
+  .loose();
+
 export const openAiCompatibleResponsesResponseSchema = z.object({
   id: z.string().min(1),
   output_text: z.string(),
   output: z.array(z.unknown()),
+  status: openAiCompatibleResponsesStatusSchema.optional(),
+  error: openAiCompatibleResponsesErrorSchema.nullable().optional(),
 });
 
 export type OpenAiCompatibleResponsesResponse = z.infer<

--- a/src/types/schemas/bookmark.ts
+++ b/src/types/schemas/bookmark.ts
@@ -14,6 +14,7 @@ import { z } from "zod/v4";
 
 /** Reusable URL schema (top-level Zod v4 form) */
 const urlSchema = z.url();
+const appRelativeAssetUrlSchema = z.string().startsWith("/api/assets/");
 
 /** Reusable nullable-optional string */
 const stringOrNullSchema = z.string().nullable().optional();
@@ -131,7 +132,7 @@ export const unifiedBookmarkSchema = z.object({
   description: z.string(),
   slug: z.string().min(1),
   tags: z.union([z.array(bookmarkTagSchema), z.array(z.string())]),
-  ogImage: z.url().optional(),
+  ogImage: z.union([z.url(), appRelativeAssetUrlSchema]).optional(),
   dateBookmarked: z.string(),
   datePublished: z.string().nullable().optional(),
   dateCreated: z.string().optional(),

--- a/src/types/schemas/bookmark.ts
+++ b/src/types/schemas/bookmark.ts
@@ -161,6 +161,9 @@ export const unifiedBookmarkSchema = z.object({
 
 export type UnifiedBookmark = z.infer<typeof unifiedBookmarkSchema>;
 
+export type BookmarkSlugSource = Pick<UnifiedBookmark, "id" | "url" | "title"> &
+  Partial<Pick<UnifiedBookmark, "slug">>;
+
 /** Array schema for validating bookmark collections */
 export const unifiedBookmarksArraySchema = z.array(unifiedBookmarkSchema);
 


### PR DESCRIPTION
## Summary
This PR hardens public API and data refresh paths that could accept unsafe inputs, lose conversation/tool history, degrade cached site content, or serve build-phase API payloads at runtime. It also keeps older project URLs usable by landing them on the current canonical project pages and restores the test TypeScript project to a clean contract-checked state.

## Changes

### Security
- **Cross-origin analysis write protection**: AI analysis persistence rejects missing or disallowed origins before rate limiting, body parsing, or writes (`src/app/api/ai/analysis/[domain]/[id]/route.ts`).
- **Verified OG-image redirects**: Bookmark fallback image URLs redirect only after they validate as fetchable image responses, so HTML or phishing URLs fall back to the placeholder (`src/app/api/og-image/route.ts`).
- **Production debug endpoint hidden**: Related-content debug requests return 404 in production before database reads (`src/app/api/related-content/debug/route.ts`).
- **Document HEAD requests rate limited**: HEAD requests for page routes classify as document traffic, so burst traffic is blocked like GET navigation (`src/lib/utils/request-utils.ts`).
- **Production CSP excludes unsafe-eval**: Static production script sources omit `'unsafe-eval'`, while development adds it at request time for Next.js tooling (`config/csp.ts`, `src/proxy.ts`).

### Bug Fixes
- **AI Responses history preserved**: Unknown but schema-valid Responses API tool calls now receive explicit `function_call_output` errors instead of being silently dropped (`src/app/api/ai/chat/[feature]/tool-dispatch.ts`).
- **Non-completed upstream turns fail loudly**: Responses API statuses such as `failed`, `queued`, `in_progress`, `cancelled`, and `incomplete` throw with provider details instead of falling through to empty model output (`src/lib/ai/openai-compatible/openai-compatible-client.ts`).
- **Sentry duplicate capture removed**: Unhandled promise rejections rely on Sentry defaults instead of a second manual Node listener (`src/instrumentation-node.ts`).
- **Bookmark refreshes fail atomically on invalid source rows**: A source collection with any invalid bookmark URL throws before partial refresh, and DB inserts validate the canonical bookmark schema before persistence (`src/lib/bookmarks/normalize.ts`, `src/lib/db/bookmark-record-mapper.ts`).
- **Alias tag filters reach canonical results**: Tag pages resolve alias links before counting and paging bookmarks, so alias-tagged bookmarks appear under canonical tag filters (`src/lib/db/queries/bookmarks.ts`).
- **OpenGraph 403s retry as Googlebot**: Metadata fetches retry once with a Googlebot user agent after direct 403 responses (`src/lib/opengraph/fetch.ts`).
- **S3 stream timeouts clean resources**: Multipart uploads abort and streams are destroyed when upload completion hangs (`src/lib/services/image-streaming.ts`).
- **Search ranking honors boosts**: MiniSearch keeps configured field boosts and hybrid SQL keyword candidates sort by weighted relevance before limiting (`src/lib/search/search-content.ts`, `src/lib/db/queries/hybrid-search.ts`).
- **GitHub activity avoids degradation**: Partial repository stats can use cached weekly data but cannot overwrite a complete existing activity dataset (`src/lib/data-access/github-repo-processor.ts`, `src/lib/db/mutations/github-activity.ts`).
- **Project links use stored slugs**: Project cards, static AI context, seed scripts, and DB writes use the same name-derived slugs as PostgreSQL (`src/lib/projects/slug-helpers.ts`).
- **Legacy project URLs keep working**: Older id-derived `/projects/...` paths resolve to the current name-derived project pages instead of 404ing (`src/lib/projects/slug-helpers.ts`, `src/app/projects/[slug]/page.tsx`).
- **Cache tags register during builds**: Production builds execute cached functions so cache tags and lifetimes are registered for static page invalidation (`src/lib/cache.ts`).
- **Related-content route runs at request time**: The public related-content API calls `connection()` before no-store/build-phase handling so build responses are not served at runtime (`src/app/api/related-content/route.ts`).
- **Test project type-checks cleanly**: Existing tests compile against canonical Next.js, bookmark, search, GitHub, SEO, upload, and route contracts instead of stale aliases and legacy fixtures (`__tests__/tsconfig.json`, `src/types/api.ts`, `src/lib/utils/search-helpers.ts`).
- **Validation warnings cleared**: Test loops no longer carry unused keys, experience logo failures log the actual error object without dead locals, and bookmark slug source typing now lives with the bookmark schema owner (`__tests__/lib/db/embedding-input-contracts.test.ts`, `src/app/experience/page.tsx`, `src/types/schemas/bookmark.ts`).
- **Review-suggested regression guards now execute cleanly**: Cache invalidation assertions run instead of sitting in todo suites, OpenGraph mock teardown always runs, and image-analysis tests no longer duplicate stale API expectations (`__tests__/lib/cache-invalidation-simple.test.ts`, `__tests__/lib/seo/opengraph.test.ts`, `__tests__/lib/image-processing/imageAnalysis.test.ts`).

### Documentation
- **Gateway key requirement documented**: Default AI gateway configuration now names the API key required for real upstream calls (`docs/architecture/ai-services.md`, `.env-example`).
- **Search cache guidance updated**: Search docs now use the Next.js 16 Cache Components `connection()` pattern instead of removed route segment config (`docs/features/search.md`).
- **Project slug compatibility documented**: Project feature docs now state that emitted project URLs are name-derived while older id-derived paths resolve server-side (`docs/features/projects.md`).

## Verification
- `bun run type-check:tests`
- `bun run validate`
- `bun run validate:with-size`
- `bun run test`
- `bun run build:only`
- `bun run build`
- Focused review-hardening tests: `bun run test __tests__/lib/cache-invalidation-simple.test.ts __tests__/lib/image-processing/imageAnalysis.test.ts __tests__/lib/seo/opengraph.test.ts __tests__/lib/bookmarks/scraped-content-pipeline.unit.test.ts __tests__/api/ai/chat-upstream-pipeline-tools.test.ts __tests__/lib/utils/search-helpers.test.ts`
- Pre-push hook on `ae350499`: production build, smoke tests, and validate
- Dogfood report: `dogfood-output/pr-361-final/report.md`
- Latest dev/alpha dogfood report: `dogfood-output/pr-361-ae350499-dev-alpha/report.md`
- Sandbox deployment dogfood: home, projects list, canonical project slug, LLMs bookmark tag page, theme toggle, and related-content API regression
- Latest dev and alpha browser dogfood: home and projects pages loaded with no page errors or console output; `/projects/tui-aventure-vc` canonicalized to `/projects/company-research-tui`; `/projects/apple-maps-java` canonicalized to `/projects/apple-maps-java-sdk`
- Latest dev and alpha API/security dogfood: `/api/health` returned HTTP 200; related-content missing ids returned runtime 404 without `buildPhase`; related-content debug returned 404; attacker-origin analysis POSTs returned 403; home CSP omitted `unsafe-eval`

## Breaking Changes
None

## Related Issues
Closes #331
Closes #335
